### PR TITLE
test(workflow): PR5 - 补充 Handler 层 + ApprovalNode Execute + E2E 流程测试 [Issue #2]

### DIFF
--- a/backend/internal/workflow/engine/nodes/approval_execute_test.go
+++ b/backend/internal/workflow/engine/nodes/approval_execute_test.go
@@ -1,0 +1,210 @@
+package nodes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/events"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- ApprovalNode Execute Tests ---
+// (Validate is already covered; these test Execute and OnEnter flows)
+
+func TestApprovalNode_Type(t *testing.T) {
+	n := ApprovalNode{}
+	assert.Equal(t, "approval", n.Type())
+}
+
+func TestApprovalNode_Execute_NextNodes(t *testing.T) {
+	n := ApprovalNode{}
+	graph := &engine.FlowGraph{
+		Nodes: map[string]*engine.FlowNode{
+			"approval": {ID: "approval", Type: "approval"},
+			"end":      {ID: "end", Type: "end"},
+		},
+		Edges: []*engine.FlowEdge{
+			{ID: "e1", Source: "approval", Target: "end"},
+		},
+	}
+
+	next, err := n.Execute(context.Background(), &model.FlowInstance{}, graph.GetNode("approval"), graph, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"end"}, next)
+}
+
+func TestApprovalNode_Execute_NoOutgoing(t *testing.T) {
+	n := ApprovalNode{}
+	graph := &engine.FlowGraph{
+		Nodes: map[string]*engine.FlowNode{
+			"approval": {ID: "approval", Type: "approval"},
+		},
+		Edges: []*engine.FlowEdge{},
+	}
+
+	next, err := n.Execute(context.Background(), &model.FlowInstance{}, graph.GetNode("approval"), graph, nil)
+	require.NoError(t, err)
+	assert.Empty(t, next)
+}
+
+func TestApprovalNode_OnEnter_StaticAssignees(t *testing.T) {
+	bus := events.NewEventBus()
+	taskRepo := &mockTaskRepo{}
+
+	n := &ApprovalNode{TaskRepo: taskRepo, EventBus: bus}
+
+	assigneeID := uuid.New()
+	inst := &model.FlowInstance{ID: uuid.New(), InitiatorID: uuid.New()}
+	config := map[string]interface{}{
+		"assigneeStrategy": "static",
+		"assignees":        []interface{}{assigneeID.String()},
+	}
+	node := &engine.FlowNode{ID: "approval", Type: "approval", Config: config, Label: "Manager Approval"}
+
+	err := n.OnEnter(context.Background(), inst, node, map[string]interface{}{})
+	require.NoError(t, err)
+
+	// Verify task was created.
+	require.NotNil(t, taskRepo.createdTask)
+	assert.Equal(t, inst.ID, taskRepo.createdTask.InstanceID)
+	assert.Equal(t, "approval", taskRepo.createdTask.NodeID)
+	assert.Equal(t, "Manager Approval", taskRepo.createdTask.NodeName)
+	assert.Equal(t, "approval", taskRepo.createdTask.TaskType)
+	require.NotNil(t, taskRepo.createdTask.AssigneeID)
+	assert.Equal(t, assigneeID, *taskRepo.createdTask.AssigneeID)
+	assert.Equal(t, 0, taskRepo.createdTask.Status) // pending
+}
+
+func TestApprovalNode_OnEnter_InitiatorStrategy(t *testing.T) {
+	bus := events.NewEventBus()
+	taskRepo := &mockTaskRepo{}
+
+	n := &ApprovalNode{TaskRepo: taskRepo, EventBus: bus}
+
+	initiatorID := uuid.New()
+	inst := &model.FlowInstance{ID: uuid.New(), InitiatorID: initiatorID}
+	config := map[string]interface{}{
+		"assigneeStrategy": "initiator",
+	}
+	node := &engine.FlowNode{ID: "approval", Type: "approval", Config: config}
+
+	err := n.OnEnter(context.Background(), inst, node, map[string]interface{}{})
+	require.NoError(t, err)
+
+	require.NotNil(t, taskRepo.createdTask)
+	assert.Equal(t, initiatorID, *taskRepo.createdTask.AssigneeID)
+}
+
+func TestApprovalNode_OnEnter_WithDueDate(t *testing.T) {
+	bus := events.NewEventBus()
+	taskRepo := &mockTaskRepo{}
+
+	n := &ApprovalNode{TaskRepo: taskRepo, EventBus: bus}
+
+	inst := &model.FlowInstance{ID: uuid.New(), InitiatorID: uuid.New()}
+	assigneeID := uuid.New()
+	config := map[string]interface{}{
+		"assigneeStrategy": "static",
+		"assignees":        []interface{}{assigneeID.String()},
+		"dueDays":          float64(3),
+	}
+	node := &engine.FlowNode{ID: "approval", Type: "approval", Config: config}
+
+	err := n.OnEnter(context.Background(), inst, node, map[string]interface{}{})
+	require.NoError(t, err)
+
+	require.NotNil(t, taskRepo.createdTask)
+	require.NotNil(t, taskRepo.createdTask.DueDate)
+}
+
+func TestApprovalNode_OnEnter_PublishesTaskCreatedEvent(t *testing.T) {
+	bus := events.NewEventBus()
+	taskRepo := &mockTaskRepo{}
+
+	var receivedEvent events.TaskCreatedEvent
+	bus.Subscribe("task.created", func(ctx context.Context, e events.Event) error {
+		te, ok := e.(events.TaskCreatedEvent)
+		if ok {
+			receivedEvent = te
+		}
+		return nil
+	})
+
+	n := &ApprovalNode{TaskRepo: taskRepo, EventBus: bus}
+
+	assigneeID := uuid.New()
+	inst := &model.FlowInstance{ID: uuid.New(), InitiatorID: uuid.New()}
+	config := map[string]interface{}{
+		"assigneeStrategy": "static",
+		"assignees":        []interface{}{assigneeID.String()},
+	}
+	node := &engine.FlowNode{ID: "approval", Type: "approval", Config: config, Label: "Manager Approval"}
+
+	err := n.OnEnter(context.Background(), inst, node, map[string]interface{}{})
+	require.NoError(t, err)
+
+	assert.Equal(t, inst.ID, receivedEvent.InstanceID)
+	assert.Equal(t, assigneeID, receivedEvent.AssigneeID)
+	assert.Equal(t, "approval", receivedEvent.NodeID)
+	assert.Equal(t, "Manager Approval", receivedEvent.NodeName)
+	assert.Equal(t, "approval", receivedEvent.TaskType)
+}
+
+func TestApprovalNode_OnEnter_NoAssignees(t *testing.T) {
+	bus := events.NewEventBus()
+	taskRepo := &mockTaskRepo{}
+
+	n := &ApprovalNode{TaskRepo: taskRepo, EventBus: bus}
+
+	inst := &model.FlowInstance{ID: uuid.New(), InitiatorID: uuid.New()}
+	config := map[string]interface{}{
+		"assigneeStrategy": "static",
+		"assignees":        []interface{}{}, // empty
+	}
+	node := &engine.FlowNode{ID: "approval", Type: "approval", Config: config}
+
+	err := n.OnEnter(context.Background(), inst, node, map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "没有处理人")
+}
+
+func TestApprovalNode_OnLeave(t *testing.T) {
+	n := ApprovalNode{}
+	err := n.OnLeave(context.Background(), &model.FlowInstance{}, &engine.FlowNode{}, nil)
+	require.NoError(t, err)
+}
+
+func TestApprovalNode_Validate_MissingConfig(t *testing.T) {
+	n := ApprovalNode{}
+	node := &engine.FlowNode{ID: "approval", Type: "approval", Config: nil}
+	err := n.Validate(node)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "缺少配置")
+}
+
+func TestApprovalNode_Validate_StaticMissingAssignees(t *testing.T) {
+	n := ApprovalNode{}
+	config := map[string]interface{}{
+		"assigneeStrategy": "static",
+		"assignees":        []interface{}{}, // empty
+	}
+	node := &engine.FlowNode{ID: "approval", Type: "approval", Config: config}
+	err := n.Validate(node)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assignees")
+}
+
+func TestApprovalNode_Validate_InvalidStrategy(t *testing.T) {
+	n := ApprovalNode{}
+	config := map[string]interface{}{
+		"assigneeStrategy": "nonexistent_strategy",
+	}
+	node := &engine.FlowNode{ID: "approval", Type: "approval", Config: config}
+	err := n.Validate(node)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "不支持的处理人策略")
+}

