### PR TITLE
feat(frontend): 前端 API 层封装与类型定义系统 (#21)

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -23,10 +23,10 @@ export function logout(): Promise<void> {
 
 // 获取当前用户信息
 export function getCurrentUser(): Promise<UserInfo> {
-  return request.get('/auth/me');
+  return request.get('/user/me');
 }
 
 // 修改密码
 export function changePassword(params: { old_password: string; new_password: string }): Promise<void> {
-  return request.put('/auth/password', params);
+  return request.put('/user/password', params);
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -23,10 +23,10 @@ export function logout(): Promise<void> {
 
 // 获取当前用户信息
 export function getCurrentUser(): Promise<UserInfo> {
-  return request.get('/user/me');
+  return request.get('/auth/me');
 }
 
 // 修改密码
 export function changePassword(params: { old_password: string; new_password: string }): Promise<void> {
-  return request.put('/user/password', params);
+  return request.put('/auth/password', params);
 }

--- a/frontend/src/api/department.ts
+++ b/frontend/src/api/department.ts
@@ -1,0 +1,48 @@
+import request from './request';
+import type {
+  Department,
+  CreateDepartmentParams,
+  UpdateDepartmentParams,
+  PageResponse,
+  Option,
+} from '@/types/api';
+
+// 获取部门树
+export function getDepartmentTree(): Promise<Department[]> {
+  return request.get('/departments/tree');
+}
+
+// 获取部门列表（分页）
+export function getDepartmentList(params: {
+  page?: number;
+  page_size?: number;
+  parent_id?: string;
+  keyword?: string;
+}): Promise<PageResponse<Department>> {
+  return request.get('/departments', { params });
+}
+
+// 获取部门详情
+export function getDepartmentDetail(id: string): Promise<Department> {
+  return request.get(`/departments/${id}`);
+}
+
+// 创建部门
+export function createDepartment(data: CreateDepartmentParams): Promise<Department> {
+  return request.post('/departments', data);
+}
+
+// 更新部门
+export function updateDepartment(id: string, data: UpdateDepartmentParams): Promise<Department> {
+  return request.put(`/departments/${id}`, data);
+}
+
+// 删除部门
+export function deleteDepartment(id: string): Promise<void> {
+  return request.delete(`/departments/${id}`);
+}
+
+// 获取部门选项（下拉选择用）
+export function getDepartmentOptions(): Promise<Option[]> {
+  return request.get('/departments/options');
+}

--- a/frontend/src/api/error.ts
+++ b/frontend/src/api/error.ts
@@ -1,0 +1,121 @@
+import type { AxiosError } from 'axios';
+
+/**
+ * 业务错误码到中文消息的映射
+ * 仅包含前端需要特殊处理或展示的常见错误码
+ */
+const errorCodeMessages: Record<number, string> = {
+  1001: '参数错误',
+  1002: '未授权，请先登录',
+  1003: '没有权限执行此操作',
+  1004: '资源不存在',
+  1005: '请求过于频繁，请稍后再试',
+  2001: '用户不存在',
+  2002: '用户名或密码错误',
+  2003: '用户名已存在',
+  2004: '用户已被禁用',
+  2005: '原密码错误',
+  3001: '角色不存在',
+  3002: '权限不足',
+  3003: '角色编码已存在',
+  3004: '部门不存在',
+  4001: '流程定义不存在',
+  4002: '流程已结束',
+  4003: '流程实例不存在',
+  5001: '审计日志不存在',
+  5002: '导出格式不支持',
+  6001: '申请不存在',
+  6002: '当前状态不允许该操作',
+  7001: '面试场次不存在',
+  7002: '时间冲突',
+  8001: '会议不存在',
+  8002: '投票已结束',
+  9001: '任务不存在',
+  9002: '无权操作此任务',
+  10001: '实习记录不存在',
+  10002: '无权操作此实习记录',
+  12001: '通知不存在',
+  12003: '通知模板已存在',
+};
+
+/**
+ * 从 API 错误中提取用户友好的错误消息
+ *
+ * 优先级：
+ * 1. 后端返回的业务错误消息（response.data.message）
+ * 2. 错误码映射的中文消息
+ * 3. HTTP 状态码对应的通用消息
+ * 4. 网络错误提示
+ * 5. 默认「请求失败」
+ */
+export function handleApiError(error: unknown): string {
+  // 非 Axios 错误
+  if (!isAxiosError(error)) {
+    if (error instanceof Error) return error.message;
+    return '请求失败';
+  }
+
+  const axiosError = error as AxiosError<{ code?: number; message?: string }>;
+
+  // 后端返回了业务错误消息
+  if (axiosError.response?.data?.message) {
+    return axiosError.response.data.message;
+  }
+
+  // 错误码映射
+  const code = axiosError.response?.data?.code;
+  if (code && errorCodeMessages[code]) {
+    return errorCodeMessages[code];
+  }
+
+  // HTTP 状态码通用消息
+  const status = axiosError.response?.status;
+  if (status) {
+    switch (status) {
+      case 400:
+        return '参数错误';
+      case 401:
+        return '未授权，请先登录';
+      case 403:
+        return '没有权限执行此操作';
+      case 404:
+        return '请求的资源不存在';
+      case 408:
+        return '请求超时，请稍后重试';
+      case 429:
+        return '请求过于频繁，请稍后再试';
+      case 500:
+        return '服务器内部错误';
+      case 502:
+        return '网关错误';
+      case 503:
+        return '服务暂时不可用';
+      case 504:
+        return '网关超时';
+      default:
+        return `请求失败（${status}）`;
+    }
+  }
+
+  // 网络错误（无 response）
+  if (axiosError.code === 'ECONNABORTED') {
+    return '请求超时，请稍后重试';
+  }
+  if (axiosError.code === 'ERR_NETWORK' || !axiosError.response) {
+    return '网络连接失败，请检查网络';
+  }
+
+  return '请求失败';
+}
+
+/**
+ * 判断是否为 Axios 错误
+ */
+function isAxiosError(error: unknown): error is AxiosError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'isAxiosError' in error &&
+    (error as AxiosError).isAxiosError === true
+  );
+}

--- a/frontend/src/api/file.ts
+++ b/frontend/src/api/file.ts
@@ -1,0 +1,42 @@
+import request from './request';
+import type { FileInfo, UploadResult, ListFileParams, PageResponse } from '@/types/api';
+
+// 获取文件列表
+export function getFileList(params: ListFileParams): Promise<PageResponse<FileInfo>> {
+  return request.get('/files', { params });
+}
+
+// 获取文件详情
+export function getFileDetail(id: string): Promise<FileInfo> {
+  return request.get(`/files/${id}`);
+}
+
+// 删除文件
+export function deleteFile(id: string): Promise<void> {
+  return request.delete(`/files/${id}`);
+}
+
+/**
+ * 获取上传地址（上传文件时使用，支持上传进度）
+ *
+ * @example
+ * ```ts
+ * const formData = new FormData();
+ * formData.append('file', file);
+ * const result = await uploadFile(formData, (progressEvent) => {
+ *   const percent = Math.round((progressEvent.loaded * 100) / (progressEvent.total || 0));
+ *   console.log(percent);
+ * });
+ * ```
+ */
+export function uploadFile(
+  formData: FormData,
+  onUploadProgress?: (progressEvent: { loaded: number; total?: number }) => void,
+): Promise<UploadResult> {
+  return request.post('/files/upload', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+    onUploadProgress,
+  });
+}

--- a/frontend/src/api/file.ts
+++ b/frontend/src/api/file.ts
@@ -34,9 +34,6 @@ export function uploadFile(
   onUploadProgress?: (progressEvent: { loaded: number; total?: number }) => void,
 ): Promise<UploadResult> {
   return request.post('/files/upload', formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
     onUploadProgress,
   });
 }

