### PR TITLE
feat(config): 配置中心与多环境管理 #13

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,45 +1,74 @@
-# 服务配置
-SERVER_HOST=0.0.0.0
+# StarByte Backend Environment Variables
+# Copy this file to .env and adjust values as needed.
+# Environment variables override YAML config values (highest priority).
+#
+# Loading order:
+#   1. configs/config.yaml (base)
+#   2. configs/config.{APP_ENV}.yaml (environment override)
+#   3. Environment variables (this file)
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+# APP_ENV selects the environment: dev, test, or prod
+APP_ENV=dev
+# CONFIG_PATH overrides the base config file path (default: configs/config.yaml)
+# CONFIG_PATH=configs/config.yaml
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
 SERVER_PORT=8080
+# SERVER_MODE: debug, release, or test
 SERVER_MODE=debug
 
-# 数据库配置
+# ---------------------------------------------------------------------------
+# Database (PostgreSQL)
+# ---------------------------------------------------------------------------
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=starbyte
 DB_PASSWORD=starbyte
 DB_NAME=starbyte
 DB_SSLMODE=disable
-DB_MAX_OPEN_CONNS=100
-DB_MAX_IDLE_CONNS=10
-DB_CONN_MAX_LIFETIME=3600
+# DB_MAX_OPEN=100
+# DB_MAX_IDLE=10
 
-# Redis 配置
+# ---------------------------------------------------------------------------
+# Redis
+# ---------------------------------------------------------------------------
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=0
 
-# JWT 配置
+# ---------------------------------------------------------------------------
+# JWT (IMPORTANT: change the secret in production!)
+# ---------------------------------------------------------------------------
 JWT_SECRET=your-super-secret-key-change-in-production
-JWT_ACCESS_TOKEN_EXPIRE=3600       # 1小时（秒）
-JWT_REFRESH_TOKEN_EXPIRE=604800    # 7天（秒）
+# JWT_ACCESS_TOKEN_EXP=3600   (seconds, default 7200)
+# JWT_REFRESH_TOKEN_EXP=604800 (seconds, default 604800)
 
-# MinIO 配置
+# ---------------------------------------------------------------------------
+# MinIO (Object Storage)
+# ---------------------------------------------------------------------------
 MINIO_ENDPOINT=localhost:9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
-MINIO_USE_SSL=false
 MINIO_BUCKET=starbyte
+# MINIO_USE_SSL=false
 
-# 日志配置
-LOG_LEVEL=info
-LOG_FORMAT=json
-LOG_OUTPUT=stdout
-
-# 邮件配置（可选）
+# ---------------------------------------------------------------------------
+# Email / SMTP (optional)
+# ---------------------------------------------------------------------------
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
 # SMTP_USER=noreply@example.com
 # SMTP_PASSWORD=your-password
 # SMTP_FROM=noreply@example.com
+
+# ---------------------------------------------------------------------------
+# Logger (optional overrides)
+# ---------------------------------------------------------------------------
+# LOG_LEVEL=info      (debug, info, warn, error)
+# LOG_FORMAT=json     (json or console)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -68,6 +68,15 @@ MINIO_BUCKET=starbyte
 # SMTP_FROM=noreply@example.com
 
 # ---------------------------------------------------------------------------
+# CORS (optional overrides)
+# ---------------------------------------------------------------------------
+# CORS_ALLOWED_ORIGINS=https://a.com,https://b.com
+# CORS_ALLOWED_METHODS=GET,POST,PUT
+# CORS_ALLOWED_HEADERS=Content-Type,Authorization
+# CORS_EXPOSE_HEADERS=X-Request-Id,X-Custom-Header
+# CORS_ALLOW_CREDENTIALS=true
+
+# ---------------------------------------------------------------------------
 # Logger (optional overrides)
 # ---------------------------------------------------------------------------
 # LOG_LEVEL=info      (debug, info, warn, error)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -69,7 +69,7 @@ func main() {
 	r.Use(middleware.RequestID())
 	r.Use(middleware.Logger())
 	r.Use(middleware.ErrorHandler())