--- a/backend/internal/workflow/engine/nodes/e2e_test.go
+++ b/backend/internal/workflow/engine/nodes/e2e_test.go
@@ -1,0 +1,334 @@
+package nodes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/events"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEndToEnd_ApprovalFlow simulates a complete approval workflow:
+//
+//   start → approval → end
+//
+// It verifies:
+// 1. StartNode moves to the approval node
+// 2. ApprovalNode.OnEnter creates a task and publishes an event
+// 3. ApprovalNode.Execute (after task completion) moves to end
+// 4. EndNode.Execute terminates the flow
+
+func TestEndToEnd_ApprovalFlow(t *testing.T) {
+	// --- Setup ---
+	bus := events.NewEventBus()
+	taskRepo := &mockTaskRepo{}
+	registry := NewNodeRegistry()
+
+	// Register all nodes.
+	startNode := &StartNode{}
+	endNode := &EndNode{}
+	approvalNode := &ApprovalNode{TaskRepo: taskRepo, EventBus: bus}
+	registry.Register(startNode)
+	registry.Register(endNode)
+	registry.Register(approvalNode)
+
+	// Build the graph: start → approval → end
+	assigneeID := uuid.New()
+	graph := &engine.FlowGraph{
+		Nodes: map[string]*engine.FlowNode{
+			"start":    {ID: "start", Type: "start", Label: "Start"},
+			"approval": {ID: "approval", Type: "approval", Label: "Manager Approval", Config: map[string]interface{}{
+				"assigneeStrategy": "static",
+				"assignees":        []interface{}{assigneeID.String()},
+			}},
+			"end": {ID: "end", Type: "end", Label: "End"},
+		},
+		Edges: []*engine.FlowEdge{
+			{ID: "e1", Source: "start", Target: "approval"},
+			{ID: "e2", Source: "approval", Target: "end"},
+		},
+	}
+
+	// Track events.
+	var taskCreatedEvents []events.TaskCreatedEvent
+	bus.Subscribe("task.created", func(ctx context.Context, e events.Event) error {
+		if te, ok := e.(events.TaskCreatedEvent); ok {
+			taskCreatedEvents = append(taskCreatedEvents, te)
+		}
+		return nil
+	})
+
+	inst := &model.FlowInstance{
+		ID:         uuid.New(),
+		InitiatorID: uuid.New(),
+		Status:     0, // running
+	}
+	vars := map[string]interface{}{}
+
+	// --- Step 1: StartNode Execute → should go to approval ---
+	startHandler, err := registry.Get("start")
+	require.NoError(t, err)
+
+	next, err := startHandler.Execute(context.Background(), inst, graph.GetNode("start"), graph, vars)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"approval"}, next)
+
+	// --- Step 2: ApprovalNode OnEnter → creates task ---
+	approvalHandler, err := registry.Get("approval")
+	require.NoError(t, err)
+
+	err = approvalHandler.OnEnter(context.Background(), inst, graph.GetNode("approval"), vars)
+	require.NoError(t, err)
+
+	// Verify task was created.
+	require.NotNil(t, taskRepo.createdTask)
+	assert.Equal(t, inst.ID, taskRepo.createdTask.InstanceID)
+	assert.Equal(t, "approval", taskRepo.createdTask.NodeID)
+	assert.Equal(t, "Manager Approval", taskRepo.createdTask.NodeName)
+	assert.Equal(t, "approval", taskRepo.createdTask.TaskType)
+	require.NotNil(t, taskRepo.createdTask.AssigneeID)
+	assert.Equal(t, assigneeID, *taskRepo.createdTask.AssigneeID)
+	assert.Equal(t, 0, taskRepo.createdTask.Status) // pending
+
+	// Verify event was published.
+	require.Len(t, taskCreatedEvents, 1)
+	assert.Equal(t, assigneeID, taskCreatedEvents[0].AssigneeID)
+	assert.Equal(t, "Manager Approval", taskCreatedEvents[0].NodeName)
+
+	// --- Step 3: ApprovalNode Execute (task completed) → should go to end ---
+	next, err = approvalHandler.Execute(context.Background(), inst, graph.GetNode("approval"), graph, vars)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"end"}, next)
+
+	// --- Step 4: EndNode Execute → flow ends ---
+	endHandler, err := registry.Get("end")
+	require.NoError(t, err)
+
+	next, err = endHandler.Execute(context.Background(), inst, graph.GetNode("end"), graph, vars)
+	require.NoError(t, err)
+	assert.Empty(t, next) // end node has no outgoing
+}
+
+// TestEndToEnd_ExclusiveGatewayFlow simulates a branching workflow:
+//
+//   start → exclusive_gateway → (amount > 10000 → high_approval → end)
+//                              (amount <= 10000 → low_approval → end)
+
+func TestEndToEnd_ExclusiveGatewayFlow(t *testing.T) {
+	bus := events.NewEventBus()
+	taskRepo := &mockTaskRepo{}
+	registry := NewNodeRegistry()
+
+	exprEngine := engine.NewExpressionEngine()
+	registry.Register(&StartNode{})
+	registry.Register(&EndNode{})
+	registry.Register(&ApprovalNode{TaskRepo: taskRepo, EventBus: bus})
+	registry.Register(&ExclusiveGatewayNode{ExprEngine: exprEngine})
+
+	// Build the graph.
+	graph := &engine.FlowGraph{
+		Nodes: map[string]*engine.FlowNode{
+			"start":    {ID: "start", Type: "start"},
+			"gw":       {ID: "gw", Type: "exclusive_gateway", Config: map[string]interface{}{
+				"branches": []interface{}{
+					map[string]interface{}{"id": "high", "expression": "amount > 10000"},
+					map[string]interface{}{"id": "low", "expression": "amount <= 10000"},
+				},
+			}},
+			"high_approval": {ID: "high_approval", Type: "approval", Config: map[string]interface{}{
+				"assigneeStrategy": "initiator",
+			}, Label: "High Value Approval"},
+			"low_approval": {ID: "low_approval", Type: "approval", Config: map[string]interface{}{
+				"assigneeStrategy": "initiator",
+			}, Label: "Low Value Approval"},
+			"end": {ID: "end", Type: "end"},
+		},
+		Edges: []*engine.FlowEdge{
+			{ID: "e1", Source: "start", Target: "gw"},
+			{ID: "e2", Source: "gw", Target: "high_approval", SourceHandle: "high"},
+			{ID: "e3", Source: "gw", Target: "low_approval", SourceHandle: "low"},
+			{ID: "e4", Source: "high_approval", Target: "end"},
+			{ID: "e5", Source: "low_approval", Target: "end"},
+		},
+	}
+
+	inst := &model.FlowInstance{
+		ID:          uuid.New(),
+		InitiatorID: uuid.New(),
+		Status:      0,
+	}
+
+	// --- High amount path ---
+	vars := map[string]interface{}{"amount": 15000}
+
+	startHandler, err := registry.Get("start")
+	require.NoError(t, err)
+	next, err := startHandler.Execute(context.Background(), inst, graph.GetNode("start"), graph, vars)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gw"}, next)
+
+	// Gateway should route to high_approval.
+	gwHandler, err := registry.Get("exclusive_gateway")
+	require.NoError(t, err)
+	next, err = gwHandler.Execute(context.Background(), inst, graph.GetNode("gw"), graph, vars)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"high_approval"}, next)
+
+	// High approval OnEnter should create a task.
+	approvalHandler, err := registry.Get("approval")
+	require.NoError(t, err)
+	err = approvalHandler.OnEnter(context.Background(), inst, graph.GetNode("high_approval"), vars)
+	require.NoError(t, err)
+	require.NotNil(t, taskRepo.createdTask)
+	assert.Equal(t, inst.InitiatorID, *taskRepo.createdTask.AssigneeID)
+
+	// High approval Execute should go to end.
+	next, err = approvalHandler.Execute(context.Background(), inst, graph.GetNode("high_approval"), graph, vars)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"end"}, next)
+
+	// End node.
+	endHandler, err := registry.Get("end")
+	require.NoError(t, err)
+	next, err = endHandler.Execute(context.Background(), inst, graph.GetNode("end"), graph, vars)
+	require.NoError(t, err)
+	assert.Empty(t, next)
+}
+
+// TestEndToEnd_LowAmountPath tests the low-amount branch of the exclusive gateway.
+
+func TestEndToEnd_LowAmountPath(t *testing.T) {
+	bus := events.NewEventBus()
+	taskRepo := &mockTaskRepo{}
+	registry := NewNodeRegistry()
+
+	exprEngine := engine.NewExpressionEngine()
+	registry.Register(&StartNode{})
+	registry.Register(&EndNode{})
+	registry.Register(&ExclusiveGatewayNode{ExprEngine: exprEngine})
+
+	graph := &engine.FlowGraph{
+		Nodes: map[string]*engine.FlowNode{
+			"gw":  {ID: "gw", Type: "exclusive_gateway", Config: map[string]interface{}{
+				"branches": []interface{}{
+					map[string]interface{}{"id": "high", "expression": "amount > 10000"},
+					map[string]interface{}{"id": "low", "expression": "amount <= 10000"},
+				},
+			}},
+			"high_end": {ID: "high_end", Type: "end"},
+			"low_end":  {ID: "low_end", Type: "end"},
+		},
+		Edges: []*engine.FlowEdge{
+			{ID: "e1", Source: "gw", Target: "high_end", SourceHandle: "high"},
+			{ID: "e2", Source: "gw", Target: "low_end", SourceHandle: "low"},
+		},
+	}
+
+	inst := &model.FlowInstance{ID: uuid.New(), InitiatorID: uuid.New()}
+	vars := map[string]interface{}{"amount": 5000}
+
+	gwHandler, err := registry.Get("exclusive_gateway")
+	require.NoError(t, err)
+	next, err := gwHandler.Execute(context.Background(), inst, graph.GetNode("gw"), graph, vars)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"low_end"}, next)
+}
+
+// TestEndToEnd_ParallelGatewayFlow simulates a parallel split:
+//
+//   start → parallel_gateway → [branch_a → end, branch_b → end]
+
+func TestEndToEnd_ParallelGatewayFlow(t *testing.T) {
+	registry := NewNodeRegistry()
+	registry.Register(&StartNode{})
+	registry.Register(&EndNode{})
+	registry.Register(&ParallelGatewayNode{})
+
+	graph := &engine.FlowGraph{
+		Nodes: map[string]*engine.FlowNode{
+			"start": {ID: "start", Type: "start"},
+			"gw":    {ID: "gw", Type: "parallel_gateway"},
+			"a":     {ID: "a", Type: "end"},
+			"b":     {ID: "b", Type: "end"},
+		},
+		Edges: []*engine.FlowEdge{
+			{ID: "e1", Source: "start", Target: "gw"},
+			{ID: "e2", Source: "gw", Target: "a"},
+			{ID: "e3", Source: "gw", Target: "b"},
+		},
+	}
+
+	inst := &model.FlowInstance{ID: uuid.New(), InitiatorID: uuid.New()}
+
+	// Start → gw.
+	startHandler, err := registry.Get("start")
+	require.NoError(t, err)
+	next, err := startHandler.Execute(context.Background(), inst, graph.GetNode("start"), graph, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gw"}, next)
+
+	// gw → both branches.
+	gwHandler, err := registry.Get("parallel_gateway")
+	require.NoError(t, err)
+	next, err = gwHandler.Execute(context.Background(), inst, graph.GetNode("gw"), graph, nil)
+	require.NoError(t, err)
+	assert.Len(t, next, 2)
+	assert.Contains(t, next, "a")
+	assert.Contains(t, next, "b")
+}
+
+// TestEndToEnd_ServiceTaskFlow simulates:
+//
+//   start → service_task → end
+
+func TestEndToEnd_ServiceTaskFlow(t *testing.T) {
+	registry := NewNodeRegistry()
+
+	executed := false
+	serviceNode := &ServiceTaskNode{
+		Callbacks: map[string]ServiceCallback{
+			"sendEmail": func(ctx context.Context, inst *model.FlowInstance, node *engine.FlowNode, vars map[string]interface{}) (map[string]interface{}, error) {
+				executed = true
+				return map[string]interface{}{"sent": true}, nil
+			},
+		},
+	}
+	registry.Register(&StartNode{})
+	registry.Register(&EndNode{})
+	registry.Register(serviceNode)
+
+	graph := &engine.FlowGraph{
+		Nodes: map[string]*engine.FlowNode{
+			"start": {ID: "start", Type: "start"},
+			"task":  {ID: "task", Type: "service_task", Config: map[string]interface{}{"service": "sendEmail"}},
+			"end":   {ID: "end", Type: "end"},
+		},
+		Edges: []*engine.FlowEdge{
+			{ID: "e1", Source: "start", Target: "task"},
+			{ID: "e2", Source: "task", Target: "end"},
+		},
+	}
+
+	inst := &model.FlowInstance{ID: uuid.New(), InitiatorID: uuid.New()}
+	vars := map[string]interface{}{}
+
+	// Start → task.
+	startHandler, err := registry.Get("start")
+	require.NoError(t, err)
+	next, err := startHandler.Execute(context.Background(), inst, graph.GetNode("start"), graph, vars)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"task"}, next)
+
+	// Task executes callback and → end.
+	svcHandler, err := registry.Get("service_task")
+	require.NoError(t, err)
+	next, err = svcHandler.Execute(context.Background(), inst, graph.GetNode("task"), graph, vars)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"end"}, next)
+	assert.True(t, executed)
+	assert.Equal(t, true, vars["sent"])
+}

