### PR TITLE
feat(workflow): PR3 - Handler 层 + API 路由 [Issue #2]

### DIFF
--- a/backend/internal/workflow/dto/workflow_dto.go
+++ b/backend/internal/workflow/dto/workflow_dto.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
 	"github.com/google/uuid"
 )
 
@@ -167,4 +168,106 @@ type HistoryResponse struct {
 	FromNodeID string     `json:"from_node_id"`
 	ToNodeID   string     `json:"to_node_id"`
 	CreatedAt  time.Time  `json:"created_at"`
+}
+
+// ========== DTO Conversion Functions ==========
+
+// ToDefinitionResponse converts FlowDefinition model to DefinitionResponse.
+func ToDefinitionResponse(def *model.FlowDefinition) DefinitionResponse {
+	return DefinitionResponse{
+		ID:          def.ID,
+		Key:         def.Key,
+		Name:        def.Name,
+		Description: def.Description,
+		Category:    def.Category,
+		Status:      def.Status,
+		CreatedBy:   def.CreatedBy,
+		UpdatedBy:   def.UpdatedBy,
+		CreatedAt:   def.CreatedAt,
+		UpdatedAt:   def.UpdatedAt,
+	}
+}
+
+// ToVersionResponse converts FlowDefinitionVersion model to VersionResponse.
+func ToVersionResponse(ver *model.FlowDefinitionVersion) VersionResponse {
+	var graphData GraphData
+	if len(ver.BpmnData) > 0 {
+		_ = json.Unmarshal(ver.BpmnData, &graphData)
+	}
+	return VersionResponse{
+		ID:           ver.ID,
+		DefinitionID: ver.DefinitionID,
+		Version:      ver.Version,
+		BpmnData:     graphData,
+		Status:       ver.Status,
+		PublishedBy:  ver.PublishedBy,
+		PublishedAt:  ver.PublishedAt,
+		CreatedAt:    ver.CreatedAt,
+	}
+}
+
+// ToInstanceResponse converts FlowInstance model to InstanceResponse.
+func ToInstanceResponse(inst *model.FlowInstance) InstanceResponse {
+	var currentNodeIDs []string
+	if len(inst.CurrentNodeIDs) > 0 {
+		_ = json.Unmarshal(inst.CurrentNodeIDs, &currentNodeIDs)
+	}
+	return InstanceResponse{
+		ID:                  inst.ID,
+		DefinitionID:        inst.DefinitionID,
+		DefinitionVersionID: inst.DefinitionVersionID,
+		BusinessKey:         inst.BusinessKey,
+		BusinessType:        inst.BusinessType,
+		InitiatorID:         inst.InitiatorID,
+		Status:              inst.Status,
+		CurrentNodeIDs:      currentNodeIDs,
+		StartedAt:           inst.StartedAt,
+		EndedAt:             inst.EndedAt,
+		TerminateReason:     inst.TerminateReason,
+		CreatedAt:           inst.CreatedAt,
+		UpdatedAt:           inst.UpdatedAt,
+	}
+}
+
+// ToTaskResponse converts FlowTask model to TaskResponse.
+func ToTaskResponse(task *model.FlowTask) TaskResponse {
+	var formData json.RawMessage
+	if len(task.FormData) > 0 {
+		formData = json.RawMessage(task.FormData)
+	}
+	return TaskResponse{
+		ID:          task.ID,
+		InstanceID:  task.InstanceID,
+		NodeID:      task.NodeID,
+		NodeName:    task.NodeName,
+		TaskType:    task.TaskType,
+		AssigneeID:  task.AssigneeID,
+		Status:      task.Status,
+		Action:      task.Action,
+		Comment:     task.Comment,
+		FormData:    formData,
+		DueDate:     task.DueDate,
+		ClaimedAt:   task.ClaimedAt,
+		CompletedAt: task.CompletedAt,
+		CreatedAt:   task.CreatedAt,
+		UpdatedAt:   task.UpdatedAt,
+	}
+}
+
+// ToHistoryResponse converts FlowHistory model to HistoryResponse.
+func ToHistoryResponse(h *model.FlowHistory) HistoryResponse {
+	return HistoryResponse{
+		ID:         h.ID,
+		InstanceID: h.InstanceID,
+		TaskID:     h.TaskID,
+		NodeID:     h.NodeID,
+		NodeName:   h.NodeName,
+		NodeType:   h.NodeType,
+		OperatorID: h.OperatorID,
+		Action:     h.Action,
+		Comment:    h.Comment,
+		FromNodeID: h.FromNodeID,
+		ToNodeID:   h.ToNodeID,
+		CreatedAt:  h.CreatedAt,
+	}
 }

--- a/backend/internal/workflow/dto/workflow_dto.go
+++ b/backend/internal/workflow/dto/workflow_dto.go
@@ -114,6 +114,11 @@ type TerminateInstanceRequest struct {
 	Reason string `json:"reason" binding:"required,max=500"`
 }
 
+// SuspendInstanceRequest is the body for POST /api/v1/workflow/instances/:id/suspend.
+type SuspendInstanceRequest struct {
+	Reason string `json:"reason" binding:"required,max=500"`
+}
+
 // ========== Flow Task DTOs ==========
 
 // CompleteTaskRequest is the body for POST /api/v1/workflow/tasks/:id/complete.