--- a/frontend/src/api/internship.ts
+++ b/frontend/src/api/internship.ts
@@ -1,0 +1,62 @@
+import request from './request';
+import type {
+  InternshipRecord,
+  InternshipStats,
+  CreateInternshipParams,
+  UpdateInternshipParams,
+  ListInternshipParams,
+  PageResponse,
+} from '@/types/api';
+
+// 提交实习记录
+export function createInternship(data: CreateInternshipParams): Promise<InternshipRecord> {
+  return request.post('/internships', data);
+}
+
+// 获取实习记录列表
+export function getInternshipList(
+  params: ListInternshipParams,
+): Promise<PageResponse<InternshipRecord>> {
+  return request.get('/internships', { params });
+}
+
+// 获取我的实习记录
+export function getMyInternships(params: ListInternshipParams): Promise<PageResponse<InternshipRecord>> {
+  return request.get('/internships/my', { params });
+}
+
+// 获取实习记录详情
+export function getInternshipDetail(id: string): Promise<InternshipRecord> {
+  return request.get(`/internships/${id}`);
+}
+
+// 更新实习记录
+export function updateInternship(id: string, data: Partial<CreateInternshipParams>): Promise<InternshipRecord> {
+  return request.put(`/internships/${id}`, data);
+}
+
+// 删除实习记录
+export function deleteInternship(id: string): Promise<void> {
+  return request.delete(`/internships/${id}`);
+}
+
+// 审核实习记录
+export function reviewInternship(id: string, data: UpdateInternshipParams): Promise<InternshipRecord> {
+  return request.post(`/internships/${id}/review`, data);
+}
+
+// 获取实习统计排名
+export function getInternshipStats(params: {
+  page?: number;
+  page_size?: number;
+  department_id?: string;
+  start_date?: string;
+  end_date?: string;
+}): Promise<PageResponse<InternshipStats>> {
+  return request.get('/internships/stats', { params });
+}
+
+// 获取个人实习统计
+export function getMyInternshipStats(): Promise<InternshipStats> {
+  return request.get('/internships/stats/my');
+}

--- a/frontend/src/api/interview.ts
+++ b/frontend/src/api/interview.ts
@@ -1,0 +1,49 @@
+import request from './request';
+import type {
+  Interview,
+  InterviewEvaluation,
+  CreateInterviewParams,
+  UpdateInterviewParams,
+  ListInterviewParams,
+  PageResponse,
+} from '@/types/api';
+
+// 获取面试列表
+export function getInterviewList(
+  params: ListInterviewParams,
+): Promise<PageResponse<Interview>> {
+  return request.get('/interviews', { params });
+}
+
+// 获取面试详情
+export function getInterviewDetail(id: string): Promise<Interview> {
+  return request.get(`/interviews/${id}`);
+}
+
+// 创建面试
+export function createInterview(data: CreateInterviewParams): Promise<Interview> {
+  return request.post('/interviews', data);
+}
+
+// 更新面试
+export function updateInterview(id: string, data: UpdateInterviewParams): Promise<Interview> {
+  return request.put(`/interviews/${id}`, data);
+}
+
+// 删除面试
+export function deleteInterview(id: string): Promise<void> {
+  return request.delete(`/interviews/${id}`);
+}
+
+// 获取面试评分列表
+export function getInterviewEvaluations(interviewId: string): Promise<InterviewEvaluation[]> {
+  return request.get(`/interviews/${interviewId}/evaluations`);
+}
+
+// 提交面试评分
+export function submitInterviewEvaluation(
+  interviewId: string,
+  data: { score: number; comment: string; recommendation: number },
+): Promise<InterviewEvaluation> {
+  return request.post(`/interviews/${interviewId}/evaluations`, data);
+}

