### PR TITLE
feat(frontend): 权限路由守卫与菜单过滤系统 (#20)

### DIFF
--- a/frontend/src/layouts/MainLayout/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout/MainLayout.tsx
@@ -17,10 +17,9 @@ import {
 } from '@ant-design/icons';
 
 import TopBar from './components/TopBar';
-import routes, { AppRouteObject } from '@/router/routes';
+import routes, { AppRouteObject, RouteMeta } from '@/router/routes';
 import { selectCollapsed } from '@/store/slices/appSlice';
-import { fetchCurrentUser, selectCurrentUser } from '@/store/slices/userSlice';
-import { getToken } from '@/utils/storage';
+import { fetchCurrentUser, selectCurrentUser, selectPermissions } from '@/store/slices/userSlice';
 import type { AppDispatch } from '@/store';
 
 const { Sider, Content } = Layout;
@@ -45,10 +44,45 @@ export interface MainLayoutProps {
 
 type MenuItem = NonNullable<MenuProps['items']>[number];
 
-/** 递归构建菜单项 */
-function getMenuItems(routeList: AppRouteObject[], parentPath = ''): MenuItem[] {
+/**
+ * 检查用户是否拥有指定权限
+ * - permissions 包含 '*' 时视为超级管理员，拥有所有权限
+ * - 未声明 permission 时视为公开，所有人可见
+ */
+function hasMenuPermission(permissions: string[], meta?: RouteMeta): boolean {
+  if (permissions.includes('*')) return true;
+  if (!meta?.permission) return true;
+  return permissions.includes(meta.permission);
+}
+
+/**
+ * 递归检查父路由下是否存在至少一个对当前用户可见的子路由
+ */
+function hasVisibleChildren(route: AppRouteObject, permissions: string[]): boolean {
+  if (!route.children || route.children.length === 0) return false;
+  return route.children.some((child) => {
+    if (child.meta?.hidden) return false;
+    if (child.children && child.children.length > 0) {
+      return hasVisibleChildren(child, permissions);
+    }
+    return hasMenuPermission(permissions, child.meta);
+  });
+}
+
+/**
+ * 递归构建菜单项，按权限过滤
+ */
+function getMenuItems(routeList: AppRouteObject[], permissions: string[], parentPath = ''): MenuItem[] {
   return routeList
     .filter((route) => !route.meta?.hidden && route.path && route.path !== '*')
+    .filter((route) => {
+      // 父路由：至少有一个可见子路由时才显示
+      if (route.children && route.children.length > 0) {
+        return hasVisibleChildren(route, permissions);
+      }
+      // 叶子路由：检查自身权限
+      return hasMenuPermission(permissions, route.meta);
+    })
     .map((route) => {
       const fullPath = route.path!.startsWith('/')
         ? route.path!
@@ -67,6 +101,7 @@ function getMenuItems(routeList: AppRouteObject[], parentPath = ''): MenuItem[] 
       if (route.children && route.children.length > 0) {
         const childItems = getMenuItems(
           route.children.filter((c) => c.path !== 'index'),
+          permissions,
           fullPath,
         );
         if (childItems.length > 0) {
@@ -84,24 +119,23 @@ const MainLayout: React.FC<MainLayoutProps> = () => {
   const dispatch = useDispatch<AppDispatch>();
   const collapsed = useSelector(selectCollapsed);
   const currentUser = useSelector(selectCurrentUser);
+  const permissions = useSelector(selectPermissions);
 
   const {
     token: { colorBgContainer, borderRadiusLG },
   } = theme.useToken();
 
+  // AuthRoute 已处理认证逻辑，这里仅作为安全兜底
   useEffect(() => {
-    const token = getToken();
-    if (!token) {
-      navigate('/login', { replace: true });
-      return;
-    }
     if (!currentUser) {
       dispatch(fetchCurrentUser());
     }
-  }, [dispatch, navigate, currentUser]);
+  }, [dispatch, currentUser]);
 
   const layoutRoute = (routes as AppRouteObject[]).find((r) => r.path === '/');
-  const menuItems = layoutRoute?.children ? getMenuItems(layoutRoute.children, '') : [];
+  const menuItems = layoutRoute?.children
+    ? getMenuItems(layoutRoute.children, permissions, '')
+    : [];
 
   const selectedKeys = [location.pathname];
   const parts = location.pathname.split('/').filter(Boolean);

--- a/frontend/src/pages/error/Forbidden.tsx
+++ b/frontend/src/pages/error/Forbidden.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Result, Button } from 'antd';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * 403 Forbidden 页面
+ *
+ * 当用户尝试访问没有权限的路由时展示。
+ */
+const Forbidden: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Result
+      status="403"
+      title="403"
+      subTitle="抱歉，您没有权限访问此页面。"
+      extra={
+        <Button type="primary" onClick={() => navigate('/dashboard', { replace: true })}>
+          返回工作台
+        </Button>
+      }
+      style={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }}
+    />
+  );
+};
+
+export default Forbidden;

--- a/frontend/src/pages/error/index.ts
+++ b/frontend/src/pages/error/index.ts
@@ -1,0 +1,1 @@
+export { default as Forbidden } from './Forbidden';

--- a/frontend/src/router/guards/AuthRoute.tsx
+++ b/frontend/src/router/guards/AuthRoute.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { getToken } from '@/utils/storage';
 import { logout as logoutAction } from '@/store/slices/authSlice';
-import { fetchCurrentUser, selectCurrentUser, selectUserLoading, selectUserError } from '@/store/slices/userSlice';
+import { fetchCurrentUser, selectCurrentUser, selectUserLoading, selectUserError, clearUser } from '@/store/slices/userSlice';
 import type { AppDispatch } from '@/store';
 
 /**
@@ -53,14 +53,21 @@ const AuthRoute: React.FC<AuthRouteProps> = ({ children }) => {
     }
   }, [dispatch, token, currentUser, userError]);
 
+  // 用户信息获取失败（token 过期等）→ 在 effect 中清除认证状态
+  useEffect(() => {
+    if (token && userError && !currentUser) {
+      dispatch(logoutAction());
+      dispatch(clearUser());
+    }
+  }, [token, userError, currentUser, dispatch]);
+
   // 无 token → 登录页
   if (!token) {
     return <Navigate to="/login" replace state={{ from: location }} />;
   }
 
-  // token 存在但用户信息获取失败 → 清除状态并重定向
+  // token 存在但用户信息获取失败 → 重定向登录页（dispatch 在上方 effect 中执行）
   if (userError && !currentUser) {
-    dispatch(logoutAction());
     return <Navigate to="/login" replace />;
   }
 

--- a/frontend/src/router/guards/AuthRoute.tsx
+++ b/frontend/src/router/guards/AuthRoute.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { Spin } from 'antd';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { getToken } from '@/utils/storage';
+import { logout as logoutAction } from '@/store/slices/authSlice';
+import { fetchCurrentUser, selectCurrentUser, selectUserLoading, selectUserError } from '@/store/slices/userSlice';
+import type { AppDispatch } from '@/store';
+
+/**
+ * 全屏加载占位
+ */
+const LoadingScreen: React.FC = () => (
+  <div style={{
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '100vh',
+    flexDirection: 'column',
+    gap: 16,
+  }}>
+    <Spin size="large" />
+    <span style={{ color: '#999', fontSize: 14 }}>正在加载用户信息...</span>
+  </div>
+);
+
+export interface AuthRouteProps {
+  children: React.ReactNode;
+}
+
+/**
+ * 认证路由守卫
+ *
+ * 职责：
+ * 1. 检查 localStorage 中是否存在 token，不存在则重定向到 /login
+ * 2. token 存在但用户信息未加载时，自动触发 fetchCurrentUser
+ * 3. 加载过程中显示全屏 Loading
+ * 4. 加载失败（token 过期等）时清除认证状态并重定向到 /login
+ */
+const AuthRoute: React.FC<AuthRouteProps> = ({ children }) => {
+  const location = useLocation();
+  const dispatch = useDispatch<AppDispatch>();
+
+  const token = getToken();
+  const currentUser = useSelector(selectCurrentUser);
+  const userLoading = useSelector(selectUserLoading);
+  const userError = useSelector(selectUserError);
+
+  useEffect(() => {
+    if (token && !currentUser && !userError) {
+      dispatch(fetchCurrentUser());
+    }
+  }, [dispatch, token, currentUser, userError]);
+
+  // 无 token → 登录页
+  if (!token) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  // token 存在但用户信息获取失败 → 清除状态并重定向
+  if (userError && !currentUser) {
+    dispatch(logoutAction());
+    return <Navigate to="/login" replace />;
+  }
+
+  // token 存在且正在加载用户信息 → 全屏 Loading
+  if (!currentUser && (userLoading || !userError)) {
+    return <LoadingScreen />;
+  }
+
+  // 认证通过 → 渲染子节点
+  return <>{children}</>;
+};
+
+export default AuthRoute;

--- a/frontend/src/router/guards/PermissionRoute.tsx
+++ b/frontend/src/router/guards/PermissionRoute.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+import { usePermission } from '@/hooks/usePermission';
+
+export interface PermissionRouteProps {
+  /** 权限码，不传或为空字符串时视为无权限限制 */
+  permission?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * 权限路由守卫
+ *
+ * 职责：
+ * - 当 route meta 中声明了 permission 字段时，检查当前用户是否持有该权限
+ * - 无权限时重定向到 /403 页面
+ * - 有权限或未声明 permission 时直接渲染 children
+ */
+const PermissionRoute: React.FC<PermissionRouteProps> = ({ permission, children }) => {
+  const hasPermission = usePermission(permission || '');
+
+  // 无权限码 → 不做限制
+  if (!permission) {
+    return <>{children}</>;
+  }
+
+  // 无权限 → 403
+  if (!hasPermission) {
+    return <Navigate to="/403" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default PermissionRoute;

--- a/frontend/src/router/guards/index.ts
+++ b/frontend/src/router/guards/index.ts
@@ -1,0 +1,4 @@
+export { default as AuthRoute } from './AuthRoute';
+export { default as PermissionRoute } from './PermissionRoute';
+export type { AuthRouteProps } from './AuthRoute';
+export type { PermissionRouteProps } from './PermissionRoute';

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -5,23 +5,50 @@ import type { RouteObject } from 'react-router-dom';
 // 布局组件
 import MainLayout from '@/layouts/MainLayout/MainLayout';
 
+// 路由守卫
+import AuthRoute from '@/router/guards/AuthRoute';
+import PermissionRoute from '@/router/guards/PermissionRoute';
+
 // 页面组件
 const Login = lazy(() => import('@/pages/login/Login'));
 const Dashboard = lazy(() => import('@/pages/dashboard/Dashboard'));
 const UserList = lazy(() => import('@/pages/user/UserList'));
+const Forbidden = lazy(() => import('@/pages/error/Forbidden'));
 
-// 懒加载包装器
+// 懒加载 fallback
+const LoadingFallback: React.FC = () => (
+  <div style={{ padding: 24, textAlign: 'center' }}>加载中...</div>
+);
+
+// 懒加载包装器（无权限守卫）
 const lazyWrap = (Component: React.LazyExoticComponent<React.FC>) => (
-  <Suspense fallback={<div style={{ padding: 24, textAlign: 'center' }}>加载中...</div>}>
+  <Suspense fallback={<LoadingFallback />}>
     <Component />
   </Suspense>
 );
+
+// 带权限守卫的懒加载包装器
+const lazyGuarded = (
+  Component: React.LazyExoticComponent<React.FC>,
+  permission?: string,
+) => {
+  const element = lazyWrap(Component);
+  return permission ? (
+    <PermissionRoute permission={permission}>{element}</PermissionRoute>
+  ) : element;
+};
+
+// 带权限守卫的内联元素包装器
+const guarded = (element: React.ReactNode, permission?: string) =>
+  permission ? (
+    <PermissionRoute permission={permission}>{element}</PermissionRoute>
+  ) : element;
 
 // 路由元信息类型
 export interface RouteMeta {
   title?: string;
   icon?: string;
-  permission?: string;
+  permission?: string; // 权限码
   public?: boolean; // 是否公开页面（不需要登录）
   hidden?: boolean; // 是否在菜单中隐藏
 }
@@ -40,12 +67,17 @@ const routes: AppRouteObject[] = [
   },
   {
     path: '/',
-    element: <MainLayout />,
+    element: <AuthRoute><MainLayout /></AuthRoute>,
     children: [
       { index: true, element: <Navigate to="/dashboard" replace /> },
       {
+        path: '403',
+        element: lazyWrap(Forbidden),
+        meta: { title: '无权限', hidden: true },
+      },
+      {
         path: 'dashboard',
-        element: lazyWrap(Dashboard),
+        element: lazyGuarded(Dashboard),
         meta: { title: '工作台', icon: 'DashboardOutlined' },
       },
       {
@@ -55,7 +87,7 @@ const routes: AppRouteObject[] = [
           {
             index: true,
             path: 'list',
-            element: lazyWrap(UserList),
+            element: lazyGuarded(UserList, 'user:read'),
             meta: { title: '用户列表', permission: 'user:read' },
           },
         ],
@@ -178,28 +210,28 @@ const routes: AppRouteObject[] = [
         children: [
           {
             path: 'role',
-            element: <div style={{ padding: 24 }}>角色管理（开发中）</div>,
-            meta: { title: '角色管理' },
+            element: guarded(<div style={{ padding: 24 }}>角色管理（开发中）</div>, 'role:read'),
+            meta: { title: '角色管理', permission: 'role:read' },
           },
           {
             path: 'permission',
-            element: <div style={{ padding: 24 }}>权限管理（开发中）</div>,
-            meta: { title: '权限管理' },
+            element: guarded(<div style={{ padding: 24 }}>权限管理（开发中）</div>, 'permission:read'),
+            meta: { title: '权限管理', permission: 'permission:read' },
           },
           {
             path: 'department',
-            element: <div style={{ padding: 24 }}>部门管理（开发中）</div>,
-            meta: { title: '部门管理' },
+            element: guarded(<div style={{ padding: 24 }}>部门管理（开发中）</div>, 'department:read'),
+            meta: { title: '部门管理', permission: 'department:read' },
           },
           {
             path: 'audit',
-            element: <div style={{ padding: 24 }}>审计日志（开发中）</div>,
-            meta: { title: '审计日志' },
+            element: guarded(<div style={{ padding: 24 }}>审计日志（开发中）</div>, 'audit:read'),
+            meta: { title: '审计日志', permission: 'audit:read' },
           },
           {
             path: 'config',
-            element: <div style={{ padding: 24 }}>系统配置（开发中）</div>,
-            meta: { title: '系统配置' },
+            element: guarded(<div style={{ padding: 24 }}>系统配置（开发中）</div>, 'system:config'),
+            meta: { title: '系统配置', permission: 'system:config' },
           },
         ],
       },

--- a/frontend/src/store/slices/userSlice.ts
+++ b/frontend/src/store/slices/userSlice.ts
@@ -7,12 +7,14 @@ interface UserState {
   currentUser: UserInfo | null;
   permissions: string[];
   loading: boolean;
+  error: string | null;
 }
 
 const initialState: UserState = {
   currentUser: null,
   permissions: [],
   loading: false,
+  error: null,
 };
 
 // 获取当前用户信息
@@ -31,31 +33,39 @@ const userSlice = createSlice({
     clearUser(state) {
       state.currentUser = null;
       state.permissions = [];
+      state.error = null;
     },
     setPermissions(state, action: PayloadAction<string[]>) {
       state.permissions = action.payload;
+    },
+    clearUserError(state) {
+      state.error = null;
     },
   },
   extraReducers: (builder) => {
     builder
       .addCase(fetchCurrentUser.pending, (state) => {
         state.loading = true;
+        state.error = null;
       })
       .addCase(fetchCurrentUser.fulfilled, (state, action: PayloadAction<UserInfo>) => {
         state.loading = false;
+        state.error = null;
         state.currentUser = action.payload;
         state.permissions = action.payload.permissions || [];
       })
-      .addCase(fetchCurrentUser.rejected, (state) => {
+      .addCase(fetchCurrentUser.rejected, (state, action) => {
         state.loading = false;
+        state.error = action.error.message || '获取用户信息失败';
       });
   },
 });
 
-export const { clearUser, setPermissions } = userSlice.actions;
+export const { clearUser, setPermissions, clearUserError } = userSlice.actions;
 
 export const selectCurrentUser = (state: RootState) => state.user.currentUser;
 export const selectPermissions = (state: RootState) => state.user.permissions;
 export const selectUserLoading = (state: RootState) => state.user.loading;
+export const selectUserError = (state: RootState) => state.user.error;
 
 export default userSlice.reducer;


### PR DESCRIPTION
## 概述

实现 Issue #20：前端权限路由与菜单系统。为应用添加认证路由守卫、权限路由守卫、403 页面，并改造侧边栏菜单按用户权限动态过滤。

## 改动清单

### 新增文件

| 文件 | 说明 |
|------|------|
| `src/router/guards/AuthRoute.tsx` | 认证路由守卫：检查 token、自动 fetchCurrentUser、加载失败重定向 /login |
| `src/router/guards/PermissionRoute.tsx` | 权限路由守卫：检查 `meta.permission`，无权限重定向 /403 |
| `src/router/guards/index.ts` | 守卫组件统一导出 |
| `src/pages/error/Forbidden.tsx` | 403 Forbidden 页面（antd Result 组件）|
| `src/pages/error/index.ts` | 错误页面统一导出 |

### 修改文件

| 文件 | 改动说明 |
|------|----------|
| `src/router/routes.tsx` | MainLayout 路由用 `AuthRoute` 包裹；新增 `/403` 路由；新增 `lazyGuarded` / `guarded` 包装器；系统管理路由添加权限码 |
| `src/layouts/MainLayout/MainLayout.tsx` | 菜单构建函数 `getMenuItems` 增加 `permissions` 参数；新增 `hasMenuPermission` / `hasVisibleChildren` 递归过滤逻辑；移除冗余 token 检查（由 AuthRoute 接管）|
| `src/store/slices/userSlice.ts` | 新增 `error` 状态字段与 `selectUserError` 选择器；`clearUser` 同步清除 error；`fetchCurrentUser.rejected` 记录错误信息 |

## 设计要点

### AuthRoute 认证流程

```
用户访问受保护路由
  → 检查 localStorage token
    → 无 token → 重定向 /login（携带来源路径）
    → 有 token → 检查 currentUser
      → 用户信息已加载 → 渲染子组件
      → 未加载 → dispatch(fetchCurrentUser) → 全屏 Loading
      → 加载失败 → dispatch(logout) → 重定向 /login
```

### PermissionRoute 权限流程

```
路由 meta.permission 存在？
  → 否 → 直接渲染
  → 是 → usePermission(permission) 检查
    → 有权限 → 渲染
    → 无权限 → Navigate to /403
```

### 菜单过滤逻辑

- **叶子路由**：`hasMenuPermission()` 检查 `meta.permission` 是否在用户权限列表中
- **父路由**：`hasVisibleChildren()` 递归检查是否至少有一个子路由可见，不可见的父菜单整组隐藏
- **超级管理员**：权限列表包含 `*` 时自动通过所有检查

## 验证

- `npm run lint` → 0 errors, 13 warnings（均为既有文件的 `any` 类型警告，本次新增文件零警告）
- `npm run build` → TypeScript 编译通过，Vite 生产构建成功

## 关联 Issue

Closes #20