--- a/backend/internal/workflow/handler/definition_handler_test.go
+++ b/backend/internal/workflow/handler/definition_handler_test.go
@@ -1,0 +1,408 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock DefinitionService ---
+
+type mockDefService struct {
+	createFunc      func(ctx context.Context, req *dto.CreateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error)
+	getByIDFunc     func(ctx context.Context, id uuid.UUID) (*model.FlowDefinition, error)
+	updateFunc      func(ctx context.Context, id uuid.UUID, req *dto.UpdateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error)
+	deleteFunc      func(ctx context.Context, id uuid.UUID) error
+	listFunc        func(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.FlowDefinition, int64, error)
+	publishFunc     func(ctx context.Context, id uuid.UUID, req *dto.PublishDefinitionRequest, userID uuid.UUID) (*model.FlowDefinitionVersion, error)
+	listVersionsFunc func(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error)
+	getVersionFunc  func(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error)
+}
+
+func (m *mockDefService) Create(ctx context.Context, req *dto.CreateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, req, userID)
+	}
+	return &model.FlowDefinition{ID: uuid.New(), Key: req.Key, Name: req.Name, Category: req.Category}, nil
+}
+
+func (m *mockDefService) GetByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinition, error) {
+	if m.getByIDFunc != nil {
+		return m.getByIDFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *mockDefService) Update(ctx context.Context, id uuid.UUID, req *dto.UpdateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, id, req, userID)
+	}
+	return &model.FlowDefinition{ID: id, Name: req.Name, Description: req.Description}, nil
+}
+
+func (m *mockDefService) Delete(ctx context.Context, id uuid.UUID) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockDefService) List(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.FlowDefinition, int64, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, page, pageSize, keyword, category, status)
+	}
+	return []model.FlowDefinition{}, 0, nil
+}
+
+func (m *mockDefService) Publish(ctx context.Context, id uuid.UUID, req *dto.PublishDefinitionRequest, userID uuid.UUID) (*model.FlowDefinitionVersion, error) {
+	if m.publishFunc != nil {
+		return m.publishFunc(ctx, id, req, userID)
+	}
+	return &model.FlowDefinitionVersion{ID: uuid.New(), DefinitionID: id, Version: 1}, nil
+}
+
+func (m *mockDefService) ListVersions(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error) {
+	if m.listVersionsFunc != nil {
+		return m.listVersionsFunc(ctx, definitionID)
+	}
+	return []model.FlowDefinitionVersion{}, nil
+}
+
+func (m *mockDefService) GetVersionByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error) {
+	if m.getVersionFunc != nil {
+		return m.getVersionFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+// Compile-time check.
+var _ service.DefinitionService = (*mockDefService)(nil)
+
+// --- Test Helpers ---
+
+func setupRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	return gin.New()
+}
+
+func setAuthUser(c *gin.Context, userID string) {
+	c.Set(auth.ContextKeyUserID, userID)
+}
+
+// --- DefinitionHandler Tests ---
+
+func TestDefinitionHandler_List(t *testing.T) {
+	svc := &mockDefService{
+		listFunc: func(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.FlowDefinition, int64, error) {
+			return []model.FlowDefinition{
+				{ID: uuid.New(), Key: "flow1", Name: "Flow 1"},
+				{ID: uuid.New(), Key: "flow2", Name: "Flow 2"},
+			}, 2, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.GET("/definitions", h.List)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/definitions?page=1&page_size=10", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 200, int(resp["code"].(float64)))
+}
+
+func TestDefinitionHandler_List_WithFilters(t *testing.T) {
+	var capturedKeyword, capturedCategory string
+	var capturedStatus *int
+
+	svc := &mockDefService{
+		listFunc: func(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.FlowDefinition, int64, error) {
+			capturedKeyword = keyword
+			capturedCategory = category
+			capturedStatus = status
+			return []model.FlowDefinition{}, 0, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.GET("/definitions", h.List)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/definitions?keyword=leave&category=hr&status=1", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "leave", capturedKeyword)
+	assert.Equal(t, "hr", capturedCategory)
+	require.NotNil(t, capturedStatus)
+	assert.Equal(t, 1, *capturedStatus)
+}
+
+func TestDefinitionHandler_GetByID_Success(t *testing.T) {
+	defID := uuid.New()
+	svc := &mockDefService{
+		getByIDFunc: func(ctx context.Context, id uuid.UUID) (*model.FlowDefinition, error) {
+			return &model.FlowDefinition{ID: id, Key: "test", Name: "Test Flow"}, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.GET("/definitions/:id", h.GetByID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/definitions/"+defID.String(), nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]interface{})
+	assert.Equal(t, "test", data["key"])
+	assert.Equal(t, "Test Flow", data["name"])
+}
+
+func TestDefinitionHandler_GetByID_InvalidUUID(t *testing.T) {
+	svc := &mockDefService{}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.GET("/definitions/:id", h.GetByID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/definitions/not-a-uuid", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDefinitionHandler_Create_Success(t *testing.T) {
+	userID := uuid.New()
+	var capturedReq *dto.CreateDefinitionRequest
+	var capturedUserID uuid.UUID
+
+	svc := &mockDefService{
+		createFunc: func(ctx context.Context, req *dto.CreateDefinitionRequest, uid uuid.UUID) (*model.FlowDefinition, error) {
+			capturedReq = req
+			capturedUserID = uid
+			return &model.FlowDefinition{ID: uuid.New(), Key: req.Key, Name: req.Name, Category: req.Category, CreatedBy: &uid}, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.POST("/definitions", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Create(c)
+	})
+
+	body := `{"key":"leave-approval","name":"请假审批","category":"hr"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/definitions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "leave-approval", capturedReq.Key)
+	assert.Equal(t, userID, capturedUserID)
+}
+
+func TestDefinitionHandler_Create_MissingFields(t *testing.T) {
+	svc := &mockDefService{}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.POST("/definitions", func(c *gin.Context) {
+		setAuthUser(c, uuid.New().String())
+		h.Create(c)
+	})
+
+	body := `{"description":"missing key and name"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/definitions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDefinitionHandler_Update_Success(t *testing.T) {
+	defID := uuid.New()
+	userID := uuid.New()
+
+	svc := &mockDefService{
+		updateFunc: func(ctx context.Context, id uuid.UUID, req *dto.UpdateDefinitionRequest, uid uuid.UUID) (*model.FlowDefinition, error) {
+			return &model.FlowDefinition{ID: id, Name: req.Name, Description: req.Description, UpdatedBy: &uid}, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.PUT("/definitions/:id", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Update(c)
+	})
+
+	body := `{"name":"New Name","description":"Updated"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/definitions/"+defID.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDefinitionHandler_Delete_Success(t *testing.T) {
+	defID := uuid.New()
+	deleted := false
+	svc := &mockDefService{
+		deleteFunc: func(ctx context.Context, id uuid.UUID) error {
+			deleted = true
+			assert.Equal(t, defID, id)
+			return nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.DELETE("/definitions/:id", h.Delete)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/definitions/"+defID.String(), nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, deleted)
+}
+
+func TestDefinitionHandler_Publish_Success(t *testing.T) {
+	defID := uuid.New()
+	userID := uuid.New()
+
+	svc := &mockDefService{
+		publishFunc: func(ctx context.Context, id uuid.UUID, req *dto.PublishDefinitionRequest, uid uuid.UUID) (*model.FlowDefinitionVersion, error) {
+			return &model.FlowDefinitionVersion{ID: uuid.New(), DefinitionID: id, Version: 1, PublishedBy: &uid}, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.POST("/definitions/:id/publish", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Publish(c)
+	})
+
+	body := `{"graph_data":{"nodes":[],"edges":[]}}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/definitions/"+defID.String()+"/publish", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDefinitionHandler_Publish_MissingGraphData(t *testing.T) {
+	svc := &mockDefService{}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.POST("/definitions/:id/publish", func(c *gin.Context) {
+		setAuthUser(c, uuid.New().String())
+		h.Publish(c)
+	})
+
+	body := `{}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/definitions/"+uuid.New().String()+"/publish", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDefinitionHandler_ListVersions_Success(t *testing.T) {
+	defID := uuid.New()
+	svc := &mockDefService{
+		listVersionsFunc: func(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error) {
+			return []model.FlowDefinitionVersion{
+				{ID: uuid.New(), DefinitionID: definitionID, Version: 1},
+				{ID: uuid.New(), DefinitionID: definitionID, Version: 2},
+			}, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.GET("/definitions/:id/versions", h.ListVersions)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/definitions/"+defID.String()+"/versions", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].([]interface{})
+	assert.Len(t, data, 2)
+}
+
+func TestDefinitionHandler_GetVersionByID_Success(t *testing.T) {
+	defID := uuid.New()
+	verID := uuid.New()
+	svc := &mockDefService{
+		getVersionFunc: func(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error) {
+			return &model.FlowDefinitionVersion{ID: id, DefinitionID: defID, Version: 1}, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.GET("/definitions/:id/versions/:versionId", h.GetVersionByID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/definitions/"+defID.String()+"/versions/"+verID.String(), nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDefinitionHandler_GetVersionByID_WrongDefinition(t *testing.T) {
+	defID := uuid.New()
+	verID := uuid.New()
+	otherDefID := uuid.New()
+	svc := &mockDefService{
+		getVersionFunc: func(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error) {
+			return &model.FlowDefinitionVersion{ID: id, DefinitionID: otherDefID, Version: 1}, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.GET("/definitions/:id/versions/:versionId", h.GetVersionByID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/definitions/"+defID.String()+"/versions/"+verID.String(), nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/backend/internal/workflow/handler/instance_handler_test.go
+++ b/backend/internal/workflow/handler/instance_handler_test.go
@@ -1,0 +1,360 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock InstanceService ---
+
+type mockInstService struct {
+	startFunc       func(ctx context.Context, defID uuid.UUID, businessKey, businessType string, initiatorID uuid.UUID, variables map[string]interface{}) (*model.FlowInstance, error)
+	getByIDFunc     func(ctx context.Context, id uuid.UUID) (*model.FlowInstance, error)
+	listFunc        func(ctx context.Context, page, pageSize int, status *int, definitionID, initiatorID *uuid.UUID) ([]model.FlowInstance, int64, error)
+	terminateFunc   func(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error
+	suspendFunc     func(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error
+	resumeFunc      func(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID) error
+	listHistoryFunc func(ctx context.Context, instanceID uuid.UUID) ([]model.FlowHistory, error)
+}
+
+func (m *mockInstService) Start(ctx context.Context, defID uuid.UUID, businessKey, businessType string, initiatorID uuid.UUID, variables map[string]interface{}) (*model.FlowInstance, error) {
+	if m.startFunc != nil {
+		return m.startFunc(ctx, defID, businessKey, businessType, initiatorID, variables)
+	}
+	return &model.FlowInstance{ID: uuid.New(), DefinitionID: defID, InitiatorID: initiatorID}, nil
+}
+
+func (m *mockInstService) GetByID(ctx context.Context, id uuid.UUID) (*model.FlowInstance, error) {
+	if m.getByIDFunc != nil {
+		return m.getByIDFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *mockInstService) List(ctx context.Context, page, pageSize int, status *int, definitionID, initiatorID *uuid.UUID) ([]model.FlowInstance, int64, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, page, pageSize, status, definitionID, initiatorID)
+	}
+	return []model.FlowInstance{}, 0, nil
+}
+
+func (m *mockInstService) Terminate(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error {
+	if m.terminateFunc != nil {
+		return m.terminateFunc(ctx, instanceID, operatorID, reason)
+	}
+	return nil
+}
+
+func (m *mockInstService) Suspend(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error {
+	if m.suspendFunc != nil {
+		return m.suspendFunc(ctx, instanceID, operatorID, reason)
+	}
+	return nil
+}
+
+func (m *mockInstService) Resume(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID) error {
+	if m.resumeFunc != nil {
+		return m.resumeFunc(ctx, instanceID, operatorID)
+	}
+	return nil
+}
+
+func (m *mockInstService) ListHistory(ctx context.Context, instanceID uuid.UUID) ([]model.FlowHistory, error) {
+	if m.listHistoryFunc != nil {
+		return m.listHistoryFunc(ctx, instanceID)
+	}
+	return []model.FlowHistory{}, nil
+}
+
+// Compile-time check.
+var _ service.InstanceService = (*mockInstService)(nil)
+
+// --- InstanceHandler Tests ---
+
+func TestInstanceHandler_Start_Success(t *testing.T) {
+	userID := uuid.New()
+	defID := uuid.New()
+	var capturedDefID uuid.UUID
+	var capturedInitiatorID uuid.UUID
+
+	svc := &mockInstService{
+		startFunc: func(ctx context.Context, d uuid.UUID, bk, bt string, initID uuid.UUID, vars map[string]interface{}) (*model.FlowInstance, error) {
+			capturedDefID = d
+			capturedInitiatorID = initID
+			return &model.FlowInstance{ID: uuid.New(), DefinitionID: d, InitiatorID: initID, Status: 0}, nil
+		},
+	}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.POST("/instances", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Start(c)
+	})
+
+	body := `{"definition_id":"` + defID.String() + `","business_key":"ORDER-001","business_type":"order"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/instances", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, defID, capturedDefID)
+	assert.Equal(t, userID, capturedInitiatorID)
+}
+
+func TestInstanceHandler_Start_MissingDefinitionID(t *testing.T) {
+	svc := &mockInstService{}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.POST("/instances", func(c *gin.Context) {
+		setAuthUser(c, uuid.New().String())
+		h.Start(c)
+	})
+
+	body := `{"business_key":"ORDER-001"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/instances", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestInstanceHandler_List_Success(t *testing.T) {
+	svc := &mockInstService{
+		listFunc: func(ctx context.Context, page, pageSize int, status *int, definitionID, initiatorID *uuid.UUID) ([]model.FlowInstance, int64, error) {
+			return []model.FlowInstance{
+				{ID: uuid.New(), Status: 0},
+				{ID: uuid.New(), Status: 1},
+			}, 2, nil
+		},
+	}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.GET("/instances", h.List)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/instances?page=1&page_size=10", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestInstanceHandler_List_WithFilters(t *testing.T) {
+	var capturedStatus *int
+	var capturedDefID *uuid.UUID
+	var capturedInitID *uuid.UUID
+
+	svc := &mockInstService{
+		listFunc: func(ctx context.Context, page, pageSize int, status *int, definitionID, initiatorID *uuid.UUID) ([]model.FlowInstance, int64, error) {
+			capturedStatus = status
+			capturedDefID = definitionID
+			capturedInitID = initiatorID
+			return []model.FlowInstance{}, 0, nil
+		},
+	}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.GET("/instances", h.List)
+
+	defID := uuid.New()
+	initID := uuid.New()
+	path := "/instances?status=1&definition_id=" + defID.String() + "&initiator_id=" + initID.String()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", path, nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, capturedStatus)
+	assert.Equal(t, 1, *capturedStatus)
+	require.NotNil(t, capturedDefID)
+	assert.Equal(t, defID, *capturedDefID)
+	require.NotNil(t, capturedInitID)
+	assert.Equal(t, initID, *capturedInitID)
+}
+
+func TestInstanceHandler_GetByID_Success(t *testing.T) {
+	instID := uuid.New()
+	svc := &mockInstService{
+		getByIDFunc: func(ctx context.Context, id uuid.UUID) (*model.FlowInstance, error) {
+			return &model.FlowInstance{ID: id, Status: 0}, nil
+		},
+	}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.GET("/instances/:id", h.GetByID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/instances/"+instID.String(), nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestInstanceHandler_GetByID_InvalidUUID(t *testing.T) {
+	svc := &mockInstService{}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.GET("/instances/:id", h.GetByID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/instances/not-a-uuid", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestInstanceHandler_Terminate_Success(t *testing.T) {
+	instID := uuid.New()
+	userID := uuid.New()
+	var capturedReason string
+	var capturedOperatorID uuid.UUID
+
+	svc := &mockInstService{
+		terminateFunc: func(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error {
+			capturedReason = reason
+			capturedOperatorID = operatorID
+			return nil
+		},
+	}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.POST("/instances/:id/terminate", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Terminate(c)
+	})
+
+	body := `{"reason":"不再需要"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/instances/"+instID.String()+"/terminate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "不再需要", capturedReason)
+	assert.Equal(t, userID, capturedOperatorID)
+}
+
+func TestInstanceHandler_Terminate_MissingReason(t *testing.T) {
+	svc := &mockInstService{}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.POST("/instances/:id/terminate", func(c *gin.Context) {
+		setAuthUser(c, uuid.New().String())
+		h.Terminate(c)
+	})
+
+	body := `{}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/instances/"+uuid.New().String()+"/terminate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestInstanceHandler_Suspend_Success(t *testing.T) {
+	instID := uuid.New()
+	userID := uuid.New()
+	var capturedReason string
+
+	svc := &mockInstService{
+		suspendFunc: func(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID, reason string) error {
+			capturedReason = reason
+			return nil
+		},
+	}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.POST("/instances/:id/suspend", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Suspend(c)
+	})
+
+	body := `{"reason":"等待审批"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/instances/"+instID.String()+"/suspend", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "等待审批", capturedReason)
+}
+
+func TestInstanceHandler_Resume_Success(t *testing.T) {
+	instID := uuid.New()
+	userID := uuid.New()
+	called := false
+
+	svc := &mockInstService{
+		resumeFunc: func(ctx context.Context, instanceID uuid.UUID, operatorID uuid.UUID) error {
+			called = true
+			assert.Equal(t, instID, instanceID)
+			assert.Equal(t, userID, operatorID)
+			return nil
+		},
+	}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.POST("/instances/:id/resume", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Resume(c)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/instances/"+instID.String()+"/resume", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, called)
+}
+
+func TestInstanceHandler_ListHistory_Success(t *testing.T) {
+	instID := uuid.New()
+	svc := &mockInstService{
+		listHistoryFunc: func(ctx context.Context, instanceID uuid.UUID) ([]model.FlowHistory, error) {
+			return []model.FlowHistory{
+				{ID: uuid.New(), InstanceID: instanceID, NodeID: "n1", Action: "start"},
+				{ID: uuid.New(), InstanceID: instanceID, NodeID: "n2", Action: "approve"},
+			}, nil
+		},
+	}
+	h := NewInstanceHandler(svc)
+
+	r := setupRouter()
+	r.GET("/instances/:id/history", h.ListHistory)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/instances/"+instID.String()+"/history", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].([]interface{})
+	assert.Len(t, data, 2)
+}

--- a/backend/internal/workflow/handler/task_handler_test.go
+++ b/backend/internal/workflow/handler/task_handler_test.go
@@ -1,0 +1,343 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock TaskService ---
+
+type mockTaskService struct {
+	listTodoFunc   func(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error)
+	listDoneFunc   func(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error)
+	getTaskFunc    func(ctx context.Context, id uuid.UUID) (*model.FlowTask, error)
+	completeFunc   func(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, action string, comment string, formData map[string]interface{}) error
+	transferFunc   func(ctx context.Context, taskID uuid.UUID, fromUserID uuid.UUID, toUserID uuid.UUID, comment string) error
+	rollbackFunc   func(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, targetNodeID string, comment string) error
+}
+
+func (m *mockTaskService) ListTodoTasks(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error) {
+	if m.listTodoFunc != nil {
+		return m.listTodoFunc(ctx, userID, page, pageSize)
+	}
+	return []model.FlowTask{}, 0, nil
+}
+
+func (m *mockTaskService) ListDoneTasks(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error) {
+	if m.listDoneFunc != nil {
+		return m.listDoneFunc(ctx, userID, page, pageSize)
+	}
+	return []model.FlowTask{}, 0, nil
+}
+
+func (m *mockTaskService) GetTaskByID(ctx context.Context, id uuid.UUID) (*model.FlowTask, error) {
+	if m.getTaskFunc != nil {
+		return m.getTaskFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *mockTaskService) CompleteTask(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, action string, comment string, formData map[string]interface{}) error {
+	if m.completeFunc != nil {
+		return m.completeFunc(ctx, taskID, userID, action, comment, formData)
+	}
+	return nil
+}
+
+func (m *mockTaskService) TransferTask(ctx context.Context, taskID uuid.UUID, fromUserID uuid.UUID, toUserID uuid.UUID, comment string) error {
+	if m.transferFunc != nil {
+		return m.transferFunc(ctx, taskID, fromUserID, toUserID, comment)
+	}
+	return nil
+}
+
+func (m *mockTaskService) RollbackTask(ctx context.Context, taskID uuid.UUID, userID uuid.UUID, targetNodeID string, comment string) error {
+	if m.rollbackFunc != nil {
+		return m.rollbackFunc(ctx, taskID, userID, targetNodeID, comment)
+	}
+	return nil
+}
+
+// Compile-time check.
+var _ service.TaskService = (*mockTaskService)(nil)
+
+// --- TaskHandler Tests ---
+
+func TestTaskHandler_ListTodoTasks_Success(t *testing.T) {
+	userID := uuid.New()
+	var capturedUserID uuid.UUID
+
+	svc := &mockTaskService{
+		listTodoFunc: func(ctx context.Context, uid uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error) {
+			capturedUserID = uid
+			return []model.FlowTask{
+				{ID: uuid.New(), NodeName: "Manager Approval", Status: 0},
+			}, 1, nil
+		},
+	}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.GET("/tasks/todo", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.ListTodoTasks(c)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/tasks/todo?page=1&page_size=10", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, userID, capturedUserID)
+}
+
+func TestTaskHandler_ListTodoTasks_NoAuth(t *testing.T) {
+	svc := &mockTaskService{}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.GET("/tasks/todo", h.ListTodoTasks)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/tasks/todo", nil)
+	r.ServeHTTP(w, req)
+
+	// Without auth middleware setting user_id, getUserID returns error.
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestTaskHandler_ListDoneTasks_Success(t *testing.T) {
+	userID := uuid.New()
+
+	svc := &mockTaskService{
+		listDoneFunc: func(ctx context.Context, uid uuid.UUID, page, pageSize int) ([]model.FlowTask, int64, error) {
+			return []model.FlowTask{
+				{ID: uuid.New(), NodeName: "Manager Approval", Status: 1, Action: "approve"},
+			}, 1, nil
+		},
+	}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.GET("/tasks/done", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.ListDoneTasks(c)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/tasks/done", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestTaskHandler_GetByID_Success(t *testing.T) {
+	taskID := uuid.New()
+	svc := &mockTaskService{
+		getTaskFunc: func(ctx context.Context, id uuid.UUID) (*model.FlowTask, error) {
+			return &model.FlowTask{ID: id, NodeName: "Approval", Status: 0}, nil
+		},
+	}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.GET("/tasks/:id", h.GetByID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/tasks/"+taskID.String(), nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]interface{})
+	assert.Equal(t, "Approval", data["node_name"])
+}
+
+func TestTaskHandler_GetByID_InvalidUUID(t *testing.T) {
+	svc := &mockTaskService{}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.GET("/tasks/:id", h.GetByID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/tasks/invalid-uuid", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestTaskHandler_Approve_Success(t *testing.T) {
+	taskID := uuid.New()
+	userID := uuid.New()
+	var capturedAction string
+	var capturedComment string
+
+	svc := &mockTaskService{
+		completeFunc: func(ctx context.Context, tID uuid.UUID, uID uuid.UUID, action string, comment string, formData map[string]interface{}) error {
+			capturedAction = action
+			capturedComment = comment
+			return nil
+		},
+	}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.POST("/tasks/:id/approve", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Approve(c)
+	})
+
+	body := `{"action":"approve","comment":"同意"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tasks/"+taskID.String()+"/approve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "approve", capturedAction)
+	assert.Equal(t, "同意", capturedComment)
+}
+
+func TestTaskHandler_Reject_Success(t *testing.T) {
+	taskID := uuid.New()
+	userID := uuid.New()
+	var capturedAction string
+
+	svc := &mockTaskService{
+		completeFunc: func(ctx context.Context, tID uuid.UUID, uID uuid.UUID, action string, comment string, formData map[string]interface{}) error {
+			capturedAction = action
+			return nil
+		},
+	}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.POST("/tasks/:id/reject", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Reject(c)
+	})
+
+	body := `{"action":"reject","comment":"不同意"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tasks/"+taskID.String()+"/reject", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "reject", capturedAction)
+}
+
+func TestTaskHandler_Transfer_Success(t *testing.T) {
+	taskID := uuid.New()
+	fromUserID := uuid.New()
+	toUserID := uuid.New()
+	var capturedFromID uuid.UUID
+	var capturedToID uuid.UUID
+
+	svc := &mockTaskService{
+		transferFunc: func(ctx context.Context, tID uuid.UUID, fromID uuid.UUID, toID uuid.UUID, comment string) error {
+			capturedFromID = fromID
+			capturedToID = toID
+			return nil
+		},
+	}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.POST("/tasks/:id/transfer", func(c *gin.Context) {
+		setAuthUser(c, fromUserID.String())
+		h.Transfer(c)
+	})
+
+	body := `{"target_user_id":"` + toUserID.String() + `","comment":"转交给张三"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tasks/"+taskID.String()+"/transfer", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, fromUserID, capturedFromID)
+	assert.Equal(t, toUserID, capturedToID)
+}
+
+func TestTaskHandler_Transfer_MissingTargetUserID(t *testing.T) {
+	svc := &mockTaskService{}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.POST("/tasks/:id/transfer", func(c *gin.Context) {
+		setAuthUser(c, uuid.New().String())
+		h.Transfer(c)
+	})
+
+	body := `{"comment":"missing target"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tasks/"+uuid.New().String()+"/transfer", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestTaskHandler_Rollback_Success(t *testing.T) {
+	taskID := uuid.New()
+	userID := uuid.New()
+	var capturedTargetNodeID string
+
+	svc := &mockTaskService{
+		rollbackFunc: func(ctx context.Context, tID uuid.UUID, uID uuid.UUID, targetNodeID string, comment string) error {
+			capturedTargetNodeID = targetNodeID
+			return nil
+		},
+	}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.POST("/tasks/:id/rollback", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.Rollback(c)
+	})
+
+	body := `{"target_node_id":"start_node","comment":"退回起点"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tasks/"+taskID.String()+"/rollback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "start_node", capturedTargetNodeID)
+}
+
+func TestTaskHandler_Rollback_MissingTargetNodeID(t *testing.T) {
+	svc := &mockTaskService{}
+	h := NewTaskHandler(svc)
+
+	r := setupRouter()
+	r.POST("/tasks/:id/rollback", func(c *gin.Context) {
+		setAuthUser(c, uuid.New().String())
+		h.Rollback(c)
+	})
+
+	body := `{"comment":"missing target_node_id"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tasks/"+uuid.New().String()+"/rollback", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}


### PR DESCRIPTION
## 补充测试 PR5 - 工作流引擎测试补全 [Issue #2]

### 新增测试文件

| 文件 | 测试数 | 覆盖范围 |
|------|--------|----------|
| `handler/definition_handler_test.go` | 12 | DefinitionHandler 全部 API |
| `handler/instance_handler_test.go` | 11 | InstanceHandler 全部 API |
| `handler/task_handler_test.go` | 12 | TaskHandler 全部 API |
| `engine/nodes/approval_execute_test.go` | 12 | ApprovalNode Execute + OnEnter + Validate |
| `engine/nodes/e2e_test.go` | 5 | 端到端流程测试 |

### 测试详情

#### Handler 层单元测试（35 个）
使用 mock service 测试所有 API 端点：
- **DefinitionHandler**: List(含过滤参数)、GetByID(含无效UUID)、Create(含字段缺失)、Update、Delete、Publish(含缺少graph_data)、ListVersions、GetVersionByID(含版本归属校验)
- **InstanceHandler**: Start(含缺少definition_id)、List(含多过滤)、GetByID、Terminate(含缺少reason)、Suspend、Resume、ListHistory
- **TaskHandler**: ListTodoTasks(含未认证)、ListDoneTasks、GetByID(含无效UUID)、Approve、Reject、Transfer(含缺少target_user_id)、Rollback(含缺少target_node_id)

#### ApprovalNode Execute 测试（12 个）
- Execute 正常流程（返回下一节点）
- Execute 无出线
- OnEnter 静态处理人策略
- OnEnter 发起人策略
- OnEnter 带 DueDate
- OnEnter 发布 TaskCreatedEvent 事件
- OnEnter 无处理人错误
- OnLeave 空实现
- Validate 缺少配置/静态策略缺少 assignees/无效策略

#### 端到端流程测试（5 个）
- **审批流程**: start → approval → end 完整流转
- **排他网关-高金额**: start → gateway(amount>10000) → approval → end
- **排他网关-低金额**: gateway(amount<=10000) → end
- **并行网关**: start → parallel_gateway → [branch_a, branch_b] → end
- **服务任务**: start → service_task(callback) → end

### 之前已有测试
- repo_test.go: 11 个（Repo 层 CRUD）
- engine_test.go: 11 个（引擎核心流程）
- expression_test.go: 13 个（表达式引擎）
- handlers_test.go: 18 个（节点处理器）
- types_test.go: 8 个（图结构）
- service_test.go: 14 个（Service 层）

### 合计
本次新增 52 个测试，加上已有 75 个，工作流引擎测试总数达到 **127 个**。