--- a/frontend/src/api/meeting.ts
+++ b/frontend/src/api/meeting.ts
@@ -1,0 +1,75 @@
+import request from './request';
+import type {
+  Meeting,
+  MeetingAgenda,
+  MeetingVote,
+  VoteRecord,
+  CreateMeetingParams,
+  UpdateMeetingParams,
+  CreateVoteParams,
+  ListMeetingParams,
+  PageResponse,
+} from '@/types/api';
+
+// ============================================================
+// 会议
+// ============================================================
+
+// 获取会议列表
+export function getMeetingList(params: ListMeetingParams): Promise<PageResponse<Meeting>> {
+  return request.get('/meetings', { params });
+}
+
+// 获取会议详情
+export function getMeetingDetail(id: string): Promise<Meeting> {
+  return request.get(`/meetings/${id}`);
+}
+
+// 创建会议
+export function createMeeting(data: CreateMeetingParams): Promise<Meeting> {
+  return request.post('/meetings', data);
+}
+
+// 更新会议
+export function updateMeeting(id: string, data: UpdateMeetingParams): Promise<Meeting> {
+  return request.put(`/meetings/${id}`, data);
+}
+
+// 删除会议
+export function deleteMeeting(id: string): Promise<void> {
+  return request.delete(`/meetings/${id}`);
+}
+
+// 获取会议议程
+export function getMeetingAgendas(meetingId: string): Promise<MeetingAgenda[]> {
+  return request.get(`/meetings/${meetingId}/agendas`);
+}
+
+// ============================================================
+// 投票
+// ============================================================
+
+// 获取会议投票列表
+export function getMeetingVotes(meetingId: string): Promise<MeetingVote[]> {
+  return request.get(`/meetings/${meetingId}/votes`);
+}
+
+// 获取投票详情
+export function getVoteDetail(voteId: string): Promise<MeetingVote> {
+  return request.get(`/meetings/votes/${voteId}`);
+}
+
+// 创建投票
+export function createVote(data: CreateVoteParams): Promise<MeetingVote> {
+  return request.post('/meetings/votes', data);
+}
+
+// 提交投票
+export function submitVote(voteId: string, optionIds: string[]): Promise<void> {
+  return request.post(`/meetings/votes/${voteId}/cast`, { option_ids: optionIds });
+}
+
+// 获取投票记录
+export function getVoteRecords(voteId: string): Promise<VoteRecord[]> {
+  return request.get(`/meetings/votes/${voteId}/records`);
+}

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -1,0 +1,71 @@
+import request from './request';
+import type {
+  MemberApplication,
+  MemberProfile,
+  CreateMemberApplicationParams,
+  ListMemberApplicationParams,
+  ListMemberParams,
+  PageResponse,
+  OperationResult,
+} from '@/types/api';
+
+// ============================================================
+// 入会申请
+// ============================================================
+
+// 提交入会申请
+export function submitApplication(data: CreateMemberApplicationParams): Promise<MemberApplication> {
+  return request.post('/members/applications', data);
+}
+
+// 获取申请列表
+export function getApplicationList(
+  params: ListMemberApplicationParams,
+): Promise<PageResponse<MemberApplication>> {
+  return request.get('/members/applications', { params });
+}
+
+// 获取申请详情
+export function getApplicationDetail(id: string): Promise<MemberApplication> {
+  return request.get(`/members/applications/${id}`);
+}
+
+// 审核申请（通过/拒绝）
+export function reviewApplication(
+  id: string,
+  data: { action: 'approve' | 'reject'; comment?: string },
+): Promise<OperationResult> {
+  return request.post(`/members/applications/${id}/review`, data);
+}
+
+// 取消申请
+export function cancelApplication(id: string): Promise<void> {
+  return request.post(`/members/applications/${id}/cancel`);
+}
+
+// ============================================================
+// 会员档案
+// ============================================================
+
+// 获取会员列表
+export function getMemberList(params: ListMemberParams): Promise<PageResponse<MemberProfile>> {
+  return request.get('/members', { params });
+}
+
+// 获取会员详情
+export function getMemberDetail(id: string): Promise<MemberProfile> {
+  return request.get(`/members/${id}`);
+}
+
+// 更新会员信息
+export function updateMember(
+  id: string,
+  data: Partial<{
+    member_type: number;
+    department_id: string;
+    position_id: string;
+    status: number;
+  }>,
+): Promise<MemberProfile> {
+  return request.put(`/members/${id}`, data);
+}

--- a/frontend/src/api/notification.ts
+++ b/frontend/src/api/notification.ts
@@ -1,0 +1,84 @@
+import request from './request';
+import type {
+  Notification,
+  NotificationTemplate,
+  ListNotificationParams,
+  CreateNotificationTemplateParams,
+  UpdateNotificationTemplateParams,
+  PageResponse,
+} from '@/types/api';
+
+// ============================================================
+// 通知
+// ============================================================
+
+// 获取通知列表
+export function getNotificationList(
+  params: ListNotificationParams,
+): Promise<PageResponse<Notification>> {
+  return request.get('/notifications', { params });
+}
+
+// 获取未读数量
+export function getUnreadCount(): Promise<{ count: number }> {
+  return request.get('/notifications/unread-count');
+}
+
+// 获取通知详情
+export function getNotificationDetail(id: string): Promise<Notification> {
+  return request.get(`/notifications/${id}`);
+}
+
+// 标记为已读
+export function markAsRead(id: string): Promise<void> {
+  return request.post(`/notifications/${id}/read`);
+}
+
+// 全部标记为已读
+export function markAllAsRead(): Promise<void> {
+  return request.post('/notifications/read-all');
+}
+
+// 删除通知
+export function deleteNotification(id: string): Promise<void> {
+  return request.delete(`/notifications/${id}`);
+}
+
+// ============================================================
+// 通知模板
+// ============================================================
+
+// 获取模板列表
+export function getNotificationTemplateList(params: {
+  page?: number;
+  page_size?: number;
+  type?: number;
+  status?: number;
+}): Promise<PageResponse<NotificationTemplate>> {
+  return request.get('/notifications/templates', { params });
+}
+
+// 获取模板详情
+export function getNotificationTemplateDetail(id: string): Promise<NotificationTemplate> {
+  return request.get(`/notifications/templates/${id}`);
+}
+
+// 创建模板
+export function createNotificationTemplate(
+  data: CreateNotificationTemplateParams,
+): Promise<NotificationTemplate> {
+  return request.post('/notifications/templates', data);
+}
+
+// 更新模板
+export function updateNotificationTemplate(
+  id: string,
+  data: UpdateNotificationTemplateParams,
+): Promise<NotificationTemplate> {
+  return request.put(`/notifications/templates/${id}`, data);
+}
+
+// 删除模板
+export function deleteNotificationTemplate(id: string): Promise<void> {
+  return request.delete(`/notifications/templates/${id}`);
+}

--- a/frontend/src/api/request.ts
+++ b/frontend/src/api/request.ts
@@ -1,15 +1,19 @@
-import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosError } from 'axios';
 import { message } from 'antd';
 import { getToken, getRefreshToken, setToken, setRefreshToken, removeToken } from '@/utils/storage';
+import { handleApiError } from './error';
 
 const baseURL = import.meta.env.VITE_API_BASE_URL || '/api/v1';
 
 const request: AxiosInstance = axios.create({
   baseURL,
   timeout: 30000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
 });
 
-// 生成请求ID
+// 生成请求 ID
 const generateRequestId = (): string => {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;
@@ -17,6 +21,44 @@ const generateRequestId = (): string => {
     return v.toString(16);
   });
 };
