### PR TITLE
fix(workflow): 修复 PR5 CI 编译错误 [Issue #2]

### DIFF
--- a/backend/internal/workflow/engine/nodes/e2e_test.go
+++ b/backend/internal/workflow/engine/nodes/e2e_test.go
@@ -202,8 +202,6 @@ func TestEndToEnd_ExclusiveGatewayFlow(t *testing.T) {
 // TestEndToEnd_LowAmountPath tests the low-amount branch of the exclusive gateway.
 
 func TestEndToEnd_LowAmountPath(t *testing.T) {
-	bus := events.NewEventBus()
-	taskRepo := &mockTaskRepo{}
 	registry := NewNodeRegistry()
 
 	exprEngine := engine.NewExpressionEngine()

--- a/backend/internal/workflow/handler/instance_handler_test.go
+++ b/backend/internal/workflow/handler/instance_handler_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Yogdunana/StarByte/backend/internal/workflow/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/service"
 	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"


### PR DESCRIPTION
## 修复 PR5 CI 编译错误

### 问题
PR #42 合并后 CI 失败，两个编译错误：
1. `instance_handler_test.go` 导入了 `dto` 包但未使用
2. `e2e_test.go` `TestEndToEnd_LowAmountPath` 中声明了 `bus` 和 `taskRepo` 但未使用

### 修复
- 移除 `instance_handler_test.go` 中未使用的 `dto` 包导入
- 移除 `e2e_test.go` `TestEndToEnd_LowAmountPath` 中未使用的 `bus` 和 `taskRepo` 变量