### PR TITLE
feat(workflow): PR4 - main.go 集成 + 依赖注入 [Issue #2]

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -15,8 +15,11 @@ import (
 	"github.com/Yogdunana/StarByte/backend/internal/user/handler"
 	"github.com/Yogdunana/StarByte/backend/internal/user/repo"
 	"github.com/Yogdunana/StarByte/backend/internal/user/service"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow"
+	wfHandler "github.com/Yogdunana/StarByte/backend/internal/workflow/handler"
 	"github.com/Yogdunana/StarByte/backend/pkg/config"
 	"github.com/Yogdunana/StarByte/backend/pkg/database"
+	"github.com/Yogdunana/StarByte/backend/pkg/events"
 	"github.com/Yogdunana/StarByte/backend/pkg/logger"
 	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
 	authmiddleware "github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
@@ -106,6 +109,10 @@ func main() {
 	deptHandler := rbacHandler.NewDepartmentHandler(deptService)
 	posHandler := rbacHandler.NewPositionHandler(posService)
 
+	// 工作流引擎模块
+	eventBus := events.NewEventBus()
+	wfHandlers := workflow.Init(database.DB(), eventBus, logger.GetLogger())
+
 	// 10. API 路由组
 	api := r.Group("/api/v1")
 	// API 组限流：全局 1000 req/s
@@ -152,6 +159,9 @@ func main() {
 		// RBAC 系统管理模块
 		// 权限校验和数据权限中间件在 RegisterRoutes 内部按正确顺序注册
 		rbacHandler.RegisterRoutes(protected, database.DB(), roleHandler, permHandler, deptHandler, posHandler, cacheService, deptRepo)
+
+		// 工作流引擎模块
+		wfHandler.RegisterRoutes(protected, wfHandlers.Definition, wfHandlers.Instance, wfHandlers.Task)
 	}
 
 	// 11. 404 处理

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -61,6 +61,11 @@ func main() {
 		logger.Fatal("auto migrate audit_logs failed", zap.Error(err))
 	}
 
+	// 3b. 自动迁移工作流引擎表
+	if err := workflow.AutoMigrate(database.DB()); err != nil {
+		logger.Fatal("auto migrate workflow tables failed", zap.Error(err))
+	}
+
 	// 4. 初始化 Redis
 	if err := redis.Init(&cfg.Redis); err != nil {
 		logger.Fatal("init redis failed", zap.Error(err))

--- a/backend/internal/workflow/migrate.go
+++ b/backend/internal/workflow/migrate.go
@@ -1,0 +1,19 @@
+package workflow
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"gorm.io/gorm"
+)
+
+// AutoMigrate 自动迁移工作流引擎相关的数据库表。
+// 应在服务启动时调用，确保所有工作流模型表已创建。
+func AutoMigrate(db *gorm.DB) error {
+	return db.AutoMigrate(
+		&model.FlowDefinition{},
+		&model.FlowDefinitionVersion{},
+		&model.FlowInstance{},
+		&model.FlowTask{},
+		&model.FlowHistory{},
+		&model.FlowVariable{},
+	)
+}

--- a/backend/internal/workflow/wire.go
+++ b/backend/internal/workflow/wire.go
@@ -1,0 +1,78 @@
+package workflow
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine/nodes"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/handler"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/repo"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/events"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// Handlers 封装所有 workflow handler，便于在 main.go 中注册路由。
+type Handlers struct {
+	Definition *handler.DefinitionHandler
+	Instance   *handler.InstanceHandler
+	Task       *handler.TaskHandler
+}
+
+// Init 初始化工作流引擎的所有依赖（repo → engine → service → handler）。
+//
+// 依赖关系:
+//   Repo 层 ← 数据库
+//   Engine 层 ← Repo + EventBus + NodeRegistry + ExpressionEngine
+//   Service 层 ← Repo + Engine
+//   Handler 层 ← Service
+//
+// 返回所有 handler 的集合，调用方通过 RegisterRoutes 注册路由。
+func Init(db *gorm.DB, eventBus *events.EventBus, logger *zap.Logger) *Handlers {
+	// 1. Repo 层
+	defRepo := repo.NewDefinitionRepo(db)
+	instRepo := repo.NewInstanceRepo(db)
+	taskRepo := repo.NewTaskRepo(db)
+	varRepo := repo.NewVariableRepo(db)
+
+	// 2. 表达式引擎
+	exprEngine := engine.NewExpressionEngine()
+
+	// 3. 节点注册表 + 内置节点处理器
+	registry := nodes.NewNodeRegistry()
+	registry.Register(&nodes.StartNode{})
+	registry.Register(&nodes.EndNode{})
+	registry.Register(&nodes.ApprovalNode{TaskRepo: taskRepo, EventBus: eventBus})
+	registry.Register(&nodes.ExclusiveGatewayNode{ExprEngine: exprEngine})
+	registry.Register(&nodes.ParallelGatewayNode{})
+	registry.Register(&nodes.ServiceTaskNode{Callbacks: make(map[string]nodes.ServiceCallback)})
+	registry.Register(&nodes.NotificationTaskNode{EventBus: eventBus})
+
+	// 4. 流程引擎核心
+	flowEngine := engine.NewFlowEngine(
+		defRepo,
+		instRepo,
+		taskRepo,
+		varRepo,
+		db,
+		registry,
+		exprEngine,
+		eventBus,
+		logger,
+	)
+
+	// 5. Service 层
+	defService := service.NewDefinitionService(defRepo, db)
+	instService := service.NewInstanceService(instRepo, defRepo, taskRepo, flowEngine, db)
+	taskService := service.NewTaskService(taskRepo, instRepo, flowEngine, db)
+
+	// 6. Handler 层
+	defHandler := handler.NewDefinitionHandler(defService)
+	instHandler := handler.NewInstanceHandler(instService)
+	taskHandler := handler.NewTaskHandler(taskService)
+
+	return &Handlers{
+		Definition: defHandler,
+		Instance:   instHandler,
+		Task:       taskHandler,
+	}
+}

--- a/backend/internal/workflow/wire.go
+++ b/backend/internal/workflow/wire.go
@@ -1,9 +1,12 @@
 package workflow
 
 import (
+	"context"
+
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine/nodes"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/handler"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/repo"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
 	"github.com/Yogdunana/StarByte/backend/pkg/events"
@@ -11,11 +14,19 @@ import (
 	"gorm.io/gorm"
 )
 
-// Handlers 封装所有 workflow handler，便于在 main.go 中注册路由。
+// Handlers 封装所有 workflow handler 和扩展能力，便于在 main.go 中使用。
 type Handlers struct {
-	Definition *handler.DefinitionHandler
-	Instance   *handler.InstanceHandler
-	Task       *handler.TaskHandler
+	Definition      *handler.DefinitionHandler
+	Instance        *handler.InstanceHandler
+	Task            *handler.TaskHandler
+	serviceTaskNode *nodes.ServiceTaskNode
+}
+
+// RegisterServiceCallback 注册一个服务任务回调函数，供 service_task 节点调用。
+// 业务模块可以通过此方法将自定义业务逻辑接入工作流引擎。
+// 线程安全。
+func (h *Handlers) RegisterServiceCallback(name string, cb func(ctx context.Context, inst *model.FlowInstance, node *engine.FlowNode, vars map[string]interface{}) (map[string]interface{}, error)) {
+	h.serviceTaskNode.RegisterService(name, nodes.ServiceCallback(cb))
 }
 
 // Init 初始化工作流引擎的所有依赖（repo → engine → service → handler）。
@@ -44,7 +55,10 @@ func Init(db *gorm.DB, eventBus *events.EventBus, logger *zap.Logger) *Handlers 
 	registry.Register(&nodes.ApprovalNode{TaskRepo: taskRepo, EventBus: eventBus})
 	registry.Register(&nodes.ExclusiveGatewayNode{ExprEngine: exprEngine})
 	registry.Register(&nodes.ParallelGatewayNode{})
-	registry.Register(&nodes.ServiceTaskNode{Callbacks: make(map[string]nodes.ServiceCallback)})
+
+	serviceTaskNode := &nodes.ServiceTaskNode{Callbacks: make(map[string]nodes.ServiceCallback)}
+	registry.Register(serviceTaskNode)
+
 	registry.Register(&nodes.NotificationTaskNode{EventBus: eventBus})
 
 	// 4. 流程引擎核心
@@ -71,8 +85,9 @@ func Init(db *gorm.DB, eventBus *events.EventBus, logger *zap.Logger) *Handlers 
 	taskHandler := handler.NewTaskHandler(taskService)
 
 	return &Handlers{
-		Definition: defHandler,
-		Instance:   instHandler,
-		Task:       taskHandler,
+		Definition:      defHandler,
+		Instance:        instHandler,
+		Task:            taskHandler,
+		serviceTaskNode: serviceTaskNode,
 	}
 }

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	log *zap.Logger
-	mu  sync.Mutex
+	mu  sync.RWMutex
 )
 
 func init() {
@@ -75,7 +75,10 @@ func Sync() {
 
 // GetLogger returns the underlying *zap.Logger instance.
 // Useful for components that need direct access to the zap logger.
+// Safe for concurrent use.
 func GetLogger() *zap.Logger {
+	mu.RLock()
+	defer mu.RUnlock()
 	return log
 }
 

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -73,6 +73,12 @@ func Sync() {
 	}
 }
 
+// GetLogger returns the underlying *zap.Logger instance.
+// Useful for components that need direct access to the zap logger.
+func GetLogger() *zap.Logger {
+	return log
+}
+
 // Info logs a message at the info level.
 func Info(msg string, fields ...zap.Field) {
 	log.Info(msg, fields...)


### PR DESCRIPTION
## 概述

工作流引擎 PR4 - 主程序集成与依赖注入模块。

本 PR 将工作流引擎模块完整集成到 `main.go` 中，并提供集中式的依赖注入入口。

## 变更内容

### 新增文件
- `backend/internal/workflow/wire.go` - 集中式依赖注入模块
  - `Handlers` 结构体封装所有 workflow handler
  - `Init()` 函数按 repo → engine → service → handler 层级初始化所有组件
  - 注册所有内置节点处理器（Start、End、Approval、ExclusiveGateway、ParallelGateway、ServiceTask、NotificationTask）

### 修改文件
- `backend/cmd/server/main.go`
  - 导入 workflow 模块
  - 初始化 EventBus 和 workflow handlers
  - 在受保护的路由组中注册工作流 API 路由

- `backend/pkg/logger/logger.go`
  - 新增 `GetLogger()` 方法，暴露底层 `*zap.Logger` 实例
  - 供工作流引擎等需要直接访问 zap logger 的组件使用

## 依赖关系

```
Repo 层 ← 数据库
Engine 层 ← Repo + EventBus + NodeRegistry + ExpressionEngine
Service 层 ← Repo + Engine
Handler 层 ← Service
```

## Issue 关联

Issue #2 - 工作流引擎核心模块

这是工作流引擎系列 PR 的第 4 个（共 4 个）：
- PR1: 模型层 + Repo 层 ✅
- PR2: 引擎核心 + 节点处理器 + Service 层 ✅
- PR3: Handler 层 + API 路由 ✅
- PR4: main.go 集成 + 依赖注入（本 PR）