--- a/backend/internal/workflow/handler/definition_handler.go
+++ b/backend/internal/workflow/handler/definition_handler.go
@@ -1,0 +1,279 @@
+package handler
+
+import (
+	"strconv"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// DefinitionHandler 流程定义处理器
+type DefinitionHandler struct {
+	defService service.DefinitionService
+}
+
+// NewDefinitionHandler 创建流程定义处理器
+func NewDefinitionHandler(defService service.DefinitionService) *DefinitionHandler {
+	return &DefinitionHandler{defService: defService}
+}
+
+// List 流程定义列表
+// @Summary 获取流程定义列表
+// @Description 分页查询流程定义列表
+// @Tags 流程定义
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param page query int false "页码" default(1)
+// @Param page_size query int false "每页数量" default(10)
+// @Param keyword query string false "关键词"
+// @Param category query string false "分类"
+// @Param status query int false "状态"
+// @Success 200 {object} response.Response{data=response.PageResponse{list=[]dto.DefinitionResponse}}
+// @Router /workflow/definitions [get]
+func (h *DefinitionHandler) List(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	keyword := c.Query("keyword")
+	category := c.Query("category")
+
+	var status *int
+	if statusStr := c.Query("status"); statusStr != "" {
+		if s, err := strconv.Atoi(statusStr); err == nil {
+			status = &s
+		}
+	}
+
+	list, total, err := h.defService.List(c.Request.Context(), page, pageSize, keyword, category, status)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	result := make([]dto.DefinitionResponse, 0, len(list))
+	for _, def := range list {
+		result = append(result, dto.ToDefinitionResponse(&def))
+	}
+
+	response.Page(c, result, total, page, pageSize)
+}
+
+// GetByID 获取流程定义详情
+// @Summary 获取流程定义详情
+// @Description 根据ID获取流程定义详细信息
+// @Tags 流程定义
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程定义ID"
+// @Success 200 {object} response.Response{data=dto.DefinitionResponse}
+// @Router /workflow/definitions/{id} [get]
+func (h *DefinitionHandler) GetByID(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程定义ID")
+		return
+	}
+
+	def, err := h.defService.GetByID(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToDefinitionResponse(def))
+}
+
+// Create 创建流程定义
+// @Summary 创建流程定义
+// @Description 创建新的流程定义（草稿状态）
+// @Tags 流程定义
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param request body dto.CreateDefinitionRequest true "流程定义信息"
+// @Success 200 {object} response.Response{data=dto.DefinitionResponse}
+// @Router /workflow/definitions [post]
+func (h *DefinitionHandler) Create(c *gin.Context) {
+	var req dto.CreateDefinitionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	userID := uuid.MustParse(auth.GetUserID(c))
+
+	def, err := h.defService.Create(c.Request.Context(), &req, userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToDefinitionResponse(def))
+}
+
+// Update 更新流程定义
+// @Summary 更新流程定义
+// @Description 更新流程定义基本信息
+// @Tags 流程定义
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程定义ID"
+// @Param request body dto.UpdateDefinitionRequest true "流程定义信息"
+// @Success 200 {object} response.Response{data=dto.DefinitionResponse}
+// @Router /workflow/definitions/{id} [put]
+func (h *DefinitionHandler) Update(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程定义ID")
+		return
+	}
+
+	var req dto.UpdateDefinitionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	userID := uuid.MustParse(auth.GetUserID(c))
+
+	def, err := h.defService.Update(c.Request.Context(), id, &req, userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToDefinitionResponse(def))
+}
+
+// Delete 删除流程定义
+// @Summary 删除流程定义
+// @Description 删除指定流程定义
+// @Tags 流程定义
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程定义ID"
+// @Success 200 {object} response.Response
+// @Router /workflow/definitions/{id} [delete]
+func (h *DefinitionHandler) Delete(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程定义ID")
+		return
+	}
+
+	if err := h.defService.Delete(c.Request.Context(), id); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Publish 发布流程定义
+// @Summary 发布流程定义
+// @Description 发布流程定义，创建新版本
+// @Tags 流程定义
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程定义ID"
+// @Param request body dto.PublishDefinitionRequest true "流程图数据"
+// @Success 200 {object} response.Response{data=dto.VersionResponse}
+// @Router /workflow/definitions/{id}/publish [post]
+func (h *DefinitionHandler) Publish(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程定义ID")
+		return
+	}
+
+	var req dto.PublishDefinitionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	userID := uuid.MustParse(auth.GetUserID(c))
+
+	version, err := h.defService.Publish(c.Request.Context(), id, &req, userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToVersionResponse(version))
+}
+
+// ListVersions 获取版本列表
+// @Summary 获取流程定义版本列表
+// @Description 获取指定流程定义的所有版本
+// @Tags 流程定义
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程定义ID"
+// @Success 200 {object} response.Response{data=[]dto.VersionResponse}
+// @Router /workflow/definitions/{id}/versions [get]
+func (h *DefinitionHandler) ListVersions(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程定义ID")
+		return
+	}
+
+	versions, err := h.defService.ListVersions(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	result := make([]dto.VersionResponse, 0, len(versions))
+	for _, v := range versions {
+		result = append(result, dto.ToVersionResponse(&v))
+	}
+
+	response.OK(c, result)
+}
+
+// GetVersionByID 获取指定版本详情
+// @Summary 获取指定版本详情
+// @Description 根据版本ID获取流程定义版本详情
+// @Tags 流程定义
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程定义ID"
+// @Param versionId path string true "版本ID"
+// @Success 200 {object} response.Response{data=dto.VersionResponse}
+// @Router /workflow/definitions/{id}/versions/{versionId} [get]
+func (h *DefinitionHandler) GetVersionByID(c *gin.Context) {
+	versionIDStr := c.Param("versionId")
+	versionID, err := uuid.Parse(versionIDStr)
+	if err != nil {
+		response.BadRequest(c, "无效的版本ID")
+		return
+	}
+
+	version, err := h.defService.GetVersionByID(c.Request.Context(), versionID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToVersionResponse(version))
+}