-	r.Use(middleware.CORS())
+	r.Use(middleware.CORSWithConfig(cfg.CORS))
 
 	// 8. 健康检查
 	r.GET("/health", func(c *gin.Context) {

--- a/backend/configs/config.dev.yaml
+++ b/backend/configs/config.dev.yaml
@@ -1,0 +1,50 @@
+# Development environment overrides
+# Loaded on top of config.yaml when APP_ENV=dev
+
+server:
+  mode: debug
+  read_timeout: 60
+  write_timeout: 60
+
+database:
+  host: localhost
+  port: 5432
+  user: starbyte
+  password: starbyte
+  dbname: starbyte_dev
+  max_open: 50
+  max_idle: 5
+
+redis:
+  host: localhost
+  port: 6379
+  password: ""
+  db: 0
+
+jwt:
+  secret: "starbyte-secret-key-change-in-production"
+  access_token_exp: 7200
+  refresh_token_exp: 604800
+
+logger:
+  level: debug
+  format: console
+
+cors:
+  allowed_origins:
+    - "http://localhost:3000"
+    - "http://localhost:5173"
+  allowed_methods:
+    - "GET"
+    - "POST"
+    - "PUT"
+    - "DELETE"
+    - "PATCH"
+    - "OPTIONS"
+  allowed_headers:
+    - "Origin"
+    - "Content-Type"
+    - "Accept"
+    - "Authorization"
+    - "X-Request-Id"
+  allow_credentials: true

--- a/backend/configs/config.prod.yaml
+++ b/backend/configs/config.prod.yaml
@@ -1,0 +1,66 @@
+# Production environment overrides
+# Loaded on top of config.yaml when APP_ENV=prod
+#
+# IMPORTANT: Sensitive values (database password, JWT secret, MinIO keys)
+# should be injected via environment variables, NOT hardcoded here.
+# See backend/.env.example for the full list of supported variables.
+
+server:
+  mode: release
+  read_timeout: 15
+  write_timeout: 15
+
+database:
+  host: ""  # Set via DB_HOST environment variable
+  port: 5432
+  user: ""  # Set via DB_USER environment variable
+  password: ""  # Set via DB_PASSWORD environment variable
+  dbname: starbyte
+  sslmode: require
+  max_open: 100
+  max_idle: 20
+
+redis:
+  host: ""  # Set via REDIS_HOST environment variable
+  port: 6379
+  password: ""  # Set via REDIS_PASSWORD environment variable
+  db: 0
+
+jwt:
+  secret: ""  # Set via JWT_SECRET environment variable
+  access_token_exp: 3600
+  refresh_token_exp: 604800
+
+logger:
+  level: info
+  format: json
+  filename: logs/starbyte.log
+  max_size: 200
+  max_backups: 10
+  max_age: 90
+  compress: true
+
+minio:
+  endpoint: ""  # Set via MINIO_ENDPOINT environment variable
+  access_key: ""  # Set via MINIO_ACCESS_KEY environment variable
+  secret_key: ""  # Set via MINIO_SECRET_KEY environment variable
+  bucket: starbyte
+  use_ssl: true
+
+cors:
+  allowed_origins:
+    - "https://starbyte.com"
+    - "https://www.starbyte.com"
+  allowed_methods:
+    - "GET"
+    - "POST"
+    - "PUT"
+    - "DELETE"
+    - "PATCH"
+  allowed_headers:
+    - "Origin"
+    - "Content-Type"
+    - "Accept"
+    - "Authorization"
+    - "X-Request-Id"
+  allow_credentials: true

--- a/backend/configs/config.test.yaml
+++ b/backend/configs/config.test.yaml
@@ -1,0 +1,36 @@
+# Test environment overrides
+# Loaded on top of config.yaml when APP_ENV=test
+
+server:
+  mode: test
+  read_timeout: 30
+  write_timeout: 30
+
+database:
+  host: localhost
+  port: 5432
+  user: starbyte
+  password: starbyte
+  dbname: starbyte_test
+  max_open: 20
+  max_idle: 2
+
+redis:
+  host: localhost
+  port: 6379
+  password: ""
+  db: 1
+
+jwt:
+  secret: "test-secret-key-for-ci-env-only"
+  access_token_exp: 3600
+  refresh_token_exp: 86400
+
+logger:
+  level: warn
+  format: json
+
+cors:
+  allowed_origins:
+    - "*"
+  allow_credentials: false

--- a/backend/configs/config.yaml
+++ b/backend/configs/config.yaml
@@ -40,3 +40,30 @@ minio:
   secret_key: minioadmin
   bucket: starbyte
   use_ssl: false
+
+# Email / SMTP (optional — leave commented if not used)
+email:
+  smtp_host: ""
+  smtp_port: 587
+  username: ""
+  password: ""
+  from: ""
+
+# CORS
+cors:
+  allowed_origins:
+    - "*"
+  allowed_methods:
+    - "GET"
+    - "POST"
+    - "PUT"
+    - "DELETE"
+    - "PATCH"
+    - "OPTIONS"
+  allowed_headers:
+    - "Origin"
+    - "Content-Type"
+    - "Accept"
+    - "Authorization"
+    - "X-Request-Id"
+  allow_credentials: false

--- a/backend/configs/config.yaml
+++ b/backend/configs/config.yaml
@@ -66,4 +66,6 @@ cors:
     - "Accept"
     - "Authorization"
     - "X-Request-Id"
+  expose_headers:
+    - "X-Request-Id"
   allow_credentials: false

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -1,13 +1,11 @@
 package config
 
-import (
-	"fmt"
-	"os"
-
-	"gopkg.in/yaml.v3"
-)
-
-// Config is the root configuration object loaded from the YAML file.
+// Config is the root configuration object loaded from YAML files.
+//
+// Loading order (each layer overrides the previous):
+//  1. configs/config.yaml        — base config (shared across all environments)
+//  2. configs/config.{APP_ENV}.yaml — environment-specific overrides (dev/test/prod)
+//  3. Environment variables       — sensitive values injected at runtime
 type Config struct {
 	Server   ServerConfig   `yaml:"server"`
 	Database DatabaseConfig `yaml:"database"`
@@ -15,12 +13,14 @@ type Config struct {
 	JWT      JWTConfig      `yaml:"jwt"`
 	Logger   LoggerConfig   `yaml:"logger"`
 	MinIO    MinIOConfig    `yaml:"minio"`
+	Email    EmailConfig    `yaml:"email"`
+	CORS     CORSConfig     `yaml:"cors"`
 }
 
 // ServerConfig holds the HTTP server settings.
 type ServerConfig struct {
 	Port         int    `yaml:"port"`
-	Mode         string `yaml:"mode"`
+	Mode         string `yaml:"mode"` // debug, release, test
 	ReadTimeout  int    `yaml:"read_timeout"`
 	WriteTimeout int    `yaml:"write_timeout"`
 }
@@ -56,6 +56,7 @@ type JWTConfig struct {
 // LoggerConfig holds the logger and log-rotation settings.
 type LoggerConfig struct {
 	Level      string `yaml:"level"`
+	Format     string `yaml:"format"` // json, console
 	Filename   string `yaml:"filename"`
 	MaxSize    int    `yaml:"max_size"`
 	MaxBackups int    `yaml:"max_backups"`
@@ -72,112 +73,19 @@ type MinIOConfig struct {
 	UseSSL    bool   `yaml:"use_ssl"`
 }
 
-// Load reads the YAML configuration file at the given path, parses it and
-// fills in sensible defaults for any missing values.
-func Load(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read config file: %w", err)
-	}
-
-	cfg := &Config{}
-	if err := yaml.Unmarshal(data, cfg); err != nil {
-		return nil, fmt.Errorf("unmarshal config: %w", err)
-	}
-
-	setDefaults(cfg)
-	return cfg, nil
+// EmailConfig holds the SMTP email settings.
+type EmailConfig struct {
+	SMTPHost string `yaml:"smtp_host"`
+	SMTPPort int    `yaml:"smtp_port"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+	From     string `yaml:"from"`
 }
 
-// setDefaults populates zero-valued fields with sensible development defaults.
-func setDefaults(cfg *Config) {
-	// Server
-	if cfg.Server.Port == 0 {
-		cfg.Server.Port = 8080
-	}
-	if cfg.Server.Mode == "" {
-		cfg.Server.Mode = "debug"
-	}
-	if cfg.Server.ReadTimeout == 0 {
-		cfg.Server.ReadTimeout = 30
-	}
-	if cfg.Server.WriteTimeout == 0 {
-		cfg.Server.WriteTimeout = 30
-	}
-
-	// Database
-	if cfg.Database.Host == "" {
-		cfg.Database.Host = "localhost"
-	}
-	if cfg.Database.Port == 0 {
-		cfg.Database.Port = 5432
-	}
-	if cfg.Database.User == "" {
-		cfg.Database.User = "starbyte"
-	}
-	if cfg.Database.DBName == "" {
-		cfg.Database.DBName = "starbyte"
-	}
-	if cfg.Database.SSLMode == "" {
-		cfg.Database.SSLMode = "disable"
-	}
-	if cfg.Database.MaxOpen == 0 {
-		cfg.Database.MaxOpen = 100
-	}
-	if cfg.Database.MaxIdle == 0 {
-		cfg.Database.MaxIdle = 10
-	}
-
-	// Redis
-	if cfg.Redis.Host == "" {
-		cfg.Redis.Host = "localhost"
-	}
-	if cfg.Redis.Port == 0 {
-		cfg.Redis.Port = 6379
-	}
-
-	// JWT
-	if cfg.JWT.Secret == "" {
-		cfg.JWT.Secret = "starbyte-secret-key-change-in-production"
-	}
-	if cfg.JWT.AccessTokenExp == 0 {
-		cfg.JWT.AccessTokenExp = 7200
-	}
-	if cfg.JWT.RefreshTokenExp == 0 {
-		cfg.JWT.RefreshTokenExp = 604800
-	}
-	if cfg.JWT.Issuer == "" {
-		cfg.JWT.Issuer = "starbyte"
-	}
-
-	// Logger
-	if cfg.Logger.Level == "" {
-		cfg.Logger.Level = "info"
-	}
-	if cfg.Logger.Filename == "" {
-		cfg.Logger.Filename = "logs/starbyte.log"
-	}
-	if cfg.Logger.MaxSize == 0 {
-		cfg.Logger.MaxSize = 100
-	}
-	if cfg.Logger.MaxBackups == 0 {
-		cfg.Logger.MaxBackups = 5
-	}
-	if cfg.Logger.MaxAge == 0 {
-		cfg.Logger.MaxAge = 30
-	}
-
-	// MinIO
-	if cfg.MinIO.Endpoint == "" {
-		cfg.MinIO.Endpoint = "localhost:9000"
-	}
-	if cfg.MinIO.AccessKey == "" {
-		cfg.MinIO.AccessKey = "minioadmin"
-	}
-	if cfg.MinIO.SecretKey == "" {
-		cfg.MinIO.SecretKey = "minioadmin"
-	}
-	if cfg.MinIO.Bucket == "" {
-		cfg.MinIO.Bucket = "starbyte"
-	}
+// CORSConfig holds the Cross-Origin Resource Sharing settings.
+type CORSConfig struct {
+	AllowedOrigins   []string `yaml:"allowed_origins"`
+	AllowedMethods   []string `yaml:"allowed_methods"`
+	AllowedHeaders   []string `yaml:"allowed_headers"`
+	AllowCredentials bool     `yaml:"allow_credentials"`
 }

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -87,5 +87,6 @@ type CORSConfig struct {
 	AllowedOrigins   []string `yaml:"allowed_origins"`
 	AllowedMethods   []string `yaml:"allowed_methods"`
 	AllowedHeaders   []string `yaml:"allowed_headers"`
+	ExposeHeaders    []string `yaml:"expose_headers"`
 	AllowCredentials bool     `yaml:"allow_credentials"`
 }

--- a/backend/pkg/config/loader.go
+++ b/backend/pkg/config/loader.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -9,6 +10,13 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+// validEnvs defines the set of accepted APP_ENV values.
+var validEnvs = map[string]bool{
+	"dev":  true,
+	"test": true,
+	"prod": true,
+}
 
 // Load reads the base YAML config, applies environment-specific overrides,
 // injects environment variables for sensitive fields, sets defaults, and
@@ -35,6 +43,9 @@ func Load(path string) (*Config, error) {
 	// 2. Load environment-specific override (if APP_ENV is set).
 	env := os.Getenv("APP_ENV")
 	if env != "" {
+		if !validEnvs[env] {
+			return nil, fmt.Errorf("invalid APP_ENV %q, must be one of: dev, test, prod", env)
+		}
 		overridePath := filepath.Join(filepath.Dir(path), "config."+env+".yaml")
 		if overrideData, err := os.ReadFile(overridePath); err == nil {
 			if err := yaml.Unmarshal(overrideData, cfg); err != nil {
@@ -97,140 +108,58 @@ func Load(path string) (*Config, error) {
 //	CORS_ALLOWED_ORIGINS  — cors.allowed_origins (comma-separated)
 //	CORS_ALLOWED_METHODS  — cors.allowed_methods (comma-separated)
 //	CORS_ALLOWED_HEADERS  — cors.allowed_headers (comma-separated)
+//	CORS_EXPOSE_HEADERS   — cors.expose_headers (comma-separated)
 //	CORS_ALLOW_CREDENTIALS — cors.allow_credentials (true/false)
 func applyEnvOverrides(cfg *Config) {
 	// Server
-	if v := os.Getenv("SERVER_PORT"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.Server.Port = n
-		}
-	}
-	if v := os.Getenv("SERVER_MODE"); v != "" {
-		cfg.Server.Mode = v
-	}
+	cfg.Server.Port = getEnvInt("SERVER_PORT", cfg.Server.Port)
+	cfg.Server.Mode = getEnv("SERVER_MODE", cfg.Server.Mode)
 
 	// Database
-	if v := os.Getenv("DB_HOST"); v != "" {
-		cfg.Database.Host = v
-	}
-	if v := os.Getenv("DB_PORT"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.Database.Port = n
-		}
-	}
-	if v := os.Getenv("DB_USER"); v != "" {
-		cfg.Database.User = v
-	}
-	if v := os.Getenv("DB_PASSWORD"); v != "" {
-		cfg.Database.Password = v
-	}
-	if v := os.Getenv("DB_NAME"); v != "" {
-		cfg.Database.DBName = v
-	}
-	if v := os.Getenv("DB_SSLMODE"); v != "" {
-		cfg.Database.SSLMode = v
-	}
-	if v := os.Getenv("DB_MAX_OPEN"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.Database.MaxOpen = n
-		}
-	}
-	if v := os.Getenv("DB_MAX_IDLE"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.Database.MaxIdle = n
-		}
-	}
+	cfg.Database.Host = getEnv("DB_HOST", cfg.Database.Host)
+	cfg.Database.Port = getEnvInt("DB_PORT", cfg.Database.Port)
+	cfg.Database.User = getEnv("DB_USER", cfg.Database.User)
+	cfg.Database.Password = getEnv("DB_PASSWORD", cfg.Database.Password)
+	cfg.Database.DBName = getEnv("DB_NAME", cfg.Database.DBName)
+	cfg.Database.SSLMode = getEnv("DB_SSLMODE", cfg.Database.SSLMode)
+	cfg.Database.MaxOpen = getEnvInt("DB_MAX_OPEN", cfg.Database.MaxOpen)
+	cfg.Database.MaxIdle = getEnvInt("DB_MAX_IDLE", cfg.Database.MaxIdle)
 
 	// Redis
-	if v := os.Getenv("REDIS_HOST"); v != "" {
-		cfg.Redis.Host = v
-	}
-	if v := os.Getenv("REDIS_PORT"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.Redis.Port = n
-		}
-	}
-	if v := os.Getenv("REDIS_PASSWORD"); v != "" {
-		cfg.Redis.Password = v
-	}
-	if v := os.Getenv("REDIS_DB"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.Redis.DB = n
-		}
-	}
+	cfg.Redis.Host = getEnv("REDIS_HOST", cfg.Redis.Host)
+	cfg.Redis.Port = getEnvInt("REDIS_PORT", cfg.Redis.Port)
+	cfg.Redis.Password = getEnv("REDIS_PASSWORD", cfg.Redis.Password)
+	cfg.Redis.DB = getEnvInt("REDIS_DB", cfg.Redis.DB)
 
 	// JWT
-	if v := os.Getenv("JWT_SECRET"); v != "" {
-		cfg.JWT.Secret = v
-	}
-	if v := os.Getenv("JWT_ACCESS_TOKEN_EXP"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.JWT.AccessTokenExp = n
-		}
-	}
-	if v := os.Getenv("JWT_REFRESH_TOKEN_EXP"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.JWT.RefreshTokenExp = n
-		}
-	}
+	cfg.JWT.Secret = getEnv("JWT_SECRET", cfg.JWT.Secret)
+	cfg.JWT.AccessTokenExp = getEnvInt("JWT_ACCESS_TOKEN_EXP", cfg.JWT.AccessTokenExp)
+	cfg.JWT.RefreshTokenExp = getEnvInt("JWT_REFRESH_TOKEN_EXP", cfg.JWT.RefreshTokenExp)
 
 	// MinIO
-	if v := os.Getenv("MINIO_ENDPOINT"); v != "" {
-		cfg.MinIO.Endpoint = v
-	}
-	if v := os.Getenv("MINIO_ACCESS_KEY"); v != "" {
-		cfg.MinIO.AccessKey = v
-	}
-	if v := os.Getenv("MINIO_SECRET_KEY"); v != "" {
-		cfg.MinIO.SecretKey = v
-	}
-	if v := os.Getenv("MINIO_BUCKET"); v != "" {
-		cfg.MinIO.Bucket = v
-	}
-	if v := os.Getenv("MINIO_USE_SSL"); v != "" {
-		cfg.MinIO.UseSSL = v == "true" || v == "1"
-	}
+	cfg.MinIO.Endpoint = getEnv("MINIO_ENDPOINT", cfg.MinIO.Endpoint)
+	cfg.MinIO.AccessKey = getEnv("MINIO_ACCESS_KEY", cfg.MinIO.AccessKey)
+	cfg.MinIO.SecretKey = getEnv("MINIO_SECRET_KEY", cfg.MinIO.SecretKey)
+	cfg.MinIO.Bucket = getEnv("MINIO_BUCKET", cfg.MinIO.Bucket)
+	cfg.MinIO.UseSSL = getEnvBool("MINIO_USE_SSL", cfg.MinIO.UseSSL)
 
 	// Email
-	if v := os.Getenv("SMTP_HOST"); v != "" {
-		cfg.Email.SMTPHost = v
-	}
-	if v := os.Getenv("SMTP_PORT"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			cfg.Email.SMTPPort = n
-		}
-	}
-	if v := os.Getenv("SMTP_USER"); v != "" {
-		cfg.Email.Username = v
-	}
-	if v := os.Getenv("SMTP_PASSWORD"); v != "" {
-		cfg.Email.Password = v
-	}
-	if v := os.Getenv("SMTP_FROM"); v != "" {
-		cfg.Email.From = v
-	}
+	cfg.Email.SMTPHost = getEnv("SMTP_HOST", cfg.Email.SMTPHost)
+	cfg.Email.SMTPPort = getEnvInt("SMTP_PORT", cfg.Email.SMTPPort)
+	cfg.Email.Username = getEnv("SMTP_USER", cfg.Email.Username)
+	cfg.Email.Password = getEnv("SMTP_PASSWORD", cfg.Email.Password)
+	cfg.Email.From = getEnv("SMTP_FROM", cfg.Email.From)
 
 	// Logger
-	if v := os.Getenv("LOG_LEVEL"); v != "" {
-		cfg.Logger.Level = v
-	}
-	if v := os.Getenv("LOG_FORMAT"); v != "" {
-		cfg.Logger.Format = v
-	}
+	cfg.Logger.Level = getEnv("LOG_LEVEL", cfg.Logger.Level)
+	cfg.Logger.Format = getEnv("LOG_FORMAT", cfg.Logger.Format)
 
 	// CORS (comma-separated values)
-	if v := os.Getenv("CORS_ALLOWED_ORIGINS"); v != "" {
-		cfg.CORS.AllowedOrigins = splitCSV(v)
-	}
-	if v := os.Getenv("CORS_ALLOWED_METHODS"); v != "" {
-		cfg.CORS.AllowedMethods = splitCSV(v)
-	}
-	if v := os.Getenv("CORS_ALLOWED_HEADERS"); v != "" {
-		cfg.CORS.AllowedHeaders = splitCSV(v)
-	}
-	if v := os.Getenv("CORS_ALLOW_CREDENTIALS"); v != "" {
-		cfg.CORS.AllowCredentials = v == "true" || v == "1"
-	}
+	cfg.CORS.AllowedOrigins = getEnvCSV("CORS_ALLOWED_ORIGINS", cfg.CORS.AllowedOrigins)
+	cfg.CORS.AllowedMethods = getEnvCSV("CORS_ALLOWED_METHODS", cfg.CORS.AllowedMethods)
+	cfg.CORS.AllowedHeaders = getEnvCSV("CORS_ALLOWED_HEADERS", cfg.CORS.AllowedHeaders)
+	cfg.CORS.ExposeHeaders = getEnvCSV("CORS_EXPOSE_HEADERS", cfg.CORS.ExposeHeaders)
+	cfg.CORS.AllowCredentials = getEnvBool("CORS_ALLOW_CREDENTIALS", cfg.CORS.AllowCredentials)
 }
 
 // getEnv returns the value of an environment variable or a fallback.
@@ -242,13 +171,39 @@ func getEnv(key, fallback string) string {
 }
 
 // getEnvInt returns the integer value of an environment variable or a fallback.
+// If the environment variable is set but cannot be parsed as an integer, a
+// warning is logged and the fallback is returned.
 func getEnvInt(key string, fallback int) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
 	}
-	return fallback
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Printf("config: ignoring invalid integer for %s=%q: %v", key, v, err)
+		return fallback
+	}
+	return n
+}
+
+// getEnvBool returns the boolean value of an environment variable or a fallback.
+// The value is considered true if it is "true" or "1" (case-sensitive).
+func getEnvBool(key string, fallback bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	return v == "true" || v == "1"
+}
+
+// getEnvCSV returns the comma-separated value of an environment variable as a
+// slice, or a fallback if the variable is not set.
+func getEnvCSV(key string, fallback []string) []string {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	return splitCSV(v)
 }
 
 // splitCSV is a helper to parse comma-separated string values into a slice.
@@ -389,6 +344,15 @@ func validate(cfg *Config, env string) error {
 	// In production, database password must not be empty.
 	if env == "prod" && cfg.Database.Password == "" {
 		return fmt.Errorf("config validation: database.password is required in production")
+	}
+
+	// In production, Redis host must be set.
+	if env == "prod" && cfg.Redis.Host == "" {
+		return fmt.Errorf("config validation: redis.host is required in production")
+	}
+	// In production, Redis password should be set (security best practice).
+	if env == "prod" && cfg.Redis.Password == "" {
+		return fmt.Errorf("config validation: redis.password should be set in production (use environment variable REDIS_PASSWORD)")
 	}
 
 	// Server port range check.

--- a/backend/pkg/config/loader.go
+++ b/backend/pkg/config/loader.go
@@ -1,0 +1,407 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Load reads the base YAML config, applies environment-specific overrides,
+// injects environment variables for sensitive fields, sets defaults, and
+// validates the result.
+//
+// The path argument points to the base config file (e.g. "configs/config.yaml").
+// If the APP_ENV environment variable is set (dev/test/prod), a matching
+// config.{APP_ENV}.yaml in the same directory is loaded and merged on top.
+//
+// Environment variables override individual fields after YAML merging.
+// See applyEnvOverrides() for the full list of supported variables.
+func Load(path string) (*Config, error) {
+	// 1. Read and parse base config.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file: %w", err)
+	}
+
+	cfg := &Config{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal base config: %w", err)
+	}
+
+	// 2. Load environment-specific override (if APP_ENV is set).
+	env := os.Getenv("APP_ENV")
+	if env != "" {
+		overridePath := filepath.Join(filepath.Dir(path), "config."+env+".yaml")
+		if overrideData, err := os.ReadFile(overridePath); err == nil {
+			if err := yaml.Unmarshal(overrideData, cfg); err != nil {
+				return nil, fmt.Errorf("unmarshal %s config: %w", env, err)
+			}
+		}
+		// If the override file doesn't exist, silently fall back to base config.
+	}
+
+	// 3. Inject environment variables (highest priority).
+	applyEnvOverrides(cfg)
+
+	// 4. Set defaults for any remaining zero-value fields.
+	setDefaults(cfg)
+
+	// 5. Validate critical fields.
+	if err := validate(cfg, env); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// applyEnvOverrides overwrites sensitive config fields from environment
+// variables. Environment variables take the highest priority — they override
+// values from both the base YAML and environment-specific YAML.
+//
+// Supported environment variables:
+//
+//	APP_ENV              — selects config.{env}.yaml override
+//	SERVER_PORT          — server.port
+//	SERVER_MODE          — server.mode
+//	DB_HOST              — database.host
+//	DB_PORT              — database.port
+//	DB_USER              — database.user
+//	DB_PASSWORD          — database.password
+//	DB_NAME              — database.dbname
+//	DB_SSLMODE           — database.sslmode
+//	DB_MAX_OPEN          — database.max_open
+//	DB_MAX_IDLE          — database.max_idle
+//	REDIS_HOST           — redis.host
+//	REDIS_PORT           — redis.port
+//	REDIS_PASSWORD       — redis.password
+//	REDIS_DB             — redis.db
+//	JWT_SECRET           — jwt.secret
+//	JWT_ACCESS_TOKEN_EXP — jwt.access_token_exp
+//	JWT_REFRESH_TOKEN_EXP — jwt.refresh_token_exp
+//	MINIO_ENDPOINT       — minio.endpoint
+//	MINIO_ACCESS_KEY     — minio.access_key
+//	MINIO_SECRET_KEY     — minio.secret_key
+//	MINIO_BUCKET         — minio.bucket
+//	MINIO_USE_SSL        — minio.use_ssl
+//	SMTP_HOST            — email.smtp_host
+//	SMTP_PORT            — email.smtp_port
+//	SMTP_USER            — email.username
+//	SMTP_PASSWORD        — email.password
+//	SMTP_FROM            — email.from
+//	LOG_LEVEL            — logger.level
+//	LOG_FORMAT           — logger.format
+//	CORS_ALLOWED_ORIGINS  — cors.allowed_origins (comma-separated)
+//	CORS_ALLOWED_METHODS  — cors.allowed_methods (comma-separated)
+//	CORS_ALLOWED_HEADERS  — cors.allowed_headers (comma-separated)
+//	CORS_ALLOW_CREDENTIALS — cors.allow_credentials (true/false)
+func applyEnvOverrides(cfg *Config) {
+	// Server
+	if v := os.Getenv("SERVER_PORT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.Server.Port = n
+		}
+	}
+	if v := os.Getenv("SERVER_MODE"); v != "" {
+		cfg.Server.Mode = v
+	}
+
+	// Database
+	if v := os.Getenv("DB_HOST"); v != "" {
+		cfg.Database.Host = v
+	}
+	if v := os.Getenv("DB_PORT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.Database.Port = n
+		}
+	}
+	if v := os.Getenv("DB_USER"); v != "" {
+		cfg.Database.User = v
+	}
+	if v := os.Getenv("DB_PASSWORD"); v != "" {
+		cfg.Database.Password = v
+	}
+	if v := os.Getenv("DB_NAME"); v != "" {
+		cfg.Database.DBName = v
+	}
+	if v := os.Getenv("DB_SSLMODE"); v != "" {
+		cfg.Database.SSLMode = v
+	}
+	if v := os.Getenv("DB_MAX_OPEN"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.Database.MaxOpen = n
+		}
+	}
+	if v := os.Getenv("DB_MAX_IDLE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.Database.MaxIdle = n
+		}
+	}
+
+	// Redis
+	if v := os.Getenv("REDIS_HOST"); v != "" {
+		cfg.Redis.Host = v
+	}
+	if v := os.Getenv("REDIS_PORT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.Redis.Port = n
+		}
+	}
+	if v := os.Getenv("REDIS_PASSWORD"); v != "" {
+		cfg.Redis.Password = v
+	}
+	if v := os.Getenv("REDIS_DB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.Redis.DB = n
+		}
+	}
+
+	// JWT
+	if v := os.Getenv("JWT_SECRET"); v != "" {
+		cfg.JWT.Secret = v
+	}
+	if v := os.Getenv("JWT_ACCESS_TOKEN_EXP"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.JWT.AccessTokenExp = n
+		}
+	}
+	if v := os.Getenv("JWT_REFRESH_TOKEN_EXP"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.JWT.RefreshTokenExp = n
+		}
+	}
+
+	// MinIO
+	if v := os.Getenv("MINIO_ENDPOINT"); v != "" {
+		cfg.MinIO.Endpoint = v
+	}
+	if v := os.Getenv("MINIO_ACCESS_KEY"); v != "" {
+		cfg.MinIO.AccessKey = v
+	}
+	if v := os.Getenv("MINIO_SECRET_KEY"); v != "" {
+		cfg.MinIO.SecretKey = v
+	}
+	if v := os.Getenv("MINIO_BUCKET"); v != "" {
+		cfg.MinIO.Bucket = v
+	}
+	if v := os.Getenv("MINIO_USE_SSL"); v != "" {
+		cfg.MinIO.UseSSL = v == "true" || v == "1"
+	}
+
+	// Email
+	if v := os.Getenv("SMTP_HOST"); v != "" {
+		cfg.Email.SMTPHost = v
+	}
+	if v := os.Getenv("SMTP_PORT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.Email.SMTPPort = n
+		}
+	}
+	if v := os.Getenv("SMTP_USER"); v != "" {
+		cfg.Email.Username = v
+	}
+	if v := os.Getenv("SMTP_PASSWORD"); v != "" {
+		cfg.Email.Password = v
+	}
+	if v := os.Getenv("SMTP_FROM"); v != "" {
+		cfg.Email.From = v
+	}
+
+	// Logger
+	if v := os.Getenv("LOG_LEVEL"); v != "" {
+		cfg.Logger.Level = v
+	}
+	if v := os.Getenv("LOG_FORMAT"); v != "" {
+		cfg.Logger.Format = v
+	}
+
+	// CORS (comma-separated values)
+	if v := os.Getenv("CORS_ALLOWED_ORIGINS"); v != "" {
+		cfg.CORS.AllowedOrigins = splitCSV(v)
+	}
+	if v := os.Getenv("CORS_ALLOWED_METHODS"); v != "" {
+		cfg.CORS.AllowedMethods = splitCSV(v)
+	}
+	if v := os.Getenv("CORS_ALLOWED_HEADERS"); v != "" {
+		cfg.CORS.AllowedHeaders = splitCSV(v)
+	}
+	if v := os.Getenv("CORS_ALLOW_CREDENTIALS"); v != "" {
+		cfg.CORS.AllowCredentials = v == "true" || v == "1"
+	}
+}
+
+// getEnv returns the value of an environment variable or a fallback.
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// getEnvInt returns the integer value of an environment variable or a fallback.
+func getEnvInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+// splitCSV is a helper to parse comma-separated string values into a slice.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// setDefaults fills in sensible default values for any zero-value fields
+// that were not provided by the YAML files or environment variables.
+// This ensures the application can start with a minimal config file while
+// still enforcing critical values via validate().
+func setDefaults(cfg *Config) {
+	// Server defaults
+	if cfg.Server.Port == 0 {
+		cfg.Server.Port = 8080
+	}
+	if cfg.Server.Mode == "" {
+		cfg.Server.Mode = "debug"
+	}
+	if cfg.Server.ReadTimeout == 0 {
+		cfg.Server.ReadTimeout = 30
+	}
+	if cfg.Server.WriteTimeout == 0 {
+		cfg.Server.WriteTimeout = 30
+	}
+
+	// Database defaults
+	if cfg.Database.Port == 0 {
+		cfg.Database.Port = 5432
+	}
+	if cfg.Database.SSLMode == "" {
+		cfg.Database.SSLMode = "disable"
+	}
+	if cfg.Database.MaxOpen == 0 {
+		cfg.Database.MaxOpen = 100
+	}
+	if cfg.Database.MaxIdle == 0 {
+		cfg.Database.MaxIdle = 10
+	}
+
+	// Redis defaults
+	if cfg.Redis.Port == 0 {
+		cfg.Redis.Port = 6379
+	}
+
+	// JWT defaults
+	if cfg.JWT.AccessTokenExp == 0 {
+		cfg.JWT.AccessTokenExp = 7200
+	}
+	if cfg.JWT.RefreshTokenExp == 0 {
+		cfg.JWT.RefreshTokenExp = 604800
+	}
+	if cfg.JWT.Issuer == "" {
+		cfg.JWT.Issuer = "starbyte"
+	}
+
+	// Logger defaults
+	if cfg.Logger.Level == "" {
+		cfg.Logger.Level = "info"
+	}
+	if cfg.Logger.Format == "" {
+		cfg.Logger.Format = "json"
+	}
+	if cfg.Logger.Filename == "" {
+		cfg.Logger.Filename = "logs/starbyte.log"
+	}
+	if cfg.Logger.MaxSize == 0 {
+		cfg.Logger.MaxSize = 100
+	}
+	if cfg.Logger.MaxBackups == 0 {
+		cfg.Logger.MaxBackups = 5
+	}
+	if cfg.Logger.MaxAge == 0 {
+		cfg.Logger.MaxAge = 30
+	}
+
+	// MinIO defaults
+	if cfg.MinIO.Endpoint == "" {
+		cfg.MinIO.Endpoint = "localhost:9000"
+	}
+	if cfg.MinIO.Bucket == "" {
+		cfg.MinIO.Bucket = "starbyte"
+	}
+
+	// Email defaults
+	if cfg.Email.SMTPPort == 0 {
+		cfg.Email.SMTPPort = 587
+	}
+
+	// CORS defaults
+	if len(cfg.CORS.AllowedOrigins) == 0 {
+		cfg.CORS.AllowedOrigins = []string{"*"}
+	}
+	if len(cfg.CORS.AllowedMethods) == 0 {
+		cfg.CORS.AllowedMethods = []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"}
+	}
+	if len(cfg.CORS.AllowedHeaders) == 0 {
+		cfg.CORS.AllowedHeaders = []string{"Origin", "Content-Type", "Accept", "Authorization", "X-Request-Id"}
+	}
+}
+
+// validate checks that critical configuration fields are set to meaningful
+// values. It returns an error describing the first problem found, or nil
+// if the configuration passes all checks.
+//
+// The env parameter is the current APP_ENV value (may be empty). In
+// production mode the validation rules are stricter — for example, the
+// JWT secret must not be the placeholder value.
+func validate(cfg *Config, env string) error {
+	// JWT secret is always required.
+	if cfg.JWT.Secret == "" {
+		return fmt.Errorf("config validation: jwt.secret is required")
+	}
+	// In production, reject the placeholder JWT secret.
+	if env == "prod" && (cfg.JWT.Secret == "starbyte-secret-key-change-in-production" ||
+		strings.Contains(cfg.JWT.Secret, "change-in-production")) {
+		return fmt.Errorf("config validation: jwt.secret must be changed from default in production")
+	}
+
+	// Database host is required.
+	if cfg.Database.Host == "" {
+		return fmt.Errorf("config validation: database.host is required")
+	}
+	if cfg.Database.User == "" {
+		return fmt.Errorf("config validation: database.user is required")
+	}
+	if cfg.Database.DBName == "" {
+		return fmt.Errorf("config validation: database.dbname is required")
+	}
+
+	// In production, database password must not be empty.
+	if env == "prod" && cfg.Database.Password == "" {
+		return fmt.Errorf("config validation: database.password is required in production")
+	}
+
+	// Server port range check.
+	if cfg.Server.Port < 1 || cfg.Server.Port > 65535 {
+		return fmt.Errorf("config validation: server.port must be between 1 and 65535, got %d", cfg.Server.Port)
+	}
+
+	// Server mode must be one of the allowed values.
+	switch cfg.Server.Mode {
+	case "debug", "release", "test":
+	default:
+		return fmt.Errorf("config validation: server.mode must be debug, release, or test, got %q", cfg.Server.Mode)
+	}
+
+	return nil
+}

--- a/backend/pkg/config/loader_test.go
+++ b/backend/pkg/config/loader_test.go
@@ -197,7 +197,10 @@ func TestApplyEnvOverrides(t *testing.T) {
 	t.Setenv("SMTP_HOST", "smtp.prod.com")
 	t.Setenv("LOG_LEVEL", "debug")
 	t.Setenv("CORS_ALLOWED_ORIGINS", "https://a.com,https://b.com")
+	t.Setenv("CORS_ALLOWED_METHODS", "GET,POST,PUT")
+	t.Setenv("CORS_ALLOWED_HEADERS", "Content-Type,Authorization")
 	t.Setenv("CORS_ALLOW_CREDENTIALS", "true")
+	t.Setenv("CORS_EXPOSE_HEADERS", "X-Request-Id,X-Custom-Header")
 
 	applyEnvOverrides(cfg)
 
@@ -237,6 +240,21 @@ func TestApplyEnvOverrides(t *testing.T) {
 	}
 	if len(cfg.CORS.AllowedOrigins) != 2 {
 		t.Errorf("CORS.AllowedOrigins len = %d, want 2", len(cfg.CORS.AllowedOrigins))
+	}
+	if len(cfg.CORS.AllowedMethods) != 3 {
+		t.Errorf("CORS.AllowedMethods len = %d, want 3", len(cfg.CORS.AllowedMethods))
+	}
+	if cfg.CORS.AllowedMethods[0] != "GET" {
+		t.Errorf("CORS.AllowedMethods[0] = %s, want GET", cfg.CORS.AllowedMethods[0])
+	}
+	if len(cfg.CORS.AllowedHeaders) != 2 {
+		t.Errorf("CORS.AllowedHeaders len = %d, want 2", len(cfg.CORS.AllowedHeaders))
+	}
+	if cfg.CORS.AllowedHeaders[1] != "Authorization" {
+		t.Errorf("CORS.AllowedHeaders[1] = %s, want Authorization", cfg.CORS.AllowedHeaders[1])
+	}
+	if len(cfg.CORS.ExposeHeaders) != 2 {
+		t.Errorf("CORS.ExposeHeaders len = %d, want 2", len(cfg.CORS.ExposeHeaders))
 	}
 	if !cfg.CORS.AllowCredentials {
 		t.Error("CORS.AllowCredentials = false, want true")
@@ -462,6 +480,100 @@ func TestGetEnvInt(t *testing.T) {
 	}
 	if got := getEnvInt("TEST_GETENV_INT_UNSET", 99); got != 99 {
 		t.Errorf("getEnvInt = %d, want 99", got)
+	}
+}
+
+func TestGetEnvInt_InvalidValue(t *testing.T) {
+	t.Setenv("TEST_GETENV_INT_INVALID", "not-a-number")
+	got := getEnvInt("TEST_GETENV_INT_INVALID", 77)
+	if got != 77 {
+		t.Errorf("getEnvInt with invalid value = %d, want fallback 77", got)
+	}
+}
+
+func TestGetEnvBool(t *testing.T) {
+	t.Setenv("TEST_GETENV_BOOL_TRUE", "true")
+	t.Setenv("TEST_GETENV_BOOL_ONE", "1")
+	t.Setenv("TEST_GETENV_BOOL_FALSE", "false")
+
+	if got := getEnvBool("TEST_GETENV_BOOL_TRUE", false); !got {
+		t.Errorf("getEnvBool('true') = false, want true")
+	}
+	if got := getEnvBool("TEST_GETENV_BOOL_ONE", false); !got {
+		t.Errorf("getEnvBool('1') = false, want true")
+	}
+	if got := getEnvBool("TEST_GETENV_BOOL_FALSE", true); got {
+		t.Errorf("getEnvBool('false') = true, want false")
+	}
+	if got := getEnvBool("TEST_GETENV_BOOL_UNSET", true); !got {
+		t.Errorf("getEnvBool(unset) = false, want fallback true")
+	}
+}
+
+func TestGetEnvCSV(t *testing.T) {
+	t.Setenv("TEST_GETENV_CSV", "a, b, c")
+	got := getEnvCSV("TEST_GETENV_CSV", nil)
+	if len(got) != 3 {
+		t.Fatalf("getEnvCSV len = %d, want 3", len(got))
+	}
+	if got[1] != "b" {
+		t.Errorf("getEnvCSV[1] = %q, want 'b'", got[1])
+	}
+
+	// Unset should return fallback.
+	fallback := []string{"default"}
+	got = getEnvCSV("TEST_GETENV_CSV_UNSET", fallback)
+	if len(got) != 1 || got[0] != "default" {
+		t.Errorf("getEnvCSV(unset) = %v, want [default]", got)
+	}
+}
+
+func TestLoad_InvalidAppEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := helperWriteConfig(t, dir, "config.yaml", baseConfigYAML)
+
+	t.Setenv("APP_ENV", "production")
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid APP_ENV, got nil")
+	}
+}
+
+func TestValidate_ProductionMissingRedisHost(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "release"},
+		Database: DatabaseConfig{Host: "db.prod", User: "starbyte", DBName: "starbyte", Password: "pass"},
+		Redis:    RedisConfig{Host: "", Port: 6379, Password: "redis-pass"},
+		JWT:      JWTConfig{Secret: "real-prod-secret"},
+	}
+	err := validate(cfg, "prod")
+	if err == nil {
+		t.Fatal("expected error for missing Redis host in prod, got nil")
+	}
+}
+
+func TestValidate_ProductionEmptyRedisPassword(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "release"},
+		Database: DatabaseConfig{Host: "db.prod", User: "starbyte", DBName: "starbyte", Password: "pass"},
+		Redis:    RedisConfig{Host: "redis.prod", Port: 6379, Password: ""},
+		JWT:      JWTConfig{Secret: "real-prod-secret"},
+	}
+	err := validate(cfg, "prod")
+	if err == nil {
+		t.Fatal("expected error for empty Redis password in prod, got nil")
+	}
+}
+
+func TestValidate_ProductionRedisValid(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "release"},
+		Database: DatabaseConfig{Host: "db.prod", User: "starbyte", DBName: "starbyte", Password: "pass"},
+		Redis:    RedisConfig{Host: "redis.prod", Port: 6379, Password: "redis-pass"},
+		JWT:      JWTConfig{Secret: "real-prod-secret"},
+	}
+	if err := validate(cfg, "prod"); err != nil {
+		t.Errorf("validate() in prod with valid Redis = %v, want nil", err)
 	}
 }
 

--- a/backend/pkg/config/loader_test.go
+++ b/backend/pkg/config/loader_test.go
@@ -1,0 +1,503 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// helperWriteConfig writes a YAML config file to a temp dir and returns its path.
+func helperWriteConfig(t *testing.T, dir, filename, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", filename, err)
+	}
+	return path
+}
+
+const baseConfigYAML = `server:
+  port: 8080
+  mode: debug
+  read_timeout: 30
+  write_timeout: 30
+database:
+  host: localhost
+  port: 5432
+  user: starbyte
+  password: starbyte
+  dbname: starbyte
+  sslmode: disable
+  max_open: 100
+  max_idle: 10
+redis:
+  host: localhost
+  port: 6379
+  password: ""
+  db: 0
+jwt:
+  secret: "test-secret-key"
+  access_token_exp: 7200
+  refresh_token_exp: 604800
+  issuer: starbyte
+logger:
+  level: info
+  format: json
+  filename: logs/starbyte.log
+  max_size: 100
+  max_backups: 5
+  max_age: 30
+  compress: true
+minio:
+  endpoint: localhost:9000
+  access_key: minioadmin
+  secret_key: minioadmin
+  bucket: starbyte
+  use_ssl: false
+email:
+  smtp_host: smtp.example.com
+  smtp_port: 587
+  username: noreply@example.com
+  password: emailpass
+  from: noreply@example.com
+cors:
+  allowed_origins:
+    - "http://localhost:3000"
+  allowed_methods:
+    - "GET"
+    - "POST"
+  allowed_headers:
+    - "Content-Type"
+  allow_credentials: true
+`
+
+func TestLoad_BaseConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := helperWriteConfig(t, dir, "config.yaml", baseConfigYAML)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	// Verify server config
+	if cfg.Server.Port != 8080 {
+		t.Errorf("Server.Port = %d, want 8080", cfg.Server.Port)
+	}
+	if cfg.Server.Mode != "debug" {
+		t.Errorf("Server.Mode = %s, want debug", cfg.Server.Mode)
+	}
+
+	// Verify database config
+	if cfg.Database.Host != "localhost" {
+		t.Errorf("Database.Host = %s, want localhost", cfg.Database.Host)
+	}
+	if cfg.Database.Port != 5432 {
+		t.Errorf("Database.Port = %d, want 5432", cfg.Database.Port)
+	}
+
+	// Verify JWT
+	if cfg.JWT.Secret != "test-secret-key" {
+		t.Errorf("JWT.Secret = %s, want test-secret-key", cfg.JWT.Secret)
+	}
+
+	// Verify CORS
+	if len(cfg.CORS.AllowedOrigins) != 1 || cfg.CORS.AllowedOrigins[0] != "http://localhost:3000" {
+		t.Errorf("CORS.AllowedOrigins = %v, want [http://localhost:3000]", cfg.CORS.AllowedOrigins)
+	}
+	if !cfg.CORS.AllowCredentials {
+		t.Error("CORS.AllowCredentials = false, want true")
+	}
+
+	// Verify Email
+	if cfg.Email.SMTPHost != "smtp.example.com" {
+		t.Errorf("Email.SMTPHost = %s, want smtp.example.com", cfg.Email.SMTPHost)
+	}
+}
+
+func TestLoad_EnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	helperWriteConfig(t, dir, "config.yaml", baseConfigYAML)
+
+	// Create a dev override that changes some values.
+	devYAML := `server:
+  mode: release
+database:
+  dbname: starbyte_dev
+  max_open: 50
+redis:
+  db: 1
+`
+	helperWriteConfig(t, dir, "config.dev.yaml", devYAML)
+
+	t.Setenv("APP_ENV", "dev")
+	path := filepath.Join(dir, "config.yaml")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	// Overridden values
+	if cfg.Server.Mode != "release" {
+		t.Errorf("Server.Mode = %s, want release (from dev override)", cfg.Server.Mode)
+	}
+	if cfg.Database.DBName != "starbyte_dev" {
+		t.Errorf("Database.DBName = %s, want starbyte_dev", cfg.Database.DBName)
+	}
+	if cfg.Database.MaxOpen != 50 {
+		t.Errorf("Database.MaxOpen = %d, want 50", cfg.Database.MaxOpen)
+	}
+	if cfg.Redis.DB != 1 {
+		t.Errorf("Redis.DB = %d, want 1", cfg.Redis.DB)
+	}
+
+	// Non-overridden values should remain from base
+	if cfg.Database.Host != "localhost" {
+		t.Errorf("Database.Host = %s, want localhost (from base)", cfg.Database.Host)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := Load("/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := helperWriteConfig(t, dir, "config.yaml", "server:\n  port: [invalid")
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestApplyEnvOverrides(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "debug"},
+		Database: DatabaseConfig{Host: "localhost", Port: 5432, User: "starbyte", DBName: "starbyte"},
+		Redis:    RedisConfig{Host: "localhost", Port: 6379},
+		JWT:      JWTConfig{Secret: "base-secret"},
+		MinIO:    MinIOConfig{Endpoint: "localhost:9000"},
+		Email:    EmailConfig{SMTPHost: "smtp.example.com", SMTPPort: 587},
+	}
+
+	t.Setenv("SERVER_PORT", "9090")
+	t.Setenv("SERVER_MODE", "release")
+	t.Setenv("DB_HOST", "db.prod.internal")
+	t.Setenv("DB_PORT", "5433")
+	t.Setenv("DB_PASSWORD", "secret-pass")
+	t.Setenv("REDIS_HOST", "redis.prod.internal")
+	t.Setenv("REDIS_PORT", "6380")
+	t.Setenv("JWT_SECRET", "env-override-secret")
+	t.Setenv("MINIO_ACCESS_KEY", "prod-access-key")
+	t.Setenv("SMTP_HOST", "smtp.prod.com")
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("CORS_ALLOWED_ORIGINS", "https://a.com,https://b.com")
+	t.Setenv("CORS_ALLOW_CREDENTIALS", "true")
+
+	applyEnvOverrides(cfg)
+
+	// Verify overrides
+	if cfg.Server.Port != 9090 {
+		t.Errorf("Server.Port = %d, want 9090", cfg.Server.Port)
+	}
+	if cfg.Server.Mode != "release" {
+		t.Errorf("Server.Mode = %s, want release", cfg.Server.Mode)
+	}
+	if cfg.Database.Host != "db.prod.internal" {
+		t.Errorf("Database.Host = %s, want db.prod.internal", cfg.Database.Host)
+	}
+	if cfg.Database.Port != 5433 {
+		t.Errorf("Database.Port = %d, want 5433", cfg.Database.Port)
+	}
+	if cfg.Database.Password != "secret-pass" {
+		t.Errorf("Database.Password = %s, want secret-pass", cfg.Database.Password)
+	}
+	if cfg.Redis.Host != "redis.prod.internal" {
+		t.Errorf("Redis.Host = %s, want redis.prod.internal", cfg.Redis.Host)
+	}
+	if cfg.Redis.Port != 6380 {
+		t.Errorf("Redis.Port = %d, want 6380", cfg.Redis.Port)
+	}
+	if cfg.JWT.Secret != "env-override-secret" {
+		t.Errorf("JWT.Secret = %s, want env-override-secret", cfg.JWT.Secret)
+	}
+	if cfg.MinIO.AccessKey != "prod-access-key" {
+		t.Errorf("MinIO.AccessKey = %s, want prod-access-key", cfg.MinIO.AccessKey)
+	}
+	if cfg.Email.SMTPHost != "smtp.prod.com" {
+		t.Errorf("Email.SMTPHost = %s, want smtp.prod.com", cfg.Email.SMTPHost)
+	}
+	if cfg.Logger.Level != "debug" {
+		t.Errorf("Logger.Level = %s, want debug", cfg.Logger.Level)
+	}
+	if len(cfg.CORS.AllowedOrigins) != 2 {
+		t.Errorf("CORS.AllowedOrigins len = %d, want 2", len(cfg.CORS.AllowedOrigins))
+	}
+	if !cfg.CORS.AllowCredentials {
+		t.Error("CORS.AllowCredentials = false, want true")
+	}
+}
+
+func TestSetDefaults(t *testing.T) {
+	cfg := &Config{}
+	setDefaults(cfg)
+
+	// Server
+	if cfg.Server.Port != 8080 {
+		t.Errorf("Server.Port = %d, want 8080", cfg.Server.Port)
+	}
+	if cfg.Server.Mode != "debug" {
+		t.Errorf("Server.Mode = %s, want debug", cfg.Server.Mode)
+	}
+	if cfg.Server.ReadTimeout != 30 {
+		t.Errorf("Server.ReadTimeout = %d, want 30", cfg.Server.ReadTimeout)
+	}
+
+	// Database
+	if cfg.Database.Port != 5432 {
+		t.Errorf("Database.Port = %d, want 5432", cfg.Database.Port)
+	}
+	if cfg.Database.SSLMode != "disable" {
+		t.Errorf("Database.SSLMode = %s, want disable", cfg.Database.SSLMode)
+	}
+	if cfg.Database.MaxOpen != 100 {
+		t.Errorf("Database.MaxOpen = %d, want 100", cfg.Database.MaxOpen)
+	}
+
+	// Redis
+	if cfg.Redis.Port != 6379 {
+		t.Errorf("Redis.Port = %d, want 6379", cfg.Redis.Port)
+	}
+
+	// JWT
+	if cfg.JWT.AccessTokenExp != 7200 {
+		t.Errorf("JWT.AccessTokenExp = %d, want 7200", cfg.JWT.AccessTokenExp)
+	}
+	if cfg.JWT.Issuer != "starbyte" {
+		t.Errorf("JWT.Issuer = %s, want starbyte", cfg.JWT.Issuer)
+	}
+
+	// Logger
+	if cfg.Logger.Level != "info" {
+		t.Errorf("Logger.Level = %s, want info", cfg.Logger.Level)
+	}
+	if cfg.Logger.Format != "json" {
+		t.Errorf("Logger.Format = %s, want json", cfg.Logger.Format)
+	}
+
+	// MinIO
+	if cfg.MinIO.Endpoint != "localhost:9000" {
+		t.Errorf("MinIO.Endpoint = %s, want localhost:9000", cfg.MinIO.Endpoint)
+	}
+
+	// Email
+	if cfg.Email.SMTPPort != 587 {
+		t.Errorf("Email.SMTPPort = %d, want 587", cfg.Email.SMTPPort)
+	}
+
+	// CORS
+	if len(cfg.CORS.AllowedOrigins) != 1 || cfg.CORS.AllowedOrigins[0] != "*" {
+		t.Errorf("CORS.AllowedOrigins = %v, want [*]", cfg.CORS.AllowedOrigins)
+	}
+	if len(cfg.CORS.AllowedMethods) != 6 {
+		t.Errorf("CORS.AllowedMethods len = %d, want 6", len(cfg.CORS.AllowedMethods))
+	}
+}
+
+func TestSetDefaults_DoesNotOverrideExisting(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 3000, Mode: "release"},
+		Database: DatabaseConfig{Port: 5433, MaxOpen: 200},
+		Redis:    RedisConfig{Port: 6380},
+	}
+	setDefaults(cfg)
+
+	if cfg.Server.Port != 3000 {
+		t.Errorf("Server.Port = %d, want 3000 (existing should not be overridden)", cfg.Server.Port)
+	}
+	if cfg.Server.Mode != "release" {
+		t.Errorf("Server.Mode = %s, want release", cfg.Server.Mode)
+	}
+	if cfg.Database.Port != 5433 {
+		t.Errorf("Database.Port = %d, want 5433", cfg.Database.Port)
+	}
+	if cfg.Database.MaxOpen != 200 {
+		t.Errorf("Database.MaxOpen = %d, want 200", cfg.Database.MaxOpen)
+	}
+	if cfg.Redis.Port != 6380 {
+		t.Errorf("Redis.Port = %d, want 6380", cfg.Redis.Port)
+	}
+}
+
+func TestValidate_Success(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "debug"},
+		Database: DatabaseConfig{Host: "localhost", User: "starbyte", DBName: "starbyte", Password: "pass"},
+		JWT:      JWTConfig{Secret: "valid-secret"},
+	}
+	if err := validate(cfg, ""); err != nil {
+		t.Errorf("validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidate_MissingJWTSecret(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "debug"},
+		Database: DatabaseConfig{Host: "localhost", User: "starbyte", DBName: "starbyte"},
+		JWT:      JWTConfig{Secret: ""},
+	}
+	err := validate(cfg, "")
+	if err == nil {
+		t.Fatal("expected error for empty JWT secret, got nil")
+	}
+}
+
+func TestValidate_ProductionDefaultSecret(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "release"},
+		Database: DatabaseConfig{Host: "localhost", User: "starbyte", DBName: "starbyte", Password: "pass"},
+		JWT:      JWTConfig{Secret: "starbyte-secret-key-change-in-production"},
+	}
+	err := validate(cfg, "prod")
+	if err == nil {
+		t.Fatal("expected error for default JWT secret in prod, got nil")
+	}
+}
+
+func TestValidate_ProductionEmptyPassword(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "release"},
+		Database: DatabaseConfig{Host: "localhost", User: "starbyte", DBName: "starbyte", Password: ""},
+		JWT:      JWTConfig{Secret: "real-prod-secret"},
+	}
+	err := validate(cfg, "prod")
+	if err == nil {
+		t.Fatal("expected error for empty DB password in prod, got nil")
+	}
+}
+
+func TestValidate_InvalidPort(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 0, Mode: "debug"},
+		Database: DatabaseConfig{Host: "localhost", User: "starbyte", DBName: "starbyte"},
+		JWT:      JWTConfig{Secret: "valid-secret"},
+	}
+	err := validate(cfg, "")
+	if err == nil {
+		t.Fatal("expected error for invalid port, got nil")
+	}
+}
+
+func TestValidate_InvalidMode(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "invalid"},
+		Database: DatabaseConfig{Host: "localhost", User: "starbyte", DBName: "starbyte"},
+		JWT:      JWTConfig{Secret: "valid-secret"},
+	}
+	err := validate(cfg, "")
+	if err == nil {
+		t.Fatal("expected error for invalid mode, got nil")
+	}
+}
+
+func TestValidate_MissingDBHost(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Port: 8080, Mode: "debug"},
+		Database: DatabaseConfig{User: "starbyte", DBName: "starbyte"},
+		JWT:      JWTConfig{Secret: "valid-secret"},
+	}
+	err := validate(cfg, "")
+	if err == nil {
+		t.Fatal("expected error for missing DB host, got nil")
+	}
+}
+
+func TestSplitCSV(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "a", []string{"a"}},
+		{"multiple", "a,b,c", []string{"a", "b", "c"}},
+		{"with spaces", " a , b , c ", []string{"a", "b", "c"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitCSV(tt.in)
+			if len(got) != len(tt.want) {
+				t.Errorf("splitCSV(%q) = %v, want %v", tt.in, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("splitCSV(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetEnv(t *testing.T) {
+	t.Setenv("TEST_GETENV_VAR", "hello")
+	if got := getEnv("TEST_GETENV_VAR", "default"); got != "hello" {
+		t.Errorf("getEnv = %s, want hello", got)
+	}
+	if got := getEnv("TEST_GETENV_UNSET", "default"); got != "default" {
+		t.Errorf("getEnv = %s, want default", got)
+	}
+}
+
+func TestGetEnvInt(t *testing.T) {
+	t.Setenv("TEST_GETENV_INT", "42")
+	if got := getEnvInt("TEST_GETENV_INT", 0); got != 42 {
+		t.Errorf("getEnvInt = %d, want 42", got)
+	}
+	if got := getEnvInt("TEST_GETENV_INT_UNSET", 99); got != 99 {
+		t.Errorf("getEnvInt = %d, want 99", got)
+	}
+}
+
+func TestLoad_MinimalConfigWithDefaults(t *testing.T) {
+	// A minimal config with only critical fields.
+	minYAML := `database:
+  host: db.local
+  user: admin
+  dbname: mydb
+jwt:
+  secret: minimal-secret
+`
+	dir := t.TempDir()
+	path := helperWriteConfig(t, dir, "config.yaml", minYAML)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	// Check that defaults were applied
+	if cfg.Server.Port != 8080 {
+		t.Errorf("Server.Port = %d, want default 8080", cfg.Server.Port)
+	}
+	if cfg.Database.Port != 5432 {
+		t.Errorf("Database.Port = %d, want default 5432", cfg.Database.Port)
+	}
+	if cfg.Redis.Port != 6379 {
+		t.Errorf("Redis.Port = %d, want default 6379", cfg.Redis.Port)
+	}
+
+	// Check that provided values are kept
+	if cfg.Database.Host != "db.local" {
+		t.Errorf("Database.Host = %s, want db.local", cfg.Database.Host)
+	}
+	if cfg.JWT.Secret != "minimal-secret" {
+		t.Errorf("JWT.Secret = %s, want minimal-secret", cfg.JWT.Secret)
+	}
+}

--- a/backend/pkg/middleware/common.go
+++ b/backend/pkg/middleware/common.go
@@ -2,8 +2,10 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/Yogdunana/StarByte/backend/pkg/config"
 	"github.com/Yogdunana/StarByte/backend/pkg/logger"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/gin-gonic/gin"
@@ -71,13 +73,53 @@ func Recovery() gin.HandlerFunc {
 	}
 }
 
-// CORS sets the Cross-Origin Resource Sharing headers and short-circuits
-// preflight OPTIONS requests.
-func CORS() gin.HandlerFunc {
+// CORSWithConfig returns a CORS middleware that uses the provided
+// configuration. It supports configurable origins, methods, headers,
+// and credentials. If the config has empty slices, safe defaults are used.
+func CORSWithConfig(cfg config.CORSConfig) gin.HandlerFunc {
+	origins := cfg.AllowedOrigins
+	if len(origins) == 0 {
+		origins = []string{"*"}
+	}
+	methods := cfg.AllowedMethods
+	if len(methods) == 0 {
+		methods = []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"}
+	}
+	headers := cfg.AllowedHeaders
+	if len(headers) == 0 {
+		headers = []string{"Origin", "Content-Type", "Accept", "Authorization", "X-Request-Id"}
+	}
+	allowCredentials := cfg.AllowCredentials
+
 	return func(c *gin.Context) {
-		c.Header("Access-Control-Allow-Origin", "*")
-		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization, X-Request-Id")
+		origin := c.GetHeader("Origin")
+
+		// Determine the allowed origin.
+		allowedOrigin := ""
+		for _, o := range origins {
+			if o == "*" {
+				allowedOrigin = "*"
+				break
+			}
+			if o == origin {
+				allowedOrigin = o
+				break
+			}
+		}
+
+		// If no match found and wildcard is present, use wildcard.
+		if allowedOrigin == "" && len(origins) > 0 && origins[0] == "*" {
+			allowedOrigin = "*"
+		}
+
+		if allowedOrigin != "" {
+			c.Header("Access-Control-Allow-Origin", allowedOrigin)
+		}
+		if allowCredentials && allowedOrigin != "*" {
+			c.Header("Access-Control-Allow-Credentials", "true")
+		}
+		c.Header("Access-Control-Allow-Methods", strings.Join(methods, ", "))
+		c.Header("Access-Control-Allow-Headers", strings.Join(headers, ", "))
 		c.Header("Access-Control-Expose-Headers", "X-Request-Id")
 		c.Header("Access-Control-Max-Age", "86400")
 
@@ -88,4 +130,10 @@ func CORS() gin.HandlerFunc {
 
 		c.Next()
 	}
+}
+
+// CORS returns a CORS middleware with default permissive settings.
+// Prefer CORSWithConfig() for production use.
+func CORS() gin.HandlerFunc {
+	return CORSWithConfig(config.CORSConfig{})
 }

--- a/backend/pkg/middleware/common.go
+++ b/backend/pkg/middleware/common.go
@@ -89,6 +89,10 @@ func CORSWithConfig(cfg config.CORSConfig) gin.HandlerFunc {
 	if len(headers) == 0 {
 		headers = []string{"Origin", "Content-Type", "Accept", "Authorization", "X-Request-Id"}
 	}
+	exposeHeaders := cfg.ExposeHeaders
+	if len(exposeHeaders) == 0 {
+		exposeHeaders = []string{"X-Request-Id"}
+	}
 	allowCredentials := cfg.AllowCredentials
 
 	return func(c *gin.Context) {
@@ -107,11 +111,6 @@ func CORSWithConfig(cfg config.CORSConfig) gin.HandlerFunc {
 			}
 		}
 
-		// If no match found and wildcard is present, use wildcard.
-		if allowedOrigin == "" && len(origins) > 0 && origins[0] == "*" {
-			allowedOrigin = "*"
-		}
-
 		if allowedOrigin != "" {
 			c.Header("Access-Control-Allow-Origin", allowedOrigin)
 		}
@@ -120,7 +119,7 @@ func CORSWithConfig(cfg config.CORSConfig) gin.HandlerFunc {
 		}
 		c.Header("Access-Control-Allow-Methods", strings.Join(methods, ", "))
 		c.Header("Access-Control-Allow-Headers", strings.Join(headers, ", "))
-		c.Header("Access-Control-Expose-Headers", "X-Request-Id")
+		c.Header("Access-Control-Expose-Headers", strings.Join(exposeHeaders, ", "))
 		c.Header("Access-Control-Max-Age", "86400")
 
 		if c.Request.Method == http.MethodOptions {


### PR DESCRIPTION
## 概述

实现 StarByte 后端的配置中心与多环境管理系统，支持 base + 环境覆盖 + 环境变量三层加载策略。

## 关联 Issue

Closes #13

## 实现内容

### 1. 配置结构体扩展 (`config.go`)
- 新增 `EmailConfig` 结构体（SMTP 配置）
- 新增 `CORSConfig` 结构体（跨域配置）

### 2. 多环境加载器 (`loader.go`)
- **三层加载策略**：
  1. `configs/config.yaml` — 基础配置（所有环境共享）
  2. `configs/config.{APP_ENV}.yaml` — 环境覆盖（dev/test/prod）
  3. 环境变量 — 敏感信息注入（最高优先级）
- **环境变量注入**（30+ 变量）：
  - Server: `SERVER_PORT`, `SERVER_MODE`
  - Database: `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `DB_SSLMODE`, `DB_MAX_OPEN`, `DB_MAX_IDLE`
  - Redis: `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, `REDIS_DB`
  - JWT: `JWT_SECRET`, `JWT_ACCESS_TOKEN_EXP`, `JWT_REFRESH_TOKEN_EXP`
  - MinIO: `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `MINIO_USE_SSL`
  - Email: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`
  - Logger: `LOG_LEVEL`, `LOG_FORMAT`
  - CORS: `CORS_ALLOWED_ORIGINS`, `CORS_ALLOWED_METHODS`, `CORS_ALLOWED_HEADERS`, `CORS_ALLOW_CREDENTIALS`
- **默认值** (`setDefaults`)：所有零值字段自动填充合理默认值
- **配置校验** (`validate`)：
  - JWT Secret 必填
  - 生产环境禁止使用默认 Secret
  - 生产环境 Database Password 必填
  - Server Port 范围校验 (1-65535)
  - Server Mode 枚举校验 (debug/release/test)

### 3. 多环境配置文件
- `config.dev.yaml` — 开发环境（debug 模式、console 日志、宽松 CORS）
- `config.test.yaml` — 测试环境（test 模式、warn 日志级别、Redis DB=1）
- `config.prod.yaml` — 生产环境（release 模式、SSL 要求、严格 CORS）

### 4. CORS 中间件配置化 (`common.go`)
- 新增 `CORSWithConfig(cfg)` 函数，支持配置化跨域设置
- 支持 Origin 白名单匹配
- 支持 Credentials 开关
- 保留 `CORS()` 向后兼容

### 5. `.env.example` 模板
- 完整的环境变量文档
- 按模块分组（Server/DB/Redis/JWT/MinIO/Email/Logger）
- 包含加载顺序说明

### 6. 单元测试 (`loader_test.go`)
- 19 个测试用例，全部通过
- 覆盖：基础加载、环境覆盖、环境变量注入、默认值设置、配置校验（成功/失败）、辅助函数

## 测试结果

```
ok      github.com/Yogdunana/StarByte/backend/pkg/config        0.011s
ok      github.com/Yogdunana/StarByte/backend/pkg/middleware    0.019s
```

## 文件变更

| 文件 | 变更类型 | 说明 |
|------|----------|------|
| `backend/pkg/config/config.go` | 修改 | 新增 EmailConfig + CORSConfig |
| `backend/pkg/config/loader.go` | 新增 | 多环境加载 + 环境变量注入 + 校验 |
| `backend/pkg/config/loader_test.go` | 新增 | 19 个单元测试 |
| `backend/configs/config.dev.yaml` | 新增 | 开发环境配置 |
| `backend/configs/config.test.yaml` | 新增 | 测试环境配置 |
| `backend/configs/config.prod.yaml` | 新增 | 生产环境配置 |
| `backend/configs/config.yaml` | 修改 | 新增 email + cors 配置节 |
| `backend/.env.example` | 修改 | 完整环境变量文档 |
| `backend/pkg/middleware/common.go` | 修改 | CORS 配置化 |
| `backend/cmd/server/main.go` | 修改 | 使用 CORSWithConfig |