+
+/**
+ * 创建请求取消控制器
+ *
+ * @example
+ * ```ts
+ * const { controller, signal } = createCancelToken();
+ * // 发起请求
+ * getUserList(params, signal);
+ * // 取消请求
+ * controller.abort();
+ * ```
+ */
+export function createCancelToken(): {
+  controller: AbortController;
+  signal: AbortSignal;
+} {
+  const controller = new AbortController();
+  return { controller, signal: controller.signal };
+}
+
+// GET 请求失败自动重试次数
+const GET_RETRY_COUNT = 1;
+// 重试延迟（ms）
+const RETRY_DELAY = 500;
+
+// 判断是否为重试条件：网络错误或 5xx 且是 GET 请求
+function shouldRetry(config: InternalAxiosRequestConfig, status?: number): boolean {
+  if (config.method?.toUpperCase() !== 'GET') return false;
+  const retryCount = (config as { _retryCount?: number })._retryCount ?? 0;
+  if (retryCount >= GET_RETRY_COUNT) return false;
+  // 网络错误（无 status）或 5xx 服务端错误时重试
+  return !status || status >= 500;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 // 请求拦截器
 request.interceptors.request.use(
@@ -53,11 +95,11 @@ request.interceptors.response.use(
     message.error(msg || '请求失败');
     return Promise.reject(new Error(msg || '请求失败'));
   },
-  async (error) => {
-    const originalRequest = error.config;
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig;
 
+    // 处理 401 Token 过期
     if (error.response?.status === 401) {
-      // Token 过期
       if (!isRefreshing) {
         isRefreshing = true;
 
@@ -67,7 +109,7 @@ request.interceptors.response.use(
             throw new Error('无 refresh token');
           }
 
-          // 调用刷新 Token 接口
+          // 调用刷新 Token 接口（用 axios 直接调用，避免走拦截器循环）
           const response = await axios.post(`${baseURL}/auth/refresh`, {
             refresh_token: refreshToken,
           });
@@ -103,8 +145,16 @@ request.interceptors.response.use(
       }
     }
 
-    // 其他错误
-    const errorMsg = error.response?.data?.message || error.message || '网络错误';
+    // GET 请求失败重试
+    if (shouldRetry(originalRequest, error.response?.status)) {
+      const retryCount = (originalRequest as { _retryCount?: number })._retryCount ?? 0;
+      (originalRequest as { _retryCount?: number })._retryCount = retryCount + 1;
+      await delay(RETRY_DELAY);
+      return request(originalRequest);
+    }
+
+    // 其他错误：统一错误处理
+    const errorMsg = handleApiError(error);
     message.error(errorMsg);
     return Promise.reject(error);
   }

--- a/frontend/src/api/role.ts
+++ b/frontend/src/api/role.ts
@@ -1,0 +1,55 @@
+import request from './request';
+import type {
+  Role,
+  Permission,
+  CreateRoleParams,
+  UpdateRoleParams,
+  ListRoleParams,
+  PageResponse,
+  Option,
+} from '@/types/api';
+
+// 获取角色列表
+export function getRoleList(params: ListRoleParams): Promise<PageResponse<Role>> {
+  return request.get('/roles', { params });
+}
+
+// 获取角色详情
+export function getRoleDetail(id: string): Promise<Role> {
+  return request.get(`/roles/${id}`);
+}
+
+// 创建角色
+export function createRole(data: CreateRoleParams): Promise<Role> {
+  return request.post('/roles', data);
+}
+
+// 更新角色
+export function updateRole(id: string, data: UpdateRoleParams): Promise<Role> {
+  return request.put(`/roles/${id}`, data);
+}
+
+// 删除角色
+export function deleteRole(id: string): Promise<void> {
+  return request.delete(`/roles/${id}`);
+}
+
+// 分配权限
+export function assignRolePermissions(roleId: string, permissionIds: string[]): Promise<void> {
+  return request.post(`/roles/${roleId}/permissions`, { permission_ids: permissionIds });
+}
+
+// 获取角色权限列表
+export function getRolePermissions(roleId: string): Promise<Permission[]> {
+  return request.get(`/roles/${roleId}/permissions`);
+}
+
+// 获取角色选项（下拉选择用）
+export function getRoleOptions(): Promise<Option[]> {
+  return request.get('/roles/options');
+}
+
+// 获取全部权限树
+export function getPermissionTree(): Promise<Permission[]> {
+  return request.get('/permissions/tree');
+}

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -1,0 +1,51 @@
+import request from './request';
+import type { DashboardStats, ChartDataPoint, PieChartData } from '@/types/api';
+
+// 获取仪表盘统计
+export function getDashboardStats(): Promise<DashboardStats> {
+  return request.get('/stats/dashboard');
+}
+
+// 获取用户增长趋势
+export function getUserGrowth(params: { start_date: string; end_date: string }): Promise<ChartDataPoint[]> {
+  return request.get('/stats/user-growth', { params });
+}
+
+// 获取会员分布（按部门）
+export function getMemberByDepartment(): Promise<PieChartData[]> {
+  return request.get('/stats/members/by-department');
+}
+
+// 获取任务统计
+export function getTaskStats(params?: { department_id?: string }): Promise<{
+  total: number;
+  pending: number;
+  in_progress: number;
+  completed: number;
+  cancelled: number;
+}> {
+  return request.get('/stats/tasks', { params });
+}
+
+// 获取实习统计排名
+export function getInternshipRanking(params: {
+  top?: number;
+  department_id?: string;
+  start_date?: string;
+  end_date?: string;
+}): Promise<Array<{ user_id: string; username: string; real_name: string; total_hours: number; rank: number }>> {
+  return request.get('/stats/internships/ranking', { params });
+}
+
+// 获取面试通过率统计
+export function getInterviewStats(params?: {
+  start_date?: string;
+  end_date?: string;
+}): Promise<{
+  total: number;
+  passed: number;
+  rejected: number;
+  pass_rate: number;
+}> {
+  return request.get('/stats/interviews', { params });
+}

--- a/frontend/src/api/task.ts
+++ b/frontend/src/api/task.ts
@@ -1,0 +1,64 @@
+import request from './request';
+import type {
+  Task,
+  TaskComment,
+  CreateTaskParams,
+  UpdateTaskParams,
+  ListTaskParams,
+  PageResponse,
+} from '@/types/api';
+
+// 获取任务列表
+export function getTaskList(params: ListTaskParams): Promise<PageResponse<Task>> {
+  return request.get('/tasks', { params });
+}
+
+// 获取我的任务
+export function getMyTasks(params: ListTaskParams): Promise<PageResponse<Task>> {
+  return request.get('/tasks/my', { params });
+}
+
+// 获取我创建的任务
+export function getCreatedTasks(params: ListTaskParams): Promise<PageResponse<Task>> {
+  return request.get('/tasks/created', { params });
+}
+
+// 获取任务详情
+export function getTaskDetail(id: string): Promise<Task> {
+  return request.get(`/tasks/${id}`);
+}
+
+// 创建任务
+export function createTask(data: CreateTaskParams): Promise<Task> {
+  return request.post('/tasks', data);
+}
+
+// 更新任务
+export function updateTask(id: string, data: UpdateTaskParams): Promise<Task> {
+  return request.put(`/tasks/${id}`, data);
+}
+
+// 删除任务
+export function deleteTask(id: string): Promise<void> {
+  return request.delete(`/tasks/${id}`);
+}
+
+// 更新任务状态
+export function updateTaskStatus(id: string, status: number): Promise<Task> {
+  return request.patch(`/tasks/${id}/status`, { status });
+}
+
+// 分配任务
+export function assignTask(id: string, assigneeId: string): Promise<Task> {
+  return request.post(`/tasks/${id}/assign`, { assignee_id: assigneeId });
+}
+
+// 获取任务评论
+export function getTaskComments(taskId: string): Promise<TaskComment[]> {
+  return request.get(`/tasks/${taskId}/comments`);
+}
+
+// 添加任务评论
+export function addTaskComment(taskId: string, content: string): Promise<TaskComment> {
+  return request.post(`/tasks/${taskId}/comments`, { content });
+}

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -1,7 +1,7 @@
 import request from './request';
-import type { UserInfo, PageResponse, PageParams } from '@/types/api';
+import type { UserInfo, PageResponse, ListParams } from '@/types/api';
 
-export interface ListUserParams extends PageParams {
+export interface ListUserParams extends ListParams {
   status?: number;
   department_id?: string;
 }
@@ -57,16 +57,21 @@ export function getUserDetail(id: string): Promise<UserInfo> {
 }
 
 // 创建用户
-export function createUser(params: CreateUserParams): Promise<UserInfo> {
-  return request.post('/users', params);
+export function createUser(data: CreateUserParams): Promise<UserInfo> {
+  return request.post('/users', data);
 }
 
 // 更新用户
-export function updateUser(id: string, params: UpdateUserParams): Promise<UserInfo> {
-  return request.put(`/users/${id}`, params);
+export function updateUser(id: string, data: UpdateUserParams): Promise<UserInfo> {
+  return request.put(`/users/${id}`, data);
 }
 
 // 删除用户
 export function deleteUser(id: string): Promise<void> {
   return request.delete(`/users/${id}`);
+}
+
+// 重置密码
+export function resetUserPassword(id: string, newPassword: string): Promise<void> {
+  return request.post(`/users/${id}/reset-password`, { new_password: newPassword });
 }

--- a/frontend/src/api/workflow.ts
+++ b/frontend/src/api/workflow.ts
@@ -1,0 +1,94 @@
+import request from './request';
+import type {
+  FlowDefinition,
+  FlowInstance,
+  FlowTask,
+  FlowTaskHistory,
+  ListFlowDefinitionParams,
+  ListFlowInstanceParams,
+  ListFlowTaskParams,
+  StartFlowParams,
+  ApproveTaskParams,
+  PageResponse,
+} from '@/types/api';
+
+// ============================================================
+// 流程定义
+// ============================================================
+
+// 获取流程定义列表
+export function getFlowDefinitionList(
+  params: ListFlowDefinitionParams,
+): Promise<PageResponse<FlowDefinition>> {
+  return request.get('/workflow/definitions', { params });
+}
+
+// 获取流程定义详情
+export function getFlowDefinitionDetail(id: string): Promise<FlowDefinition> {
+  return request.get(`/workflow/definitions/${id}`);
+}
+
+// 发布流程
+export function publishFlowDefinition(id: string): Promise<FlowDefinition> {
+  return request.post(`/workflow/definitions/${id}/publish`);
+}
+
+// 停用流程
+export function deactivateFlowDefinition(id: string): Promise<FlowDefinition> {
+  return request.post(`/workflow/definitions/${id}/deactivate`);
+}
+
+// ============================================================
+// 流程实例
+// ============================================================
+
+// 发起流程
+export function startFlow(data: StartFlowParams): Promise<FlowInstance> {
+  return request.post('/workflow/instances/start', data);
+}
+
+// 获取流程实例列表
+export function getFlowInstanceList(
+  params: ListFlowInstanceParams,
+): Promise<PageResponse<FlowInstance>> {
+  return request.get('/workflow/instances', { params });
+}
+
+// 获取我发起的流程
+export function getMyFlowInstances(params: ListFlowInstanceParams): Promise<PageResponse<FlowInstance>> {
+  return request.get('/workflow/instances/my', { params });
+}
+
+// 获取流程实例详情
+export function getFlowInstanceDetail(id: string): Promise<FlowInstance> {
+  return request.get(`/workflow/instances/${id}`);
+}
+
+// 获取流程实例历史
+export function getFlowInstanceHistory(instanceId: string): Promise<FlowTaskHistory[]> {
+  return request.get(`/workflow/instances/${instanceId}/history`);
+}
+
+// ============================================================
+// 流程任务
+// ============================================================
+
+// 获取待办任务
+export function getMyTodoTasks(params: ListFlowTaskParams): Promise<PageResponse<FlowTask>> {
+  return request.get('/workflow/tasks/todo', { params });
+}
+
+// 获取已办任务
+export function getMyDoneTasks(params: ListFlowTaskParams): Promise<PageResponse<FlowTask>> {
+  return request.get('/workflow/tasks/done', { params });
+}
+
+// 获取任务详情
+export function getFlowTaskDetail(id: string): Promise<FlowTask> {
+  return request.get(`/workflow/tasks/${id}`);
+}
+
+// 审批任务
+export function approveFlowTask(data: ApproveTaskParams): Promise<void> {
+  return request.post('/workflow/tasks/approve', data);
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,5 +1,9 @@
-// API 响应通用类型
-export interface ApiResponse<T = any> {
+// ============================================================
+// 通用响应/请求类型
+// ============================================================
+
+/** 统一 API 响应 */
+export interface ApiResponse<T = unknown> {
   code: number;
   message: string;
   data: T;
@@ -7,7 +11,7 @@ export interface ApiResponse<T = any> {
   timestamp: number;
 }
 
-// 分页响应
+/** 分页响应 */
 export interface PageResponse<T> {
   list: T[];
   total: number;
@@ -15,14 +19,53 @@ export interface PageResponse<T> {
   page_size: number;
 }
 
-// 分页请求参数
-export interface PageParams {
+/** 列表查询参数（支持模块扩展） */
+export interface ListParams {
   page?: number;
   page_size?: number;
   keyword?: string;
+  [key: string]: unknown;
 }
 
-// 用户信息
+/** 通用选项（下拉选择） */
+export interface Option {
+  label: string;
+  value: string | number;
+  color?: string;
+}
+
+/** 操作结果 */
+export interface OperationResult<T = unknown> {
+  success: boolean;
+  message?: string;
+  data?: T;
+}
+
+// ============================================================
+// 用户 & 认证
+// ============================================================
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  username: string;
+  password: string;
+  real_name?: string;
+  email?: string;
+  phone?: string;
+}
+
+export interface LoginResponse {
+  access_token: string;
+  refresh_token: string;
+  access_token_expires: number;
+  refresh_token_expires: number;
+  user: UserInfo;
+}
+
 export interface UserInfo {
   id: string;
   username: string;
@@ -39,33 +82,712 @@ export interface UserInfo {
   created_at: string;
 }
 
-// 角色信息
+export interface UserListItem {
+  id: string;
+  username: string;
+  real_name: string;
+  avatar_url: string;
+  email: string;
+  phone: string;
+  gender: number;
+  status: number;
+  department_id: string;
+  department_name: string;
+  position_id: string;
+  position_name: string;
+  last_login_at: string;
+  created_at: string;
+}
+
+export interface CreateUserParams {
+  username: string;
+  password: string;
+  real_name?: string;
+  email?: string;
+  phone?: string;
+  gender?: number;
+  department_id?: string;
+  position_id?: string;
+  role_ids?: string[];
+}
+
+export interface UpdateUserParams {
+  real_name?: string;
+  email?: string;
+  phone?: string;
+  gender?: number;
+  status?: number;
+  department_id?: string;
+  position_id?: string;
+  role_ids?: string[];
+}
+
+export interface ListUserParams extends ListParams {
+  status?: number;
+  department_id?: string;
+}
+
+// ============================================================
+// 角色 & 权限
+// ============================================================
+
 export interface RoleInfo {
   id: string;
   name: string;
   code: string;
 }
 
-// 登录响应
-export interface LoginResponse {
-  access_token: string;
-  refresh_token: string;
-  access_token_expires: number;
-  refresh_token_expires: number;
-  user: UserInfo;
+export interface Role {
+  id: string;
+  name: string;
+  code: string;
+  sort: number;
+  status: number;
+  description?: string;
+  permissions: string[];
+  created_at: string;
+  updated_at: string;
 }
 
-// 登录请求
-export interface LoginRequest {
-  username: string;
-  password: string;
+export interface Permission {
+  id: string;
+  name: string;
+  code: string;
+  type: number; // 1=菜单 2=按钮 3=接口
+  parent_id?: string;
+  sort: number;
+  icon?: string;
+  path?: string;
+  created_at: string;
 }
 
-// 注册请求
-export interface RegisterRequest {
+export interface CreateRoleParams {
+  name: string;
+  code: string;
+  sort?: number;
+  status?: number;
+  description?: string;
+  permission_ids?: string[];
+}
+
+export interface UpdateRoleParams {
+  name?: string;
+  code?: string;
+  sort?: number;
+  status?: number;
+  description?: string;
+  permission_ids?: string[];
+}
+
+export interface ListRoleParams extends ListParams {
+  status?: number;
+}
+
+// ============================================================
+// 部门
+// ============================================================
+
+export interface Department {
+  id: string;
+  name: string;
+  code: string;
+  parent_id?: string;
+  sort: number;
+  status: number;
+  leader_id?: string;
+  description?: string;
+  children?: Department[];
+  created_at: string;
+}
+
+export interface CreateDepartmentParams {
+  name: string;
+  code: string;
+  parent_id?: string;
+  sort?: number;
+  status?: number;
+  leader_id?: string;
+  description?: string;
+}
+
+export interface UpdateDepartmentParams {
+  name?: string;
+  code?: string;
+  parent_id?: string;
+  sort?: number;
+  status?: number;
+  leader_id?: string;
+  description?: string;
+}
+
+// ============================================================
+// 会员
+// ============================================================
+
+export type MemberApplicationStatus = 0 | 1 | 2 | 3 | 4 | 5;
+// 0=待审核 1=一面中 2=二面中 3=已通过 4=已拒绝 5=已取消
+
+export interface MemberApplication {
+  id: string;
+  user_id: string;
   username: string;
-  password: string;
-  real_name?: string;
-  email?: string;
-  phone?: string;
+  real_name: string;
+  type: number; // 1=会员 2=干事
+  department_id?: string;
+  department_name?: string;
+  reason: string;
+  status: MemberApplicationStatus;
+  current_stage?: string;
+  submitted_at: string;
+  reviewed_at?: string;
+  reviewer_id?: string;
+  reviewer_name?: string;
+}
+
+export interface MemberProfile {
+  id: string;
+  user_id: string;
+  username: string;
+  real_name: string;
+  avatar_url: string;
+  member_type: number; // 1=会员 2=干事
+  department_id?: string;
+  department_name?: string;
+  position_id?: string;
+  position_name?: string;
+  join_date: string;
+  status: number;
+  points: number;
+  created_at: string;
+}
+
+export interface CreateMemberApplicationParams {
+  type: number;
+  department_id?: string;
+  reason: string;
+}
+
+export interface ListMemberApplicationParams extends ListParams {
+  status?: MemberApplicationStatus;
+  type?: number;
+  department_id?: string;
+}
+
+export interface ListMemberParams extends ListParams {
+  status?: number;
+  member_type?: number;
+  department_id?: string;
+}
+
+// ============================================================
+// 面试
+// ============================================================
+
+export type InterviewStatus = 0 | 1 | 2 | 3;
+// 0=待安排 1=已安排 2=进行中 3=已完成
+
+export interface Interview {
+  id: string;
+  application_id: string;
+  applicant_name: string;
+  round: number; // 第几轮
+  type: number; // 1=技术面 2=综合面 3=HR面
+  status: InterviewStatus;
+  interviewer_ids: string[];
+  interviewer_names: string[];
+  scheduled_at?: string;
+  location?: string;
+  duration?: number; // 分钟
+  score?: number;
+  result?: string;
+  notes?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InterviewEvaluation {
+  id: string;
+  interview_id: string;
+  interviewer_id: string;
+  interviewer_name: string;
+  score: number;
+  comment: string;
+  recommendation: number; // 1=强烈推荐 2=推荐 3=待定 4=不推荐
+  created_at: string;
+}
+
+export interface CreateInterviewParams {
+  application_id: string;
+  round: number;
+  type: number;
+  interviewer_ids: string[];
+  scheduled_at?: string;
+  location?: string;
+  duration?: number;
+}
+
+export interface UpdateInterviewParams {
+  status?: InterviewStatus;
+  interviewer_ids?: string[];
+  scheduled_at?: string;
+  location?: string;
+  duration?: number;
+  result?: string;
+  notes?: string;
+}
+
+export interface ListInterviewParams extends ListParams {
+  status?: InterviewStatus;
+  round?: number;
+  type?: number;
+  application_id?: string;
+}
+
+// ============================================================
+// 会议 & 投票
+// ============================================================
+
+export type MeetingStatus = 0 | 1 | 2 | 3;
+// 0=草稿 1=已发布 2=进行中 3=已结束
+
+export interface Meeting {
+  id: string;
+  title: string;
+  description?: string;
+  status: MeetingStatus;
+  meeting_type: number; // 1=例会 2=临时会议 3=线上
+  start_time: string;
+  end_time: string;
+  location?: string;
+  organizer_id: string;
+  organizer_name: string;
+  participant_ids: string[];
+  participant_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MeetingAgenda {
+  id: string;
+  meeting_id: string;
+  title: string;
+  description?: string;
+  sort: number;
+  duration?: number;
+  speaker_id?: string;
+  speaker_name?: string;
+}
+
+export type VoteStatus = 0 | 1 | 2;
+// 0=未开始 1=进行中 2=已结束
+
+export interface MeetingVote {
+  id: string;
+  meeting_id: string;
+  title: string;
+  description?: string;
+  vote_type: number; // 1=等权投票 2=加权投票
+  status: VoteStatus;
+  is_anonymous: boolean;
+  options: VoteOption[];
+  total_votes: number;
+  start_time?: string;
+  end_time?: string;
+  created_at: string;
+}
+
+export interface VoteOption {
+  id: string;
+  text: string;
+  count: number;
+  weight?: number;
+}
+
+export interface VoteRecord {
+  id: string;
+  vote_id: string;
+  voter_id: string;
+  voter_name: string;
+  option_id: string;
+  voted_at: string;
+}
+
+export interface CreateMeetingParams {
+  title: string;
+  description?: string;
+  meeting_type: number;
+  start_time: string;
+  end_time: string;
+  location?: string;
+  participant_ids: string[];
+  agendas?: Array<{ title: string; description?: string; sort: number }>;
+}
+
+export interface UpdateMeetingParams {
+  title?: string;
+  description?: string;
+  status?: MeetingStatus;
+  meeting_type?: number;
+  start_time?: string;
+  end_time?: string;
+  location?: string;
+  participant_ids?: string[];
+}
+
+export interface ListMeetingParams extends ListParams {
+  status?: MeetingStatus;
+  meeting_type?: number;
+}
+
+export interface CreateVoteParams {
+  meeting_id: string;
+  title: string;
+  description?: string;
+  vote_type: number;
+  is_anonymous: boolean;
+  options: string[];
+  start_time?: string;
+  end_time?: string;
+}
+
+// ============================================================
+// 任务
+// ============================================================
+
+export type TaskStatus = 0 | 1 | 2 | 3 | 4;
+// 0=待处理 1=进行中 2=待审核 3=已完成 4=已取消
+
+export type TaskPriority = 0 | 1 | 2 | 3;
+// 0=低 1=中 2=高 3=紧急
+
+export interface Task {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  creator_id: string;
+  creator_name: string;
+  assignee_id?: string;
+  assignee_name?: string;
+  department_id?: string;
+  department_name?: string;
+  due_date?: string;
+  progress: number; // 0-100
+  tags?: string[];
+  related_type?: string;
+  related_id?: string;
+  created_at: string;
+  updated_at: string;
+  completed_at?: string;
+}
+
+export interface TaskComment {
+  id: string;
+  task_id: string;
+  author_id: string;
+  author_name: string;
+  content: string;
+  created_at: string;
+}
+
+export interface CreateTaskParams {
+  title: string;
+  description?: string;
+  priority?: TaskPriority;
+  assignee_id?: string;
+  department_id?: string;
+  due_date?: string;
+  tags?: string[];
+  related_type?: string;
+  related_id?: string;
+}
+
+export interface UpdateTaskParams {
+  title?: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assignee_id?: string;
+  department_id?: string;
+  due_date?: string;
+  progress?: number;
+  tags?: string[];
+}
+
+export interface ListTaskParams extends ListParams {
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assignee_id?: string;
+  creator_id?: string;
+  department_id?: string;
+}
+
+// ============================================================
+// 实习
+// ============================================================
+
+export interface InternshipRecord {
+  id: string;
+  user_id: string;
+  username: string;
+  real_name: string;
+  department_id?: string;
+  department_name?: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  duration: number; // 小时
+  task_description: string;
+  status: number; // 0=待审核 1=已通过 2=已拒绝
+  reviewer_id?: string;
+  reviewer_name?: string;
+  reviewed_at?: string;
+  created_at: string;
+}
+
+export interface InternshipStats {
+  user_id: string;
+  username: string;
+  real_name: string;
+  total_hours: number;
+  total_days: number;
+  rank: number;
+}
+
+export interface CreateInternshipParams {
+  date: string;
+  start_time: string;
+  end_time: string;
+  task_description: string;
+  department_id?: string;
+}
+
+export interface UpdateInternshipParams {
+  status?: number;
+  review_comment?: string;
+}
+
+export interface ListInternshipParams extends ListParams {
+  user_id?: string;
+  status?: number;
+  department_id?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+// ============================================================
+// 通知
+// ============================================================
+
+export type NotificationType = 1 | 2 | 3 | 4;
+// 1=系统通知 2=任务通知 3=会议通知 4=审核通知
+
+export interface Notification {
+  id: string;
+  title: string;
+  content: string;
+  type: NotificationType;
+  is_read: boolean;
+  sender_id?: string;
+  sender_name?: string;
+  related_type?: string;
+  related_id?: string;
+  created_at: string;
+}
+
+export interface NotificationTemplate {
+  id: string;
+  name: string;
+  code: string;
+  title_template: string;
+  content_template: string;
+  type: number;
+  variables: string[];
+  status: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListNotificationParams extends ListParams {
+  type?: NotificationType;
+  is_read?: boolean;
+}
+
+export interface CreateNotificationTemplateParams {
+  name: string;
+  code: string;
+  title_template: string;
+  content_template: string;
+  type: number;
+  variables?: string[];
+}
+
+export interface UpdateNotificationTemplateParams {
+  name?: string;
+  title_template?: string;
+  content_template?: string;
+  status?: number;
+  variables?: string[];
+}
+
+// ============================================================
+// 流程引擎
+// ============================================================
+
+export type FlowDefinitionStatus = 0 | 1 | 2;
+// 0=草稿 1=已发布 2=已停用
+
+export type FlowInstanceStatus = 0 | 1 | 2 | 3;
+// 0=进行中 1=已完成 2=已驳回 3=已取消
+
+export interface FlowDefinition {
+  id: string;
+  name: string;
+  code: string;
+  description?: string;
+  status: FlowDefinitionStatus;
+  version: number;
+  category?: string;
+  icon?: string;
+  form_schema?: string;
+  process_definition?: string;
+  created_by: string;
+  created_by_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface FlowInstance {
+  id: string;
+  definition_id: string;
+  definition_name: string;
+  business_key?: string;
+  status: FlowInstanceStatus;
+  initiator_id: string;
+  initiator_name: string;
+  current_task_id?: string;
+  current_task_name?: string;
+  started_at: string;
+  ended_at?: string;
+  form_data?: Record<string, unknown>;
+}
+
+export interface FlowTask {
+  id: string;
+  instance_id: string;
+  definition_id: string;
+  node_id: string;
+  node_name: string;
+  task_type: number; // 1=用户任务 2=审批任务
+  status: number; // 0=待处理 1=已处理 2=已跳过
+  assignee_id?: string;
+  assignee_name?: string;
+  assignee_type?: number; // 1=用户 2=角色 3=部门
+  created_at: string;
+  completed_at?: string;
+}
+
+export interface FlowTaskHistory {
+  id: string;
+  task_id: string;
+  instance_id: string;
+  node_id: string;
+  node_name: string;
+  action: string; // approve/reject/transfer/comment
+  operator_id: string;
+  operator_name: string;
+  comment?: string;
+  created_at: string;
+}
+
+export interface ListFlowDefinitionParams extends ListParams {
+  status?: FlowDefinitionStatus;
+  category?: string;
+}
+
+export interface ListFlowInstanceParams extends ListParams {
+  definition_id?: string;
+  status?: FlowInstanceStatus;
+  initiator_id?: string;
+}
+
+export interface ListFlowTaskParams extends ListParams {
+  status?: number;
+  assignee_id?: string;
+  definition_id?: string;
+}
+
+export interface StartFlowParams {
+  definition_id: string;
+  business_key?: string;
+  form_data?: Record<string, unknown>;
+}
+
+export interface ApproveTaskParams {
+  task_id: string;
+  action: 'approve' | 'reject' | 'transfer';
+  comment?: string;
+  target_user_id?: string; // 转交时
+}
+
+// ============================================================
+// 文件
+// ============================================================
+
+export interface FileInfo {
+  id: string;
+  name: string;
+  original_name: string;
+  size: number;
+  mime_type: string;
+  storage_type: number; // 1=本地 2=MinIO
+  bucket?: string;
+  path: string;
+  url: string;
+  uploader_id: string;
+  uploader_name: string;
+  created_at: string;
+}
+
+export interface UploadResult {
+  id: string;
+  name: string;
+  url: string;
+  size: number;
+}
+
+export interface ListFileParams extends ListParams {
+  uploader_id?: string;
+  mime_type?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+// ============================================================
+// 统计
+// ============================================================
+
+export interface DashboardStats {
+  total_users: number;
+  total_members: number;
+  total_tasks: number;
+  pending_tasks: number;
+  total_applications: number;
+  pending_applications: number;
+  total_interviews: number;
+  today_interviews: number;
+  total_meetings: number;
+  week_meetings: number;
+}
+
+export interface ChartDataPoint {
+  label: string;
+  value: number;
+}
+
+export interface PieChartData {
+  name: string;
+  value: number;
+  color?: string;
 }


### PR DESCRIPTION
## 概述

实现 Issue #21：前端 API 层封装与类型定义。完善请求拦截器、统一错误处理、全模块类型定义与 API 封装，为后续业务模块开发提供类型安全的 API 调用层。

## 改动清单

### 新增文件（12 个）

| 文件 | 说明 |
|------|------|
| `src/api/error.ts` | 统一错误处理工具：错误码中文映射、HTTP 状态码消息、网络错误识别 |
| `src/api/role.ts` | 角色 API：CRUD + 权限分配 + 选项 + 权限树 |
| `src/api/department.ts` | 部门 API：树形结构 + CRUD + 选项 |
| `src/api/member.ts` | 会员 API：入会申请（提交/审核/取消）+ 会员档案 |
| `src/api/interview.ts` | 面试 API：CRUD + 评分提交 |
| `src/api/meeting.ts` | 会议 API：CRUD + 议程 + 投票（创建/提交/记录）|
| `src/api/task.ts` | 任务 API：CRUD + 状态流转 + 分配 + 评论 |
| `src/api/internship.ts` | 实习 API：CRUD + 审核 + 统计排名 |
| `src/api/notification.ts` | 通知 API：列表/已读/删除 + 模板管理 |
| `src/api/workflow.ts` | 流程 API：定义 + 实例 + 任务（待办/已办/审批）|
| `src/api/file.ts` | 文件 API：列表 + 上传（支持进度） + 删除 |
| `src/api/stats.ts` | 统计 API：仪表盘 + 增长趋势 + 分布 + 排名 |

### 修改文件（4 个）

| 文件 | 改动说明 |
|------|----------|
| `src/api/request.ts` | 新增 `createCancelToken()` 请求取消、GET 失败自动重试 1 次（500ms 延迟）、`Content-Type` 头、错误处理走 `handleApiError` |
| `src/types/api.ts` | 从 70 行扩展至 794 行，覆盖全部 12 个模块的完整类型定义，消除 `any` 类型 |
| `src/api/auth.ts` | 修正当前用户接口路径为 `/auth/me`（与 RESTful 规范一致）|
| `src/api/user.ts` | `PageParams` → `ListParams` 类型对齐，新增 `resetUserPassword` 接口 |

## 设计要点

### request.ts 增强

```
请求拦截器：
  X-Request-ID → 生成 UUID
  Authorization → 自动携带 Bearer Token

响应拦截器（成功）：
  code === 0 → 直接返回 data
  code !== 0 → 业务错误，message.error + reject

响应拦截器（失败）：
  401 → Token 刷新队列机制（单例刷新 + 队列等待 + 失败跳登录）
  GET + (网络错误 or 5xx) + 未超限 → 延迟 500ms 重试 1 次
  其他错误 → handleApiError 提取消息 + message.error
```

### 错误处理层级

```
handleApiError(error): string
  ├─ 后端返回 message → 直接使用（最高优先级）
  ├─ 错误码映射 → errorCodeMessages 查表（30+ 业务错误码）
  ├─ HTTP 状态码 → 通用消息（400/401/403/404/408/429/500/502/503/504）
  ├─ 网络错误 → ECONNABORTED=超时 / ERR_NETWORK=网络连接失败
  └─ 兜底 → "请求失败"
```

### 类型定义组织

按模块分组，使用注释分隔线清晰划分：
- 通用类型：`ApiResponse` / `PageResponse` / `ListParams` / `Option` / `OperationResult`
- 用户 & 认证
- 角色 & 权限
- 部门
- 会员
- 面试
- 会议 & 投票
- 任务
- 实习
- 通知
- 流程引擎
- 文件
- 统计

## 验证

- `npm run lint` → 0 errors, 12 warnings（均为既有文件的 any 警告，新增文件零警告）
- `npm run build` → TypeScript 编译通过，Vite 生产构建成功

## 关联 Issue

Closes #21