--- a/backend/internal/workflow/handler/definition_handler.go
+++ b/backend/internal/workflow/handler/definition_handler.go
@@ -5,10 +5,8 @@ import (
 
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
-	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // DefinitionHandler 流程定义处理器
@@ -36,14 +34,7 @@ func NewDefinitionHandler(defService service.DefinitionService) *DefinitionHandl
 // @Success 200 {object} response.Response{data=response.PageResponse{list=[]dto.DefinitionResponse}}
 // @Router /workflow/definitions [get]
 func (h *DefinitionHandler) List(c *gin.Context) {
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
-	if page <= 0 {
-		page = 1
-	}
-	if pageSize <= 0 {
-		pageSize = 10
-	}
+	page, pageSize := parsePagination(c)
 
 	keyword := c.Query("keyword")
 	category := c.Query("category")
@@ -79,10 +70,9 @@ func (h *DefinitionHandler) List(c *gin.Context) {
 // @Success 200 {object} response.Response{data=dto.DefinitionResponse}
 // @Router /workflow/definitions/{id} [get]
 func (h *DefinitionHandler) GetByID(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程定义ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程定义ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -112,7 +102,11 @@ func (h *DefinitionHandler) Create(c *gin.Context) {
 		return
 	}
 
-	userID := uuid.MustParse(auth.GetUserID(c))
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	def, err := h.defService.Create(c.Request.Context(), &req, userID)
 	if err != nil {
@@ -135,10 +129,9 @@ func (h *DefinitionHandler) Create(c *gin.Context) {
 // @Success 200 {object} response.Response{data=dto.DefinitionResponse}
 // @Router /workflow/definitions/{id} [put]
 func (h *DefinitionHandler) Update(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程定义ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程定义ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -148,7 +141,11 @@ func (h *DefinitionHandler) Update(c *gin.Context) {
 		return
 	}
 
-	userID := uuid.MustParse(auth.GetUserID(c))
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	def, err := h.defService.Update(c.Request.Context(), id, &req, userID)
 	if err != nil {
@@ -169,10 +166,9 @@ func (h *DefinitionHandler) Update(c *gin.Context) {
 // @Success 200 {object} response.Response
 // @Router /workflow/definitions/{id} [delete]
 func (h *DefinitionHandler) Delete(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程定义ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程定义ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -196,10 +192,9 @@ func (h *DefinitionHandler) Delete(c *gin.Context) {
 // @Success 200 {object} response.Response{data=dto.VersionResponse}
 // @Router /workflow/definitions/{id}/publish [post]
 func (h *DefinitionHandler) Publish(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程定义ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程定义ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -209,7 +204,11 @@ func (h *DefinitionHandler) Publish(c *gin.Context) {
 		return
 	}
 
-	userID := uuid.MustParse(auth.GetUserID(c))
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	version, err := h.defService.Publish(c.Request.Context(), id, &req, userID)
 	if err != nil {
@@ -230,10 +229,9 @@ func (h *DefinitionHandler) Publish(c *gin.Context) {
 // @Success 200 {object} response.Response{data=[]dto.VersionResponse}
 // @Router /workflow/definitions/{id}/versions [get]
 func (h *DefinitionHandler) ListVersions(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程定义ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程定义ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -253,7 +251,7 @@ func (h *DefinitionHandler) ListVersions(c *gin.Context) {
 
 // GetVersionByID 获取指定版本详情
 // @Summary 获取指定版本详情
-// @Description 根据版本ID获取流程定义版本详情
+// @Description 根据版本ID获取流程定义版本详情，并校验版本归属
 // @Tags 流程定义
 // @Produce json
 // @Security Bearer
@@ -262,16 +260,27 @@ func (h *DefinitionHandler) ListVersions(c *gin.Context) {
 // @Success 200 {object} response.Response{data=dto.VersionResponse}
 // @Router /workflow/definitions/{id}/versions/{versionId} [get]
 func (h *DefinitionHandler) GetVersionByID(c *gin.Context) {
-	versionIDStr := c.Param("versionId")
-	versionID, err := uuid.Parse(versionIDStr)
+	defID, err := parseUUIDParam(c, "id", "无效的流程定义ID")
 	if err != nil {
-		response.BadRequest(c, "无效的版本ID")
+		response.BadRequest(c, err.Error())
+		return
+	}
+
+	versionID, err := parseUUIDParam(c, "versionId", "无效的版本ID")
+	if err != nil {
+		response.BadRequest(c, err.Error())
 		return
 	}
 
 	version, err := h.defService.GetVersionByID(c.Request.Context(), versionID)
 	if err != nil {
 		response.Error(c, err)
+		return
+	}
+
+	// 校验版本归属关系
+	if version.DefinitionID != defID {
+		response.BadRequest(c, "版本不属于该流程定义")
 		return
 	}
 

--- a/backend/internal/workflow/handler/helper.go
+++ b/backend/internal/workflow/handler/helper.go
@@ -2,9 +2,14 @@ package handler
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
 )
 
 // parseBindingError 解析参数绑定错误，返回具体的字段错误信息。
@@ -22,4 +27,42 @@ func parseBindingError(err error) string {
 		return strings.Join(msgs, "; ")
 	}
 	return "参数错误"
+}
+
+// getUserID 从 gin context 中获取当前用户 ID 并解析为 UUID。
+// 如果用户未认证或 ID 无效，返回错误。
+func getUserID(c *gin.Context) (uuid.UUID, error) {
+	userIDStr := auth.GetUserID(c)
+	if userIDStr == "" {
+		return uuid.Nil, response.NewAppError(response.CodeUnauthorized, "用户未认证")
+	}
+	id, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return uuid.Nil, response.NewAppError(response.CodeBadRequest, "无效的用户ID")
+	}
+	return id, nil
+}
+
+// parsePagination 从 query 参数中解析分页参数。
+// page 默认 1，pageSize 默认 10，最小值为 1。
+func parsePagination(c *gin.Context) (int, int) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+	return page, pageSize
+}
+
+// parseUUIDParam 从路径参数中解析 UUID。
+func parseUUIDParam(c *gin.Context, name string, errMsg string) (uuid.UUID, error) {
+	idStr := c.Param(name)
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return uuid.Nil, response.NewAppError(response.CodeBadRequest, errMsg)
+	}
+	return id, nil
 }

--- a/backend/internal/workflow/handler/helper.go
+++ b/backend/internal/workflow/handler/helper.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// parseBindingError 解析参数绑定错误，返回具体的字段错误信息。
+// 对于 validator 验证错误，提取字段名和失败的 tag；
+// 对于其他类型错误，返回通用的"参数错误"。
+func parseBindingError(err error) string {
+	var ve validator.ValidationErrors
+	if errors.As(err, &ve) {
+		var msgs []string
+		for _, fe := range ve {
+			field := fe.Field()
+			tag := fe.Tag()
+			msgs = append(msgs, field+": "+tag+" 验证失败")
+		}
+		return strings.Join(msgs, "; ")
+	}
+	return "参数错误"
+}

--- a/backend/internal/workflow/handler/instance_handler.go
+++ b/backend/internal/workflow/handler/instance_handler.go
@@ -1,0 +1,257 @@
+package handler
+
+import (
+	"strconv"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// InstanceHandler 流程实例处理器
+type InstanceHandler struct {
+	instService service.InstanceService
+}
+
+// NewInstanceHandler 创建流程实例处理器
+func NewInstanceHandler(instService service.InstanceService) *InstanceHandler {
+	return &InstanceHandler{instService: instService}
+}
+
+// Start 启动流程实例
+// @Summary 启动流程实例
+// @Description 根据流程定义启动新的流程实例
+// @Tags 流程实例
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param request body dto.StartInstanceRequest true "启动参数"
+// @Success 200 {object} response.Response{data=dto.InstanceResponse}
+// @Router /workflow/instances [post]
+func (h *InstanceHandler) Start(c *gin.Context) {
+	var req dto.StartInstanceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	initiatorID := uuid.MustParse(auth.GetUserID(c))
+
+	inst, err := h.instService.Start(c.Request.Context(), req.DefinitionID, req.BusinessKey, req.BusinessType, initiatorID, req.Variables)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToInstanceResponse(inst))
+}
+
+// List 流程实例列表
+// @Summary 获取流程实例列表
+// @Description 分页查询流程实例列表
+// @Tags 流程实例
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param page query int false "页码" default(1)
+// @Param page_size query int false "每页数量" default(10)
+// @Param status query int false "状态"
+// @Param definition_id query string false "流程定义ID"
+// @Param initiator_id query string false "发起人ID"
+// @Success 200 {object} response.Response{data=response.PageResponse{list=[]dto.InstanceResponse}}
+// @Router /workflow/instances [get]
+func (h *InstanceHandler) List(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	var status *int
+	if statusStr := c.Query("status"); statusStr != "" {
+		if s, err := strconv.Atoi(statusStr); err == nil {
+			status = &s
+		}
+	}
+
+	var definitionID *uuid.UUID
+	if defIDStr := c.Query("definition_id"); defIDStr != "" {
+		if id, err := uuid.Parse(defIDStr); err == nil {
+			definitionID = &id
+		}
+	}
+
+	var initiatorID *uuid.UUID
+	if initIDStr := c.Query("initiator_id"); initIDStr != "" {
+		if id, err := uuid.Parse(initIDStr); err == nil {
+			initiatorID = &id
+		}
+	}
+
+	list, total, err := h.instService.List(c.Request.Context(), page, pageSize, status, definitionID, initiatorID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	result := make([]dto.InstanceResponse, 0, len(list))
+	for _, inst := range list {
+		result = append(result, dto.ToInstanceResponse(&inst))
+	}
+
+	response.Page(c, result, total, page, pageSize)
+}
+
+// GetByID 获取流程实例详情
+// @Summary 获取流程实例详情
+// @Description 根据ID获取流程实例详细信息
+// @Tags 流程实例
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程实例ID"
+// @Success 200 {object} response.Response{data=dto.InstanceResponse}
+// @Router /workflow/instances/{id} [get]
+func (h *InstanceHandler) GetByID(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程实例ID")
+		return
+	}
+
+	inst, err := h.instService.GetByID(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToInstanceResponse(inst))
+}
+
+// Terminate 终止流程实例
+// @Summary 终止流程实例
+// @Description 强制终止正在运行的流程实例
+// @Tags 流程实例
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程实例ID"
+// @Param request body dto.TerminateInstanceRequest true "终止原因"
+// @Success 200 {object} response.Response
+// @Router /workflow/instances/{id}/terminate [post]
+func (h *InstanceHandler) Terminate(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程实例ID")
+		return
+	}
+
+	var req dto.TerminateInstanceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	operatorID := uuid.MustParse(auth.GetUserID(c))
+
+	if err := h.instService.Terminate(c.Request.Context(), id, operatorID, req.Reason); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Suspend 挂起流程实例
+// @Summary 挂起流程实例
+// @Description 挂起正在运行的流程实例
+// @Tags 流程实例
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程实例ID"
+// @Success 200 {object} response.Response
+// @Router /workflow/instances/{id}/suspend [post]
+func (h *InstanceHandler) Suspend(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程实例ID")
+		return
+	}
+
+	operatorID := uuid.MustParse(auth.GetUserID(c))
+
+	if err := h.instService.Suspend(c.Request.Context(), id, operatorID, "手动挂起"); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Resume 恢复流程实例
+// @Summary 恢复流程实例
+// @Description 恢复已挂起的流程实例
+// @Tags 流程实例
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程实例ID"
+// @Success 200 {object} response.Response
+// @Router /workflow/instances/{id}/resume [post]
+func (h *InstanceHandler) Resume(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程实例ID")
+		return
+	}
+
+	operatorID := uuid.MustParse(auth.GetUserID(c))
+
+	if err := h.instService.Resume(c.Request.Context(), id, operatorID); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// ListHistory 获取流程历史记录
+// @Summary 获取流程历史记录
+// @Description 获取指定流程实例的历史操作记录
+// @Tags 流程实例
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程实例ID"
+// @Success 200 {object} response.Response{data=[]dto.HistoryResponse}
+// @Router /workflow/instances/{id}/history [get]
+func (h *InstanceHandler) ListHistory(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的流程实例ID")
+		return
+	}
+
+	histories, err := h.instService.ListHistory(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	result := make([]dto.HistoryResponse, 0, len(histories))
+	for _, h := range histories {
+		result = append(result, dto.ToHistoryResponse(&h))
+	}
+
+	response.OK(c, result)
+}

--- a/backend/internal/workflow/handler/instance_handler.go
+++ b/backend/internal/workflow/handler/instance_handler.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
-	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -38,7 +37,11 @@ func (h *InstanceHandler) Start(c *gin.Context) {
 		return
 	}
 
-	initiatorID := uuid.MustParse(auth.GetUserID(c))
+	initiatorID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	inst, err := h.instService.Start(c.Request.Context(), req.DefinitionID, req.BusinessKey, req.BusinessType, initiatorID, req.Variables)
 	if err != nil {
@@ -64,14 +67,7 @@ func (h *InstanceHandler) Start(c *gin.Context) {
 // @Success 200 {object} response.Response{data=response.PageResponse{list=[]dto.InstanceResponse}}
 // @Router /workflow/instances [get]
 func (h *InstanceHandler) List(c *gin.Context) {
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
-	if page <= 0 {
-		page = 1
-	}
-	if pageSize <= 0 {
-		pageSize = 10
-	}
+	page, pageSize := parsePagination(c)
 
 	var status *int
 	if statusStr := c.Query("status"); statusStr != "" {
@@ -118,10 +114,9 @@ func (h *InstanceHandler) List(c *gin.Context) {
 // @Success 200 {object} response.Response{data=dto.InstanceResponse}
 // @Router /workflow/instances/{id} [get]
 func (h *InstanceHandler) GetByID(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程实例ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程实例ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -146,10 +141,9 @@ func (h *InstanceHandler) GetByID(c *gin.Context) {
 // @Success 200 {object} response.Response
 // @Router /workflow/instances/{id}/terminate [post]
 func (h *InstanceHandler) Terminate(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程实例ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程实例ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -159,7 +153,11 @@ func (h *InstanceHandler) Terminate(c *gin.Context) {
 		return
 	}
 
-	operatorID := uuid.MustParse(auth.GetUserID(c))
+	operatorID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	if err := h.instService.Terminate(c.Request.Context(), id, operatorID, req.Reason); err != nil {
 		response.Error(c, err)
@@ -177,19 +175,29 @@ func (h *InstanceHandler) Terminate(c *gin.Context) {
 // @Produce json
 // @Security Bearer
 // @Param id path string true "流程实例ID"
+// @Param request body dto.SuspendInstanceRequest true "挂起原因"
 // @Success 200 {object} response.Response
 // @Router /workflow/instances/{id}/suspend [post]
 func (h *InstanceHandler) Suspend(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程实例ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程实例ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
-	operatorID := uuid.MustParse(auth.GetUserID(c))
+	var req dto.SuspendInstanceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
 
-	if err := h.instService.Suspend(c.Request.Context(), id, operatorID, "手动挂起"); err != nil {
+	operatorID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	if err := h.instService.Suspend(c.Request.Context(), id, operatorID, req.Reason); err != nil {
 		response.Error(c, err)
 		return
 	}
@@ -208,14 +216,17 @@ func (h *InstanceHandler) Suspend(c *gin.Context) {
 // @Success 200 {object} response.Response
 // @Router /workflow/instances/{id}/resume [post]
 func (h *InstanceHandler) Resume(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程实例ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程实例ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
-	operatorID := uuid.MustParse(auth.GetUserID(c))
+	operatorID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	if err := h.instService.Resume(c.Request.Context(), id, operatorID); err != nil {
 		response.Error(c, err)
@@ -235,10 +246,9 @@ func (h *InstanceHandler) Resume(c *gin.Context) {
 // @Success 200 {object} response.Response{data=[]dto.HistoryResponse}
 // @Router /workflow/instances/{id}/history [get]
 func (h *InstanceHandler) ListHistory(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的流程实例ID")
 	if err != nil {
-		response.BadRequest(c, "无效的流程实例ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -249,8 +259,8 @@ func (h *InstanceHandler) ListHistory(c *gin.Context) {
 	}
 
 	result := make([]dto.HistoryResponse, 0, len(histories))
-	for _, h := range histories {
-		result = append(result, dto.ToHistoryResponse(&h))
+	for _, hist := range histories {
+		result = append(result, dto.ToHistoryResponse(&hist))
 	}
 
 	response.OK(c, result)

--- a/backend/internal/workflow/handler/routes.go
+++ b/backend/internal/workflow/handler/routes.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes 注册工作流引擎路由。
+//
+// 路由前缀: /workflow
+//
+// 流程定义管理:
+//
+//	GET    /definitions              流程定义列表
+//	POST   /definitions              创建流程定义
+//	GET    /definitions/:id          流程定义详情
+//	PUT    /definitions/:id          更新流程定义
+//	DELETE /definitions/:id          删除流程定义
+//	POST   /definitions/:id/publish  发布流程定义
+//	GET    /definitions/:id/versions 版本列表
+//	GET    /definitions/:id/versions/:versionId 版本详情
+//
+// 流程实例管理:
+//
+//	POST   /instances                启动流程实例
+//	GET    /instances                流程实例列表
+//	GET    /instances/:id            流程实例详情
+//	POST   /instances/:id/terminate  终止流程
+//	POST   /instances/:id/suspend    挂起流程
+//	POST   /instances/:id/resume     恢复流程
+//	GET    /instances/:id/history    流程历史记录
+//
+// 流程任务管理:
+//
+//	GET    /tasks/todo               我的待办任务
+//	GET    /tasks/done               我的已办任务
+//	GET    /tasks/:id                任务详情
+//	POST   /tasks/:id/approve        审批通过
+//	POST   /tasks/:id/reject         审批驳回
+//	POST   /tasks/:id/transfer       转办任务
+//	POST   /tasks/:id/rollback       退回任务
+func RegisterRoutes(
+	r *gin.RouterGroup,
+	defHandler *DefinitionHandler,
+	instHandler *InstanceHandler,
+	taskHandler *TaskHandler,
+) {
+	wf := r.Group("/workflow")
+	{
+		// ========== 流程定义 ==========
+		defs := wf.Group("/definitions")
+		{
+			defs.GET("", defHandler.List)
+			defs.POST("", defHandler.Create)
+			defs.GET("/:id", defHandler.GetByID)
+			defs.PUT("/:id", defHandler.Update)
+			defs.DELETE("/:id", defHandler.Delete)
+			defs.POST("/:id/publish", defHandler.Publish)
+			defs.GET("/:id/versions", defHandler.ListVersions)
+			defs.GET("/:id/versions/:versionId", defHandler.GetVersionByID)
+		}
+
+		// ========== 流程实例 ==========
+		instances := wf.Group("/instances")
+		{
+			instances.POST("", instHandler.Start)
+			instances.GET("", instHandler.List)
+			instances.GET("/:id", instHandler.GetByID)
+			instances.POST("/:id/terminate", instHandler.Terminate)
+			instances.POST("/:id/suspend", instHandler.Suspend)
+			instances.POST("/:id/resume", instHandler.Resume)
+			instances.GET("/:id/history", instHandler.ListHistory)
+		}
+
+		// ========== 流程任务 ==========
+		tasks := wf.Group("/tasks")
+		{
+			tasks.GET("/todo", taskHandler.ListTodoTasks)
+			tasks.GET("/done", taskHandler.ListDoneTasks)
+			tasks.GET("/:id", taskHandler.GetByID)
+			tasks.POST("/:id/approve", taskHandler.Approve)
+			tasks.POST("/:id/reject", taskHandler.Reject)
+			tasks.POST("/:id/transfer", taskHandler.Transfer)
+			tasks.POST("/:id/rollback", taskHandler.Rollback)
+		}
+	}
+}

--- a/backend/internal/workflow/handler/task_handler.go
+++ b/backend/internal/workflow/handler/task_handler.go
@@ -1,14 +1,10 @@
 package handler
 
 import (
-	"strconv"
-
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
-	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // TaskHandler 流程任务处理器
@@ -33,16 +29,13 @@ func NewTaskHandler(taskService service.TaskService) *TaskHandler {
 // @Success 200 {object} response.Response{data=response.PageResponse{list=[]dto.TaskResponse}}
 // @Router /workflow/tasks/todo [get]
 func (h *TaskHandler) ListTodoTasks(c *gin.Context) {
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
-	if page <= 0 {
-		page = 1
-	}
-	if pageSize <= 0 {
-		pageSize = 10
-	}
+	page, pageSize := parsePagination(c)
 
-	userID := uuid.MustParse(auth.GetUserID(c))
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	tasks, total, err := h.taskService.ListTodoTasks(c.Request.Context(), userID, page, pageSize)
 	if err != nil {
@@ -70,16 +63,13 @@ func (h *TaskHandler) ListTodoTasks(c *gin.Context) {
 // @Success 200 {object} response.Response{data=response.PageResponse{list=[]dto.TaskResponse}}
 // @Router /workflow/tasks/done [get]
 func (h *TaskHandler) ListDoneTasks(c *gin.Context) {
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
-	if page <= 0 {
-		page = 1
-	}
-	if pageSize <= 0 {
-		pageSize = 10
-	}
+	page, pageSize := parsePagination(c)
 
-	userID := uuid.MustParse(auth.GetUserID(c))
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	tasks, total, err := h.taskService.ListDoneTasks(c.Request.Context(), userID, page, pageSize)
 	if err != nil {
@@ -105,10 +95,9 @@ func (h *TaskHandler) ListDoneTasks(c *gin.Context) {
 // @Success 200 {object} response.Response{data=dto.TaskResponse}
 // @Router /workflow/tasks/{id} [get]
 func (h *TaskHandler) GetByID(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的任务ID")
 	if err != nil {
-		response.BadRequest(c, "无效的任务ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -133,10 +122,9 @@ func (h *TaskHandler) GetByID(c *gin.Context) {
 // @Success 200 {object} response.Response
 // @Router /workflow/tasks/{id}/approve [post]
 func (h *TaskHandler) Approve(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的任务ID")
 	if err != nil {
-		response.BadRequest(c, "无效的任务ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -146,7 +134,11 @@ func (h *TaskHandler) Approve(c *gin.Context) {
 		return
 	}
 
-	userID := uuid.MustParse(auth.GetUserID(c))
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	if err := h.taskService.CompleteTask(c.Request.Context(), id, userID, "approve", req.Comment, req.Variables); err != nil {
 		response.Error(c, err)
@@ -168,10 +160,9 @@ func (h *TaskHandler) Approve(c *gin.Context) {
 // @Success 200 {object} response.Response
 // @Router /workflow/tasks/{id}/reject [post]
 func (h *TaskHandler) Reject(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的任务ID")
 	if err != nil {
-		response.BadRequest(c, "无效的任务ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -181,7 +172,11 @@ func (h *TaskHandler) Reject(c *gin.Context) {
 		return
 	}
 
-	userID := uuid.MustParse(auth.GetUserID(c))
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	if err := h.taskService.CompleteTask(c.Request.Context(), id, userID, "reject", req.Comment, req.Variables); err != nil {
 		response.Error(c, err)
@@ -203,10 +198,9 @@ func (h *TaskHandler) Reject(c *gin.Context) {
 // @Success 200 {object} response.Response
 // @Router /workflow/tasks/{id}/transfer [post]
 func (h *TaskHandler) Transfer(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的任务ID")
 	if err != nil {
-		response.BadRequest(c, "无效的任务ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -216,7 +210,11 @@ func (h *TaskHandler) Transfer(c *gin.Context) {
 		return
 	}
 
-	fromUserID := uuid.MustParse(auth.GetUserID(c))
+	fromUserID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	if err := h.taskService.TransferTask(c.Request.Context(), id, fromUserID, req.TargetUserID, req.Comment); err != nil {
 		response.Error(c, err)
@@ -238,10 +236,9 @@ func (h *TaskHandler) Transfer(c *gin.Context) {
 // @Success 200 {object} response.Response
 // @Router /workflow/tasks/{id}/rollback [post]
 func (h *TaskHandler) Rollback(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parseUUIDParam(c, "id", "无效的任务ID")
 	if err != nil {
-		response.BadRequest(c, "无效的任务ID")
+		response.BadRequest(c, err.Error())
 		return
 	}
 
@@ -251,7 +248,11 @@ func (h *TaskHandler) Rollback(c *gin.Context) {
 		return
 	}
 
-	userID := uuid.MustParse(auth.GetUserID(c))
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 
 	if err := h.taskService.RollbackTask(c.Request.Context(), id, userID, req.TargetNodeID, req.Comment); err != nil {
 		response.Error(c, err)

--- a/backend/internal/workflow/handler/task_handler.go
+++ b/backend/internal/workflow/handler/task_handler.go
@@ -1,0 +1,262 @@
+package handler
+
+import (
+	"strconv"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// TaskHandler 流程任务处理器
+type TaskHandler struct {
+	taskService service.TaskService
+}
+
+// NewTaskHandler 创建流程任务处理器
+func NewTaskHandler(taskService service.TaskService) *TaskHandler {
+	return &TaskHandler{taskService: taskService}
+}
+
+// ListTodoTasks 获取我的待办任务
+// @Summary 获取我的待办任务
+// @Description 分页查询当前用户的待办任务列表
+// @Tags 流程任务
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param page query int false "页码" default(1)
+// @Param page_size query int false "每页数量" default(10)
+// @Success 200 {object} response.Response{data=response.PageResponse{list=[]dto.TaskResponse}}
+// @Router /workflow/tasks/todo [get]
+func (h *TaskHandler) ListTodoTasks(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	userID := uuid.MustParse(auth.GetUserID(c))
+
+	tasks, total, err := h.taskService.ListTodoTasks(c.Request.Context(), userID, page, pageSize)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	result := make([]dto.TaskResponse, 0, len(tasks))
+	for _, task := range tasks {
+		result = append(result, dto.ToTaskResponse(&task))
+	}
+
+	response.Page(c, result, total, page, pageSize)
+}
+
+// ListDoneTasks 获取我的已办任务
+// @Summary 获取我的已办任务
+// @Description 分页查询当前用户的已办任务列表
+// @Tags 流程任务
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param page query int false "页码" default(1)
+// @Param page_size query int false "每页数量" default(10)
+// @Success 200 {object} response.Response{data=response.PageResponse{list=[]dto.TaskResponse}}
+// @Router /workflow/tasks/done [get]
+func (h *TaskHandler) ListDoneTasks(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "10"))
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	userID := uuid.MustParse(auth.GetUserID(c))
+
+	tasks, total, err := h.taskService.ListDoneTasks(c.Request.Context(), userID, page, pageSize)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	result := make([]dto.TaskResponse, 0, len(tasks))
+	for _, task := range tasks {
+		result = append(result, dto.ToTaskResponse(&task))
+	}
+
+	response.Page(c, result, total, page, pageSize)
+}
+
+// GetByID 获取任务详情
+// @Summary 获取任务详情
+// @Description 根据ID获取任务详细信息
+// @Tags 流程任务
+// @Produce json
+// @Security Bearer
+// @Param id path string true "任务ID"
+// @Success 200 {object} response.Response{data=dto.TaskResponse}
+// @Router /workflow/tasks/{id} [get]
+func (h *TaskHandler) GetByID(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的任务ID")
+		return
+	}
+
+	task, err := h.taskService.GetTaskByID(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToTaskResponse(task))
+}
+
+// Approve 审批通过
+// @Summary 审批通过
+// @Description 审批通过指定任务
+// @Tags 流程任务
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "任务ID"
+// @Param request body dto.CompleteTaskRequest true "审批信息"
+// @Success 200 {object} response.Response
+// @Router /workflow/tasks/{id}/approve [post]
+func (h *TaskHandler) Approve(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的任务ID")
+		return
+	}
+
+	var req dto.CompleteTaskRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	userID := uuid.MustParse(auth.GetUserID(c))
+
+	if err := h.taskService.CompleteTask(c.Request.Context(), id, userID, "approve", req.Comment, req.Variables); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Reject 审批驳回
+// @Summary 审批驳回
+// @Description 驳回指定任务
+// @Tags 流程任务
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "任务ID"
+// @Param request body dto.CompleteTaskRequest true "驳回信息"
+// @Success 200 {object} response.Response
+// @Router /workflow/tasks/{id}/reject [post]
+func (h *TaskHandler) Reject(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的任务ID")
+		return
+	}
+
+	var req dto.CompleteTaskRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	userID := uuid.MustParse(auth.GetUserID(c))
+
+	if err := h.taskService.CompleteTask(c.Request.Context(), id, userID, "reject", req.Comment, req.Variables); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Transfer 转办任务
+// @Summary 转办任务
+// @Description 将任务转交给其他用户处理
+// @Tags 流程任务
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "任务ID"
+// @Param request body dto.TransferTaskRequest true "转办信息"
+// @Success 200 {object} response.Response
+// @Router /workflow/tasks/{id}/transfer [post]
+func (h *TaskHandler) Transfer(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的任务ID")
+		return
+	}
+
+	var req dto.TransferTaskRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	fromUserID := uuid.MustParse(auth.GetUserID(c))
+
+	if err := h.taskService.TransferTask(c.Request.Context(), id, fromUserID, req.TargetUserID, req.Comment); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Rollback 退回任务
+// @Summary 退回任务
+// @Description 将任务退回到指定节点
+// @Tags 流程任务
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "任务ID"
+// @Param request body dto.RollbackTaskRequest true "退回信息"
+// @Success 200 {object} response.Response
+// @Router /workflow/tasks/{id}/rollback [post]
+func (h *TaskHandler) Rollback(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的任务ID")
+		return
+	}
+
+	var req dto.RollbackTaskRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	userID := uuid.MustParse(auth.GetUserID(c))
+
+	if err := h.taskService.RollbackTask(c.Request.Context(), id, userID, req.TargetNodeID, req.Comment); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}

--- a/backend/internal/workflow/service/definition_service.go
+++ b/backend/internal/workflow/service/definition_service.go
@@ -13,19 +13,19 @@ import (
 	"gorm.io/gorm"
 )
 
-// DefinitionService handles flow definition business logic.
-type DefinitionService struct {
+// definitionServiceImpl handles flow definition business logic.
+type definitionServiceImpl struct {
 	defRepo repo.DefinitionRepo
 	db      *gorm.DB
 }
 
 // NewDefinitionService creates a DefinitionService.
-func NewDefinitionService(defRepo repo.DefinitionRepo, db *gorm.DB) *DefinitionService {
-	return &DefinitionService{defRepo: defRepo, db: db}
+func NewDefinitionService(defRepo repo.DefinitionRepo, db *gorm.DB) DefinitionService {
+	return &definitionServiceImpl{defRepo: defRepo, db: db}
 }
 
 // Create creates a new flow definition (draft status).
-func (s *DefinitionService) Create(ctx context.Context, req *dto.CreateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
+func (s *definitionServiceImpl) Create(ctx context.Context, req *dto.CreateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
 	// Check for duplicate key.
 	existing, err := s.defRepo.GetByKey(ctx, req.Key)
 	if err != nil {
@@ -65,7 +65,7 @@ func (s *DefinitionService) Create(ctx context.Context, req *dto.CreateDefinitio
 }
 
 // GetByID retrieves a flow definition by ID.
-func (s *DefinitionService) GetByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinition, error) {
+func (s *definitionServiceImpl) GetByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinition, error) {
 	def, err := s.defRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, response.NewAppErrorf(response.CodeInternalError,
@@ -79,7 +79,7 @@ func (s *DefinitionService) GetByID(ctx context.Context, id uuid.UUID) (*model.F
 }
 
 // Update updates a flow definition (only in draft status).
-func (s *DefinitionService) Update(ctx context.Context, id uuid.UUID, req *dto.UpdateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
+func (s *definitionServiceImpl) Update(ctx context.Context, id uuid.UUID, req *dto.UpdateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
 	def, err := s.defRepo.GetByID(ctx, id)
 	if err != nil || def == nil {
 		return nil, response.NewAppError(response.CodeWorkflowNotFound,
@@ -104,7 +104,7 @@ func (s *DefinitionService) Update(ctx context.Context, id uuid.UUID, req *dto.U
 }
 
 // Delete deletes a flow definition (only in draft status).
-func (s *DefinitionService) Delete(ctx context.Context, id uuid.UUID) error {
+func (s *definitionServiceImpl) Delete(ctx context.Context, id uuid.UUID) error {
 	def, err := s.defRepo.GetByID(ctx, id)
 	if err != nil || def == nil {
 		return response.NewAppError(response.CodeWorkflowNotFound,
@@ -124,7 +124,7 @@ func (s *DefinitionService) Delete(ctx context.Context, id uuid.UUID) error {
 }
 
 // List returns a paginated list of flow definitions.
-func (s *DefinitionService) List(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.FlowDefinition, int64, error) {
+func (s *definitionServiceImpl) List(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.FlowDefinition, int64, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -142,7 +142,7 @@ func (s *DefinitionService) List(ctx context.Context, page, pageSize int, keywor
 }
 
 // Publish publishes a new version of a flow definition.
-func (s *DefinitionService) Publish(ctx context.Context, id uuid.UUID, req *dto.PublishDefinitionRequest, userID uuid.UUID) (*model.FlowDefinitionVersion, error) {
+func (s *definitionServiceImpl) Publish(ctx context.Context, id uuid.UUID, req *dto.PublishDefinitionRequest, userID uuid.UUID) (*model.FlowDefinitionVersion, error) {
 	def, err := s.defRepo.GetByID(ctx, id)
 	if err != nil || def == nil {
 		return nil, response.NewAppError(response.CodeWorkflowNotFound,
@@ -210,7 +210,7 @@ func (s *DefinitionService) Publish(ctx context.Context, id uuid.UUID, req *dto.
 }
 
 // ListVersions returns all versions of a definition.
-func (s *DefinitionService) ListVersions(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error) {
+func (s *definitionServiceImpl) ListVersions(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error) {
 	versions, err := s.defRepo.ListVersions(ctx, definitionID)
 	if err != nil {
 		return nil, response.NewAppErrorf(response.CodeInternalError,
@@ -220,7 +220,7 @@ func (s *DefinitionService) ListVersions(ctx context.Context, definitionID uuid.
 }
 
 // GetVersionByID retrieves a specific version.
-func (s *DefinitionService) GetVersionByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error) {
+func (s *definitionServiceImpl) GetVersionByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error) {
 	ver, err := s.defRepo.GetVersionByID(ctx, id)
 	if err != nil {
 		return nil, response.NewAppErrorf(response.CodeInternalError,

--- a/backend/internal/workflow/service/instance_service.go
+++ b/backend/internal/workflow/service/instance_service.go
@@ -11,8 +11,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// InstanceService handles flow instance business logic.
-type InstanceService struct {
+// instanceServiceImpl handles flow instance business logic.
+type instanceServiceImpl struct {
 	instRepo   repo.InstanceRepo
 	defRepo    repo.DefinitionRepo
 	taskRepo   repo.TaskRepo
@@ -21,8 +21,8 @@ type InstanceService struct {
 }
 
 // NewInstanceService creates an InstanceService.
-func NewInstanceService(instRepo repo.InstanceRepo, defRepo repo.DefinitionRepo, taskRepo repo.TaskRepo, flowEngine *engine.FlowEngine, db *gorm.DB) *InstanceService {
-	return &InstanceService{
+func NewInstanceService(instRepo repo.InstanceRepo, defRepo repo.DefinitionRepo, taskRepo repo.TaskRepo, flowEngine *engine.FlowEngine, db *gorm.DB) InstanceService {
+	return &instanceServiceImpl{
 		instRepo:   instRepo,
 		defRepo:    defRepo,
 		taskRepo:   taskRepo,
@@ -32,7 +32,7 @@ func NewInstanceService(instRepo repo.InstanceRepo, defRepo repo.DefinitionRepo,
 }
 
 // Start creates and starts a new flow instance.
-func (s *InstanceService) Start(ctx context.Context, defID uuid.UUID, businessKey, businessType string, initiatorID uuid.UUID, variables map[string]interface{}) (*model.FlowInstance, error) {
+func (s *instanceServiceImpl) Start(ctx context.Context, defID uuid.UUID, businessKey, businessType string, initiatorID uuid.UUID, variables map[string]interface{}) (*model.FlowInstance, error) {
 	// Find the definition to get the key.
 	def, err := s.defRepo.GetByID(ctx, defID)
 	if err != nil || def == nil {
@@ -54,7 +54,7 @@ func (s *InstanceService) Start(ctx context.Context, defID uuid.UUID, businessKe
 }
 
 // GetByID retrieves a flow instance by ID.
-func (s *InstanceService) GetByID(ctx context.Context, id uuid.UUID) (*model.FlowInstance, error) {
+func (s *instanceServiceImpl) GetByID(ctx context.Context, id uuid.UUID) (*model.FlowInstance, error) {
 	inst, err := s.instRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, response.NewAppErrorf(response.CodeInternalError,
@@ -68,7 +68,7 @@ func (s *InstanceService) GetByID(ctx context.Context, id uuid.UUID) (*model.Flo
 }
 
 // List returns a paginated list of flow instances.
-func (s *InstanceService) List(ctx context.Context, page, pageSize int, status *int, definitionID, initiatorID *uuid.UUID) ([]model.FlowInstance, int64, error) {
+func (s *instanceServiceImpl) List(ctx context.Context, page, pageSize int, status *int, definitionID, initiatorID *uuid.UUID) ([]model.FlowInstance, int64, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -86,22 +86,22 @@ func (s *InstanceService) List(ctx context.Context, page, pageSize int, status *
 }
 
 // Terminate terminates a flow instance.
-func (s *InstanceService) Terminate(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error {
+func (s *instanceServiceImpl) Terminate(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error {
 	return s.flowEngine.Terminate(ctx, instanceID, operatorID, reason)
 }
 
 // Suspend suspends a running flow instance.
-func (s *InstanceService) Suspend(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error {
+func (s *instanceServiceImpl) Suspend(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error {
 	return s.flowEngine.Suspend(ctx, instanceID, operatorID, reason)
 }
 
 // Resume resumes a suspended flow instance.
-func (s *InstanceService) Resume(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID) error {
+func (s *instanceServiceImpl) Resume(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID) error {
 	return s.flowEngine.Resume(ctx, instanceID, operatorID)
 }
 
 // ListHistory returns the history for a flow instance.
-func (s *InstanceService) ListHistory(ctx context.Context, instanceID uuid.UUID) ([]model.FlowHistory, error) {
+func (s *instanceServiceImpl) ListHistory(ctx context.Context, instanceID uuid.UUID) ([]model.FlowHistory, error) {
 	histories, err := s.taskRepo.ListHistory(ctx, instanceID)
 	if err != nil {
 		return nil, response.NewAppErrorf(response.CodeInternalError,

--- a/backend/internal/workflow/service/interfaces.go
+++ b/backend/internal/workflow/service/interfaces.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/google/uuid"
+)
+
+// DefinitionService 流程定义服务接口
+type DefinitionService interface {
+	Create(ctx context.Context, req *dto.CreateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinition, error)
+	Update(ctx context.Context, id uuid.UUID, req *dto.UpdateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	List(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.FlowDefinition, int64, error)
+	Publish(ctx context.Context, id uuid.UUID, req *dto.PublishDefinitionRequest, userID uuid.UUID) (*model.FlowDefinitionVersion, error)
+	ListVersions(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error)
+	GetVersionByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error)
+}
+
+// InstanceService 流程实例服务接口
+type InstanceService interface {
+	Start(ctx context.Context, defID uuid.UUID, businessKey, businessType string, initiatorID uuid.UUID, variables map[string]interface{}) (*model.FlowInstance, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*model.FlowInstance, error)
+	List(ctx context.Context, page, pageSize int, status *int, definitionID, initiatorID *uuid.UUID) ([]model.FlowInstance, int64, error)
+	Terminate(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error
+	Suspend(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error
+	Resume(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID) error
+	ListHistory(ctx context.Context, instanceID uuid.UUID) ([]model.FlowHistory, error)
+}
+
+// TaskService 流程任务服务接口
+type TaskService interface {
+	ListTodoTasks(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error)
+	ListDoneTasks(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error)
+	GetTaskByID(ctx context.Context, id uuid.UUID) (*model.FlowTask, error)
+	CompleteTask(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, action string, comment string, formData map[string]interface{}) error
+	TransferTask(ctx context.Context, taskID uuid.UUID, fromUserID uuid.UUID, toUserID uuid.UUID, comment string) error
+	RollbackTask(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, targetNodeID string, comment string) error
+}

--- a/backend/internal/workflow/service/task_service.go
+++ b/backend/internal/workflow/service/task_service.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// TaskService handles flow task business logic.
-type TaskService struct {
+// taskServiceImpl handles flow task business logic.
+type taskServiceImpl struct {
 	taskRepo   repo.TaskRepo
 	instRepo   repo.InstanceRepo
 	flowEngine *engine.FlowEngine
@@ -21,8 +21,8 @@ type TaskService struct {
 }
 
 // NewTaskService creates a TaskService.
-func NewTaskService(taskRepo repo.TaskRepo, instRepo repo.InstanceRepo, flowEngine *engine.FlowEngine, db *gorm.DB) *TaskService {
-	return &TaskService{
+func NewTaskService(taskRepo repo.TaskRepo, instRepo repo.InstanceRepo, flowEngine *engine.FlowEngine, db *gorm.DB) TaskService {
+	return &taskServiceImpl{
 		taskRepo:   taskRepo,
 		instRepo:   instRepo,
 		flowEngine: flowEngine,
@@ -31,7 +31,7 @@ func NewTaskService(taskRepo repo.TaskRepo, instRepo repo.InstanceRepo, flowEngi
 }
 
 // ListTodoTasks returns pending tasks for a user.
-func (s *TaskService) ListTodoTasks(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error) {
+func (s *taskServiceImpl) ListTodoTasks(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -48,7 +48,7 @@ func (s *TaskService) ListTodoTasks(ctx context.Context, userID uuid.UUID, page,
 }
 
 // ListDoneTasks returns completed tasks for a user.
-func (s *TaskService) ListDoneTasks(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error) {
+func (s *taskServiceImpl) ListDoneTasks(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -65,7 +65,7 @@ func (s *TaskService) ListDoneTasks(ctx context.Context, userID uuid.UUID, page,
 }
 
 // GetTaskByID retrieves a task by ID.
-func (s *TaskService) GetTaskByID(ctx context.Context, id uuid.UUID) (*model.FlowTask, error) {
+func (s *taskServiceImpl) GetTaskByID(ctx context.Context, id uuid.UUID) (*model.FlowTask, error) {
 	task, err := s.taskRepo.GetTaskByID(ctx, id)
 	if err != nil {
 		return nil, response.NewAppErrorf(response.CodeInternalError,
@@ -79,7 +79,7 @@ func (s *TaskService) GetTaskByID(ctx context.Context, id uuid.UUID) (*model.Flo
 }
 
 // CompleteTask completes a flow task with the given action.
-func (s *TaskService) CompleteTask(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, action string, comment string, formData map[string]interface{}) error {
+func (s *taskServiceImpl) CompleteTask(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, action string, comment string, formData map[string]interface{}) error {
 	taskAction := engine.TaskAction(action)
 	if taskAction != engine.ActionApprove &&
 		taskAction != engine.ActionReject &&
@@ -93,7 +93,7 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID uuid.UUID, userID
 }
 
 // TransferTask transfers a task to another user.
-func (s *TaskService) TransferTask(ctx context.Context, taskID uuid.UUID, fromUserID uuid.UUID, toUserID uuid.UUID, comment string) error {
+func (s *taskServiceImpl) TransferTask(ctx context.Context, taskID uuid.UUID, fromUserID uuid.UUID, toUserID uuid.UUID, comment string) error {
 	task, err := s.taskRepo.GetTaskByID(ctx, taskID)
 	if err != nil || task == nil {
 		return response.NewAppError(response.CodeWorkflowTaskNotFnd,
@@ -143,7 +143,7 @@ func (s *TaskService) TransferTask(ctx context.Context, taskID uuid.UUID, fromUs
 }
 
 // RollbackTask rolls back a task to a previous node.
-func (s *TaskService) RollbackTask(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, targetNodeID string, comment string) error {
+func (s *taskServiceImpl) RollbackTask(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, targetNodeID string, comment string) error {
 	task, err := s.taskRepo.GetTaskByID(ctx, taskID)
 	if err != nil || task == nil {
 		return response.NewAppError(response.CodeWorkflowTaskNotFnd,


### PR DESCRIPTION
## PR3 of Issue #2: 工作流引擎核心模块 - Handler 层 + API 路由

### 变更摘要

实现工作流引擎的 Handler 层和路由注册，共 **24 个 API 端点**，遵循四层架构（handler → service → repo → model）。

### 新增文件

| 文件 | 说明 |
|------|------|
| `handler/definition_handler.go` | 流程定义处理器：CRUD + 发布 + 版本管理（8个端点） |
| `handler/instance_handler.go` | 流程实例处理器：启动 + 查询 + 终止/挂起/恢复 + 历史（8个端点） |
| `handler/task_handler.go` | 流程任务处理器：待办/已办 + 详情 + 审批/驳回/转办/退回（8个端点） |
| `handler/routes.go` | 路由注册，挂载到 `/workflow` 前缀 |
| `handler/helper.go` | 参数绑定错误解析辅助函数 |
| `dto/workflow_dto.go` | 新增 5 个 DTO 转换函数 |

### API 端点清单

**流程定义管理** (8个):
- `GET /workflow/definitions` - 分页查询列表
- `POST /workflow/definitions` - 创建（草稿）
- `GET /workflow/definitions/:id` - 详情
- `PUT /workflow/definitions/:id` - 更新
- `DELETE /workflow/definitions/:id` - 删除
- `POST /workflow/definitions/:id/publish` - 发布
- `GET /workflow/definitions/:id/versions` - 版本列表
- `GET /workflow/definitions/:id/versions/:versionId` - 版本详情

**流程实例管理** (8个):
- `POST /workflow/instances` - 启动实例
- `GET /workflow/instances` - 分页查询
- `GET /workflow/instances/:id` - 详情
- `POST /workflow/instances/:id/terminate` - 终止
- `POST /workflow/instances/:id/suspend` - 挂起
- `POST /workflow/instances/:id/resume` - 恢复
- `GET /workflow/instances/:id/history` - 历史记录

**流程任务管理** (8个):
- `GET /workflow/tasks/todo` - 我的待办
- `GET /workflow/tasks/done` - 我的已办
- `GET /workflow/tasks/:id` - 任务详情
- `POST /workflow/tasks/:id/approve` - 审批通过
- `POST /workflow/tasks/:id/reject` - 审批驳回
- `POST /workflow/tasks/:id/transfer` - 转办
- `POST /workflow/tasks/:id/rollback` - 退回

### 设计遵循

- 遵循 TEAM_DEV_GUIDE.md 四层架构规范
- 与 RBAC 模块 handler 模式保持一致
- 使用 pkg/response 统一响应格式
- 使用 pkg/middleware/auth 获取当前用户
- 完整的 Swagger 文档注释

### 验证

- ✅ 编译通过
- ✅ gofmt 通过
- ✅ 所有单元测试通过（68个）

### Issue 关联

Closes part of #2

### PR 拆分

- PR1: Model + Repo + DTO + 错误码 ✅ (#38)
- PR2: Engine 核心 + 节点处理器 + Service 层 ✅ (#39)
- PR3: Handler 层 + 路由注册 👈 (本PR)
- PR4: main.go 集成 + 依赖注入