### PR TITLE
feat(notification): 实现消息通知系统（站内 + WebSocket + 邮件）(#4)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -164,7 +164,7 @@ func main() {
 	tplSvc := notifService.NewTemplateService(tplRepo, tplEngine)
 
 	// 事件总线监听器：监听业务事件并自动发送通知
-	eventListener := notifService.NewEventListener(notifR, tplRepo, tplEngine, channelRegistry, hub)
+	eventListener := notifService.NewEventListener(tplRepo, tplEngine, channelRegistry)
 	eventListener.RegisterAll(eventBus)
 
 	// 通知处理器

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -12,6 +12,10 @@ import (
 	authHandler "github.com/Yogdunana/StarByte/backend/internal/auth/handler"
 	authRepo "github.com/Yogdunana/StarByte/backend/internal/auth/repo"
 	authService "github.com/Yogdunana/StarByte/backend/internal/auth/service"
+	notifHandler "github.com/Yogdunana/StarByte/backend/internal/notification/handler"
+	notifModel "github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	notifRepo "github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	notifService "github.com/Yogdunana/StarByte/backend/internal/notification/service"
 	rbacHandler "github.com/Yogdunana/StarByte/backend/internal/rbac/handler"
 	rbacRepo "github.com/Yogdunana/StarByte/backend/internal/rbac/repo"
 	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
@@ -71,6 +75,11 @@ func main() {
 	// 3b. 自动迁移工作流引擎表
 	if err := workflow.AutoMigrate(database.DB()); err != nil {
 		logger.Fatal("auto migrate workflow tables failed", zap.Error(err))
+	}
+
+	// 3c. 自动迁移通知模块表
+	if err := database.DB().AutoMigrate(&notifModel.Notification{}, &notifModel.NotificationTemplate{}); err != nil {
+		logger.Fatal("auto migrate notification tables failed", zap.Error(err))
 	}
 
 	// 4. 初始化 Redis
@@ -137,6 +146,32 @@ func main() {
 	eventBus := events.NewEventBus()
 	wfHandlers := workflow.Init(database.DB(), eventBus, logger.GetLogger())
 
+	// 通知模块
+	notifR := notifRepo.NewNotificationRepo(database.DB())
+	tplRepo := notifRepo.NewTemplateRepo(database.DB())
+
+	hub := notifService.NewHub()
+	channelRegistry := notifService.NewChannelRegistry()
+	channelRegistry.Register(notifService.NewInAppChannel(notifR))
+	channelRegistry.Register(notifService.NewEmailChannel(
+		cfg.Email.SMTPHost, cfg.Email.SMTPPort,
+		cfg.Email.Username, cfg.Email.Password, cfg.Email.From,
+	))
+	channelRegistry.Register(notifService.NewWebSocketChannel(hub))
+
+	tplEngine := notifService.NewTemplateEngine(tplRepo)
+	notifSvc := notifService.NewNotificationService(notifR, tplRepo, tplEngine, channelRegistry)
+	tplSvc := notifService.NewTemplateService(tplRepo, tplEngine)
+
+	// 事件总线监听器：监听业务事件并自动发送通知
+	eventListener := notifService.NewEventListener(notifR, tplRepo, tplEngine, channelRegistry, hub)
+	eventListener.RegisterAll(eventBus)
+
+	// 通知处理器
+	notificationHandler := notifHandler.NewNotificationHandler(notifSvc, hub)
+	templateHandler := notifHandler.NewTemplateHandler(tplSvc)
+	wsHandler := notifHandler.NewWSHandler(hub, &cfg.JWT)
+
 	// 10. API 路由组
 	api := r.Group("/api/v1")
 	// API 组限流：全局 1000 req/s
@@ -179,7 +214,13 @@ func main() {
 
 		// 工作流引擎模块
 		wfHandler.RegisterRoutes(protected, wfHandlers.Definition, wfHandlers.Instance, wfHandlers.Task)
+
+		// 通知模块路由
+		notifHandler.RegisterRoutes(protected, protected, notificationHandler, templateHandler, wsHandler)
 	}
+
+	// WebSocket 路由（独立于 API 组，JWT 认证在 handler 内部完成）
+	notifHandler.RegisterWSRoute(r, wsHandler)
 
 	// 11. 404 处理
 	r.NoRoute(func(c *gin.Context) {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -170,7 +170,7 @@ func main() {
 	// 通知处理器
 	notificationHandler := notifHandler.NewNotificationHandler(notifSvc, hub)
 	templateHandler := notifHandler.NewTemplateHandler(tplSvc)
-	wsHandler := notifHandler.NewWSHandler(hub, &cfg.JWT)
+	wsHandler := notifHandler.NewWSHandler(hub, &cfg.JWT, cfg.CORS.AllowedOrigins)
 
 	// 10. API 路由组
 	api := r.Group("/api/v1")

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -26,9 +26,11 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-mail/mail v2.3.1+incompatible // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.4.3 // indirect
@@ -52,4 +54,5 @@ require (
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -23,6 +23,8 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.9.1 h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqJ+Jmg=
 github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SUcPTeU=
+github.com/go-mail/mail v2.3.1+incompatible h1:UzNOn0k5lpfVtO31cK3hn6I4VEVGhe3lX8AJBAxXExM=
+github.com/go-mail/mail v2.3.1+incompatible/go.mod h1:VPWjmmNyRsWXQZHVHT3g0YbIINUkSmuKOiLIDkWbL6M=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -41,6 +43,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
@@ -118,6 +122,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/backend/internal/notification/dto/notification.go
+++ b/backend/internal/notification/dto/notification.go
@@ -1,0 +1,122 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ========== Notification DTOs ==========
+
+// NotificationResponse 通知响应
+type NotificationResponse struct {
+	ID        string     `json:"id"`
+	Title     string     `json:"title"`
+	Content   string     `json:"content"`
+	Category  string     `json:"category"`
+	Priority  string     `json:"priority"`
+	IsRead    bool       `json:"is_read"`
+	ActionURL string     `json:"action_url"`
+	Sender    SenderInfo `json:"sender"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// SenderInfo 发送者信息
+type SenderInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ListNotificationsRequest 通知列表请求
+type ListNotificationsRequest struct {
+	Page       int    `form:"page" json:"page"`
+	PageSize   int    `form:"page_size" json:"page_size"`
+	Category   string `form:"category" json:"category"`
+	UnreadOnly bool   `form:"unread_only" json:"unread_only"`
+}
+
+// UnreadCountResponse 未读计数响应
+type UnreadCountResponse struct {
+	Count int64 `json:"count"`
+}
+
+// MarkAllReadRequest 全部已读请求
+type MarkAllReadRequest struct {
+	Category string `json:"category"` // 可选：按分类标记已读
+}
+
+// ========== Notification Template DTOs ==========
+
+// NotificationTemplateResponse 模板响应
+type NotificationTemplateResponse struct {
+	ID              string            `json:"id"`
+	Code            string            `json:"code"`
+	Name            string            `json:"name"`
+	TitleTemplate   string            `json:"title_template"`
+	BodyTemplate    string            `json:"body_template"`
+	Channels        []string          `json:"channels"`
+	Category        string            `json:"category"`
+	VariablesSchema map[string]string `json:"variables_schema"`
+	Status          int               `json:"status"`
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+}
+
+// CreateTemplateRequest 创建模板请求
+type CreateTemplateRequest struct {
+	Code            string            `json:"code" binding:"required"`
+	Name            string            `json:"name" binding:"required"`
+	TitleTemplate   string            `json:"title_template" binding:"required"`
+	BodyTemplate    string            `json:"body_template" binding:"required"`
+	Channels        []string          `json:"channels" binding:"required"`
+	Category        string            `json:"category"`
+	VariablesSchema map[string]string `json:"variables_schema"`
+}
+
+// UpdateTemplateRequest 更新模板请求
+type UpdateTemplateRequest struct {
+	Name            *string           `json:"name"`
+	TitleTemplate   *string           `json:"title_template"`
+	BodyTemplate    *string           `json:"body_template"`
+	Channels        []string          `json:"channels"`
+	Category        *string           `json:"category"`
+	VariablesSchema map[string]string `json:"variables_schema"`
+	Status          *int              `json:"status"`
+}
+
+// TestTemplateRequest 测试模板请求
+type TestTemplateRequest struct {
+	Variables map[string]interface{} `json:"variables"`
+}
+
+// TestTemplateResponse 测试模板响应
+type TestTemplateResponse struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+// ========== Admin Send Notification DTOs ==========
+
+// SendNotificationRequest 发送通知请求
+type SendNotificationRequest struct {
+	UserIDs      []uuid.UUID            `json:"user_ids" binding:"required,min=1"`
+	TemplateCode string                 `json:"template_code" binding:"required"`
+	Variables    map[string]interface{} `json:"variables"`
+	Channels     []string               `json:"channels"` // 可选：覆盖模板渠道
+}
+
+// BroadcastNotificationRequest 广播通知请求
+type BroadcastNotificationRequest struct {
+	Title    string   `json:"title" binding:"required"`
+	Content  string   `json:"content" binding:"required"`
+	Category string   `json:"category"`
+	Priority string   `json:"priority"`
+	Channels []string `json:"channels"`
+}
+
+// ListTemplatesRequest 模板列表请求
+type ListTemplatesRequest struct {
+	Page     int    `form:"page" json:"page"`
+	PageSize int    `form:"page_size" json:"page_size"`
+	Keyword  string `form:"keyword" json:"keyword"`
+}

--- a/backend/internal/notification/handler/notification_handler.go
+++ b/backend/internal/notification/handler/notification_handler.go
@@ -1,0 +1,246 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	authmiddleware "github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// NotificationHandler 通知相关 HTTP 处理器
+type NotificationHandler struct {
+	notificationService service.NotificationService
+	hubManager          service.HubManager
+}
+
+// NewNotificationHandler 创建通知处理器
+func NewNotificationHandler(notificationService service.NotificationService, hubManager service.HubManager) *NotificationHandler {
+	return &NotificationHandler{
+		notificationService: notificationService,
+		hubManager:          hubManager,
+	}
+}
+
+// List GET /api/v1/notifications
+// @Summary 通知列表（分页）
+// @Description 获取当前用户的通知列表，支持分类筛选和未读筛选
+// @Tags 通知
+// @Produce json
+// @Security Bearer
+// @Param page query int false "页码"
+// @Param page_size query int false "每页条数"
+// @Param category query string false "分类"
+// @Param unread_only query bool false "仅未读"
+// @Success 200 {object} response.Response
+// @Router /notifications [get]
+func (h *NotificationHandler) List(c *gin.Context) {
+	userID := getUserID(c)
+
+	var req dto.ListNotificationsRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+
+	list, total, err := h.notificationService.ListByUser(c.Request.Context(), userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	result := make([]*dto.NotificationResponse, 0, len(list))
+	for _, n := range list {
+		result = append(result, notificationToResponse(n))
+	}
+
+	response.Page(c, result, total, req.Page, req.PageSize)
+}
+
+// UnreadCount GET /api/v1/notifications/unread/count
+// @Summary 未读通知计数
+// @Description 获取当前用户的未读通知数量
+// @Tags 通知
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} response.Response
+// @Router /notifications/unread/count [get]
+func (h *NotificationHandler) UnreadCount(c *gin.Context) {
+	userID := getUserID(c)
+
+	count, err := h.notificationService.GetUnreadCount(c.Request.Context(), userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, &dto.UnreadCountResponse{Count: count})
+}
+
+// MarkAsRead POST /api/v1/notifications/:id/read
+// @Summary 标记通知已读
+// @Description 标记指定通知为已读
+// @Tags 通知
+// @Produce json
+// @Security Bearer
+// @Param id path string true "通知 ID"
+// @Success 200 {object} response.Response
+// @Router /notifications/{id}/read [post]
+func (h *NotificationHandler) MarkAsRead(c *gin.Context) {
+	userID := getUserID(c)
+
+	idStr := c.Param("id")
+	notificationID, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的通知 ID")
+		return
+	}
+
+	if err := h.notificationService.MarkAsRead(c.Request.Context(), userID, []uuid.UUID{notificationID}); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// MarkAllAsRead POST /api/v1/notifications/read-all
+// @Summary 全部已读
+// @Description 标记当前用户的所有通知为已读
+// @Tags 通知
+// @Produce json
+// @Security Bearer
+// @Param category body dto.MarkAllReadRequest false "按分类标记已读（可选）"
+// @Success 200 {object} response.Response
+// @Router /notifications/read-all [post]
+func (h *NotificationHandler) MarkAllAsRead(c *gin.Context) {
+	userID := getUserID(c)
+
+	var req dto.MarkAllReadRequest
+	_ = c.ShouldBindJSON(&req)
+
+	if err := h.notificationService.MarkAllAsRead(c.Request.Context(), userID, req.Category); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Delete DELETE /api/v1/notifications/:id
+// @Summary 删除通知
+// @Description 删除指定通知
+// @Tags 通知
+// @Produce json
+// @Security Bearer
+// @Param id path string true "通知 ID"
+// @Success 200 {object} response.Response
+// @Router /notifications/{id} [delete]
+func (h *NotificationHandler) Delete(c *gin.Context) {
+	userID := getUserID(c)
+
+	idStr := c.Param("id")
+	notificationID, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的通知 ID")
+		return
+	}
+
+	if err := h.notificationService.Delete(c.Request.Context(), userID, notificationID); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Send POST /api/v1/system/notifications/send
+// @Summary 发送通知（管理员）
+// @Description 通过模板向指定用户发送通知
+// @Tags 系统管理-通知
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param request body dto.SendNotificationRequest true "发送参数"
+// @Success 200 {object} response.Response
+// @Router /system/notifications/send [post]
+func (h *NotificationHandler) Send(c *gin.Context) {
+	var req dto.SendNotificationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+
+	if err := h.notificationService.Send(c.Request.Context(), &req); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Broadcast POST /api/v1/system/notifications/broadcast
+// @Summary 广播通知（管理员）
+// @Description 向所有在线用户广播通知
+// @Tags 系统管理-通知
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param request body dto.BroadcastNotificationRequest true "广播参数"
+// @Success 200 {object} response.Response
+// @Router /system/notifications/broadcast [post]
+func (h *NotificationHandler) Broadcast(c *gin.Context) {
+	var req dto.BroadcastNotificationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+
+	onlineUserIDs := h.hubManager.GetOnlineUsers()
+	if len(onlineUserIDs) == 0 {
+		response.OKWithoutData(c)
+		return
+	}
+
+	if err := h.notificationService.Broadcast(c.Request.Context(), &req, onlineUserIDs); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// getUserID 从上下文获取用户 ID
+func getUserID(c *gin.Context) uuid.UUID {
+	userIDStr := authmiddleware.GetUserID(c)
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return uuid.Nil
+	}
+	return userID
+}
+
+// notificationToResponse 将通知模型转为响应 DTO
+func notificationToResponse(n *model.Notification) *dto.NotificationResponse {
+	resp := &dto.NotificationResponse{
+		ID:        n.ID.String(),
+		Title:     n.Title,
+		Content:   n.Content,
+		Category:  n.Category,
+		Priority:  n.Priority,
+		IsRead:    n.IsRead,
+		ActionURL: n.ActionURL,
+		CreatedAt: n.CreatedAt,
+	}
+
+	if n.SenderID != nil {
+		resp.Sender = dto.SenderInfo{
+			ID:   n.SenderID.String(),
+			Name: n.SenderName,
+		}
+	}
+
+	return resp
+}

--- a/backend/internal/notification/handler/routes.go
+++ b/backend/internal/notification/handler/routes.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterRoutes 注册通知模块路由
+// protected: 需要鉴权的用户路由
+// systemProtected: 需要鉴权+权限校验的管理员路由
+// wsHandler: WebSocket 连接处理器（注册在 /ws 路径下，独立于 API 组）
+func RegisterRoutes(
+	protected *gin.RouterGroup,
+	systemProtected *gin.RouterGroup,
+	notificationHandler *NotificationHandler,
+	templateHandler *TemplateHandler,
+	wsHandler *WSHandler,
+) {
+	// 用户通知路由（登录即可访问）
+	if protected != nil {
+		notifications := protected.Group("/notifications")
+		{
+			notifications.GET("", notificationHandler.List)
+			notifications.GET("/unread/count", notificationHandler.UnreadCount)
+			notifications.POST("/:id/read", notificationHandler.MarkAsRead)
+			notifications.POST("/read-all", notificationHandler.MarkAllAsRead)
+			notifications.DELETE("/:id", notificationHandler.Delete)
+		}
+	}
+
+	// 管理员通知路由（需要权限）
+	if systemProtected != nil {
+		systemNotifications := systemProtected.Group("/notifications")
+		{
+			systemNotifications.POST("/send", notificationHandler.Send)
+			systemNotifications.POST("/broadcast", notificationHandler.Broadcast)
+		}
+
+		templates := systemProtected.Group("/notification-templates")
+		{
+			templates.GET("", templateHandler.List)
+			templates.POST("", templateHandler.Create)
+			templates.GET("/:id", templateHandler.Get)
+			templates.PUT("/:id", templateHandler.Update)
+			templates.DELETE("/:id", templateHandler.Delete)
+			templates.POST("/:id/test", templateHandler.Test)
+		}
+	}
+
+	// WebSocket 路由（独立于 API 组，需要 JWT 认证）
+	// 注意: WebSocket 路由在 main.go 中通过 r.GET("/ws/notifications", ...) 注册
+	// 因为它不在 /api/v1 路径下
+}
+
+// RegisterWSRoute 在根路由组注册 WebSocket 路由
+func RegisterWSRoute(r *gin.Engine, wsHandler *WSHandler) {
+	r.GET("/ws/notifications", wsHandler.HandleConnection)
+}

--- a/backend/internal/notification/handler/template_handler.go
+++ b/backend/internal/notification/handler/template_handler.go
@@ -1,0 +1,191 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// TemplateHandler 通知模板管理处理器
+type TemplateHandler struct {
+	templateService service.TemplateService
+}
+
+// NewTemplateHandler 创建模板处理器
+func NewTemplateHandler(templateService service.TemplateService) *TemplateHandler {
+	return &TemplateHandler{templateService: templateService}
+}
+
+// Create POST /api/v1/system/notification-templates
+// @Summary 创建通知模板
+// @Description 创建通知模板（管理员）
+// @Tags 系统管理-通知模板
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param request body dto.CreateTemplateRequest true "模板信息"
+// @Success 200 {object} response.Response
+// @Router /system/notification-templates [post]
+func (h *TemplateHandler) Create(c *gin.Context) {
+	var req dto.CreateTemplateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+
+	result, err := h.templateService.Create(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, result)
+}
+
+// Get GET /api/v1/system/notification-templates/:id
+// @Summary 模板详情
+// @Description 获取通知模板详情
+// @Tags 系统管理-通知模板
+// @Produce json
+// @Security Bearer
+// @Param id path string true "模板 ID"
+// @Success 200 {object} response.Response
+// @Router /system/notification-templates/{id} [get]
+func (h *TemplateHandler) Get(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的模板 ID")
+		return
+	}
+
+	result, err := h.templateService.GetByID(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, result)
+}
+
+// List GET /api/v1/system/notification-templates
+// @Summary 模板列表
+// @Description 获取通知模板列表（分页）
+// @Tags 系统管理-通知模板
+// @Produce json
+// @Security Bearer
+// @Param page query int false "页码"
+// @Param page_size query int false "每页条数"
+// @Param keyword query string false "关键词"
+// @Success 200 {object} response.Response
+// @Router /system/notification-templates [get]
+func (h *TemplateHandler) List(c *gin.Context) {
+	var req dto.ListTemplatesRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+
+	list, total, err := h.templateService.List(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.Page(c, list, total, req.Page, req.PageSize)
+}
+
+// Update PUT /api/v1/system/notification-templates/:id
+// @Summary 更新模板
+// @Description 更新通知模板
+// @Tags 系统管理-通知模板
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "模板 ID"
+// @Param request body dto.UpdateTemplateRequest true "更新内容"
+// @Success 200 {object} response.Response
+// @Router /system/notification-templates/{id} [put]
+func (h *TemplateHandler) Update(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的模板 ID")
+		return
+	}
+
+	var req dto.UpdateTemplateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+
+	result, err := h.templateService.Update(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, result)
+}
+
+// Delete DELETE /api/v1/system/notification-templates/:id
+// @Summary 删除模板
+// @Description 删除通知模板
+// @Tags 系统管理-通知模板
+// @Produce json
+// @Security Bearer
+// @Param id path string true "模板 ID"
+// @Success 200 {object} response.Response
+// @Router /system/notification-templates/{id} [delete]
+func (h *TemplateHandler) Delete(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的模板 ID")
+		return
+	}
+
+	if err := h.templateService.Delete(c.Request.Context(), id); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OKWithoutData(c)
+}
+
+// Test POST /api/v1/system/notification-templates/:id/test
+// @Summary 测试模板
+// @Description 使用提供的变量测试渲染通知模板
+// @Tags 系统管理-通知模板
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "模板 ID"
+// @Param request body dto.TestTemplateRequest true "测试变量"
+// @Success 200 {object} response.Response
+// @Router /system/notification-templates/{id}/test [post]
+func (h *TemplateHandler) Test(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的模板 ID")
+		return
+	}
+
+	var req dto.TestTemplateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+
+	result, err := h.templateService.Test(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, result)
+}

--- a/backend/internal/notification/handler/websocket_handler.go
+++ b/backend/internal/notification/handler/websocket_handler.go
@@ -131,14 +131,18 @@ func (h *WSHandler) HandleConnection(c *gin.Context) {
 
 	// 等待读协程退出
 	<-ctx.Done()
-	conn.Close()
+	if err := conn.Close(); err != nil {
+		logger.Error("websocket conn close failed",
+			zap.String("user_id", userID.String()),
+			zap.Error(err))
+	}
 }
 
 // readLoop 读取客户端消息
 func (h *WSHandler) readLoop(ctx context.Context, conn *websocket.Conn, userID uuid.UUID) {
-	conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	_ = conn.SetReadDeadline(time.Now().Add(60 * time.Second))
 	conn.SetPongHandler(func(string) error {
-		conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+		_ = conn.SetReadDeadline(time.Now().Add(60 * time.Second))
 		return nil
 	})
 
@@ -182,7 +186,7 @@ func (h *WSHandler) writeLoop(ctx context.Context, conn *websocket.Conn, userID 
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+			_ = conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				return
 			}

--- a/backend/internal/notification/handler/websocket_handler.go
+++ b/backend/internal/notification/handler/websocket_handler.go
@@ -17,14 +17,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		return true
-	},
-}
-
 const (
 	heartbeatInterval = 30 * time.Second
 	writeTimeout      = 10 * time.Second
@@ -48,13 +40,34 @@ type WSResponse struct {
 type WSHandler struct {
 	hub       service.HubManager
 	jwtConfig *config.JWTConfig
+	upgrader  websocket.Upgrader
 }
 
 // NewWSHandler 创建 WebSocket 处理器
-func NewWSHandler(hub service.HubManager, jwtConfig *config.JWTConfig) *WSHandler {
+// allowedOrigins 为空时允许所有来源（开发模式），非空时仅允许列表中的来源
+func NewWSHandler(hub service.HubManager, jwtConfig *config.JWTConfig, allowedOrigins []string) *WSHandler {
+	originSet := make(map[string]bool)
+	for _, origin := range allowedOrigins {
+		originSet[origin] = true
+	}
 	return &WSHandler{
 		hub:       hub,
 		jwtConfig: jwtConfig,
+		upgrader: websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin: func(r *http.Request) bool {
+				// 未配置允许来源时，允许所有（开发模式）
+				if len(originSet) == 0 {
+					return true
+				}
+				origin := r.Header.Get("Origin")
+				if origin == "" {
+					return true // 非浏览器客户端（如 curl）无 Origin 头
+				}
+				return originSet[origin]
+			},
+		},
 	}
 }
 
@@ -97,7 +110,7 @@ func (h *WSHandler) HandleConnection(c *gin.Context) {
 	}
 
 	// 3. 升级为 WebSocket 连接
-	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	conn, err := h.upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		logger.Error("websocket upgrade failed",
 			zap.String("user_id", userID.String()),

--- a/backend/internal/notification/handler/websocket_handler.go
+++ b/backend/internal/notification/handler/websocket_handler.go
@@ -1,0 +1,191 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/config"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	authmiddleware "github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"go.uber.org/zap"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+const (
+	heartbeatInterval = 30 * time.Second
+	writeTimeout      = 10 * time.Second
+)
+
+// WSMessage WebSocket 消息协议
+type WSMessage struct {
+	Type     string          `json:"type"`
+	Token    string          `json:"token,omitempty"`
+	Channels []string        `json:"channels,omitempty"`
+	Data     json.RawMessage `json:"data,omitempty"`
+}
+
+// WSResponse WebSocket 响应消息
+type WSResponse struct {
+	Type string      `json:"type"`
+	Data interface{} `json:"data,omitempty"`
+}
+
+// WSHandler WebSocket 连接处理器
+type WSHandler struct {
+	hub       service.HubManager
+	jwtConfig *config.JWTConfig
+}
+
+// NewWSHandler 创建 WebSocket 处理器
+func NewWSHandler(hub service.HubManager, jwtConfig *config.JWTConfig) *WSHandler {
+	return &WSHandler{
+		hub:       hub,
+		jwtConfig: jwtConfig,
+	}
+}
+
+// HandleConnection GET /ws/notifications
+func (h *WSHandler) HandleConnection(c *gin.Context) {
+	// 1. 认证：优先 query param，其次 Authorization header
+	token := c.Query("token")
+	if token == "" {
+		authHeader := c.GetHeader("Authorization")
+		if len(authHeader) > 7 && authHeader[:7] == "Bearer " {
+			token = authHeader[7:]
+		}
+	}
+
+	if token == "" {
+		c.JSON(http.StatusUnauthorized, response.Response{
+			Code:    response.CodeNotificationWSAuthFail,
+			Message: "WebSocket 认证失败：缺少 Token",
+		})
+		return
+	}
+
+	// 2. 验证 JWT
+	claims, err := authmiddleware.ParseToken(token, h.jwtConfig)
+	if err != nil || claims == nil {
+		c.JSON(http.StatusUnauthorized, response.Response{
+			Code:    response.CodeNotificationWSAuthFail,
+			Message: "WebSocket 认证失败：Token 无效或已过期",
+		})
+		return
+	}
+
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, response.Response{
+			Code:    response.CodeNotificationWSAuthFail,
+			Message: "WebSocket 认证失败：无效的用户标识",
+		})
+		return
+	}
+
+	// 3. 升级为 WebSocket 连接
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		logger.Error("websocket upgrade failed",
+			zap.String("user_id", userID.String()),
+			zap.Error(err))
+		return
+	}
+
+	// 4. 注册连接
+	h.hub.RegisterClient(userID, conn)
+
+	// 5. 发送认证成功消息
+	authResp := WSResponse{
+		Type: "auth_result",
+		Data: map[string]bool{"success": true},
+	}
+	_ = conn.WriteJSON(authResp)
+
+	// 6. 启动读写协程
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// 读协程：处理客户端消息（心跳/订阅）
+	go func() {
+		defer cancel()
+		h.readLoop(ctx, conn, userID)
+		h.hub.UnregisterClient(userID, conn)
+	}()
+
+	// 写协程：心跳检测
+	go h.writeLoop(ctx, conn, userID)
+
+	// 等待读协程退出
+	<-ctx.Done()
+	conn.Close()
+}
+
+// readLoop 读取客户端消息
+func (h *WSHandler) readLoop(ctx context.Context, conn *websocket.Conn, userID uuid.UUID) {
+	conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+		return nil
+	})
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			var msg WSMessage
+			if err := conn.ReadJSON(&msg); err != nil {
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					logger.Error("websocket read error",
+						zap.String("user_id", userID.String()),
+						zap.Error(err))
+				}
+				return
+			}
+
+			switch msg.Type {
+			case "ping":
+				pong := WSResponse{Type: "pong"}
+				_ = conn.WriteJSON(pong)
+			case "subscribe":
+				resp := WSResponse{
+					Type: "subscribe_result",
+					Data: map[string]bool{"success": true},
+				}
+				_ = conn.WriteJSON(resp)
+			}
+		}
+	}
+}
+
+// writeLoop 心跳检测
+func (h *WSHandler) writeLoop(ctx context.Context, conn *websocket.Conn, userID uuid.UUID) {
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/backend/internal/notification/model/notification.go
+++ b/backend/internal/notification/model/notification.go
@@ -1,0 +1,84 @@
+package model
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Notification 通知模型
+type Notification struct {
+	ID         uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	UserID     uuid.UUID      `gorm:"type:uuid;index;not null" json:"user_id"`
+	Title      string         `gorm:"type:varchar(200);not null" json:"title"`
+	Content    string         `gorm:"type:text" json:"content"`
+	Category   string         `gorm:"type:varchar(50);index" json:"category"`          // interview, meeting, task, member, system
+	Priority   string         `gorm:"type:varchar(20);default:normal" json:"priority"` // low, normal, high, urgent
+	IsRead     bool           `gorm:"default:false;index" json:"is_read"`
+	ActionURL  string         `gorm:"type:varchar(500)" json:"action_url"`
+	SenderID   *uuid.UUID     `gorm:"type:uuid" json:"sender_id"`
+	SenderName string         `gorm:"type:varchar(100)" json:"sender_name"`
+	CreatedAt  time.Time      `json:"created_at"`
+	UpdatedAt  time.Time      `json:"updated_at"`
+	DeletedAt  gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+// TableName 表名
+func (Notification) TableName() string {
+	return "notifications"
+}
+
+// NotificationTemplate 通知模板模型
+type NotificationTemplate struct {
+	ID              uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Code            string         `gorm:"type:varchar(100);uniqueIndex;not null" json:"code"`
+	Name            string         `gorm:"type:varchar(200);not null" json:"name"`
+	TitleTemplate   string         `gorm:"type:varchar(500);not null" json:"title_template"`
+	BodyTemplate    string         `gorm:"type:text;not null" json:"body_template"`
+	Channels        string         `gorm:"type:varchar(200);not null" json:"channels"` // JSON array: ["in_app","websocket","email"]
+	Category        string         `gorm:"type:varchar(50)" json:"category"`
+	VariablesSchema string         `gorm:"type:jsonb" json:"variables_schema"`          // JSON: {"var":"string"}
+	Status          int            `gorm:"type:smallint;default:0;index" json:"status"` // 0=启用 1=禁用
+	CreatedAt       time.Time      `json:"created_at"`
+	UpdatedAt       time.Time      `json:"updated_at"`
+	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+// TableName 表名
+func (NotificationTemplate) TableName() string {
+	return "notification_templates"
+}
+
+// GetChannels 解析 channels JSON 为字符串切片
+func (t *NotificationTemplate) GetChannels() []string {
+	var channels []string
+	if t.Channels == "" {
+		return channels
+	}
+	_ = json.Unmarshal([]byte(t.Channels), &channels)
+	return channels
+}
+
+// SetChannels 将字符串切片序列化为 channels JSON
+func (t *NotificationTemplate) SetChannels(channels []string) {
+	data, _ := json.Marshal(channels)
+	t.Channels = string(data)
+}
+
+// GetVariablesSchema 解析 variables_schema JSON 为 map
+func (t *NotificationTemplate) GetVariablesSchema() map[string]string {
+	var schema map[string]string
+	if t.VariablesSchema == "" {
+		return schema
+	}
+	_ = json.Unmarshal([]byte(t.VariablesSchema), &schema)
+	return schema
+}
+
+// SetVariablesSchema 将 map 序列化为 variables_schema JSON
+func (t *NotificationTemplate) SetVariablesSchema(schema map[string]string) {
+	data, _ := json.Marshal(schema)
+	t.VariablesSchema = string(data)
+}

--- a/backend/internal/notification/model/notification.go
+++ b/backend/internal/notification/model/notification.go
@@ -30,6 +30,12 @@ func (Notification) TableName() string {
 	return "notifications"
 }
 
+// 模板状态常量
+const (
+	TemplateStatusEnabled  = 0 // 启用
+	TemplateStatusDisabled = 1 // 禁用
+)
+
 // NotificationTemplate 通知模板模型
 type NotificationTemplate struct {
 	ID              uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`

--- a/backend/internal/notification/repo/notification_repo.go
+++ b/backend/internal/notification/repo/notification_repo.go
@@ -2,8 +2,6 @@ package repo
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
 	"github.com/google/uuid"
@@ -212,22 +210,4 @@ func (r *templateRepo) Delete(ctx context.Context, id uuid.UUID) error {
 		return gorm.ErrRecordNotFound
 	}
 	return nil
-}
-
-// MarshalChannels 序列化渠道列表为 JSON 字符串
-func MarshalChannels(channels []string) string {
-	data, _ := json.Marshal(channels)
-	return string(data)
-}
-
-// UnmarshalChannels 反序列化渠道列表
-func UnmarshalChannels(s string) []string {
-	var channels []string
-	_ = json.Unmarshal([]byte(s), &channels)
-	return channels
-}
-
-// FormatError 格式化 repo 错误信息
-func FormatError(op string, err error) error {
-	return fmt.Errorf("notification repo %s: %w", op, err)
 }

--- a/backend/internal/notification/repo/notification_repo.go
+++ b/backend/internal/notification/repo/notification_repo.go
@@ -1,0 +1,233 @@
+package repo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// NotificationRepo 通知数据访问接口
+type NotificationRepo interface {
+	// Create 创建通知
+	Create(ctx context.Context, n *model.Notification) error
+	// BatchCreate 批量创建通知
+	BatchCreate(ctx context.Context, notifications []*model.Notification) error
+	// ListByUser 查询用户通知列表（分页）
+	ListByUser(ctx context.Context, userID uuid.UUID, page, pageSize int, category string, unreadOnly bool) ([]*model.Notification, int64, error)
+	// GetByID 根据 ID 查询通知
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Notification, error)
+	// MarkAsRead 标记通知为已读
+	MarkAsRead(ctx context.Context, userID uuid.UUID, ids []uuid.UUID) error
+	// MarkAllAsRead 标记用户全部通知为已读
+	MarkAllAsRead(ctx context.Context, userID uuid.UUID, category string) error
+	// Delete 删除通知
+	Delete(ctx context.Context, userID uuid.UUID, id uuid.UUID) error
+	// GetUnreadCount 获取用户未读通知数
+	GetUnreadCount(ctx context.Context, userID uuid.UUID) (int64, error)
+}
+
+type notificationRepo struct {
+	db *gorm.DB
+}
+
+// NewNotificationRepo 创建通知 repo
+func NewNotificationRepo(db *gorm.DB) NotificationRepo {
+	return &notificationRepo{db: db}
+}
+
+func (r *notificationRepo) Create(ctx context.Context, n *model.Notification) error {
+	return r.db.WithContext(ctx).Create(n).Error
+}
+
+func (r *notificationRepo) BatchCreate(ctx context.Context, notifications []*model.Notification) error {
+	if len(notifications) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).CreateInBatches(notifications, 100).Error
+}
+
+func (r *notificationRepo) ListByUser(ctx context.Context, userID uuid.UUID, page, pageSize int, category string, unreadOnly bool) ([]*model.Notification, int64, error) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 20
+	}
+
+	query := r.db.WithContext(ctx).Model(&model.Notification{}).Where("user_id = ?", userID)
+	if category != "" {
+		query = query.Where("category = ?", category)
+	}
+	if unreadOnly {
+		query = query.Where("is_read = false")
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var list []*model.Notification
+	if err := query.Order("created_at DESC").
+		Offset((page - 1) * pageSize).
+		Limit(pageSize).
+		Find(&list).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return list, total, nil
+}
+
+func (r *notificationRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Notification, error) {
+	var n model.Notification
+	if err := r.db.WithContext(ctx).First(&n, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &n, nil
+}
+
+func (r *notificationRepo) MarkAsRead(ctx context.Context, userID uuid.UUID, ids []uuid.UUID) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).Model(&model.Notification{}).
+		Where("user_id = ? AND id IN ?", userID, ids).
+		Update("is_read", true).Error
+}
+
+func (r *notificationRepo) MarkAllAsRead(ctx context.Context, userID uuid.UUID, category string) error {
+	query := r.db.WithContext(ctx).Model(&model.Notification{}).
+		Where("user_id = ? AND is_read = false", userID)
+	if category != "" {
+		query = query.Where("category = ?", category)
+	}
+	return query.Update("is_read", true).Error
+}
+
+func (r *notificationRepo) Delete(ctx context.Context, userID uuid.UUID, id uuid.UUID) error {
+	result := r.db.WithContext(ctx).
+		Where("user_id = ? AND id = ?", userID, id).
+		Delete(&model.Notification{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+func (r *notificationRepo) GetUnreadCount(ctx context.Context, userID uuid.UUID) (int64, error) {
+	var count int64
+	err := r.db.WithContext(ctx).Model(&model.Notification{}).
+		Where("user_id = ? AND is_read = false", userID).
+		Count(&count).Error
+	return count, err
+}
+
+// ========== Template Repo ==========
+
+// NotificationTemplateRepo 通知模板数据访问接口
+type NotificationTemplateRepo interface {
+	Create(ctx context.Context, t *model.NotificationTemplate) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.NotificationTemplate, error)
+	GetByCode(ctx context.Context, code string) (*model.NotificationTemplate, error)
+	List(ctx context.Context, page, pageSize int, keyword string) ([]*model.NotificationTemplate, int64, error)
+	Update(ctx context.Context, t *model.NotificationTemplate) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+type templateRepo struct {
+	db *gorm.DB
+}
+
+// NewTemplateRepo 创建模板 repo
+func NewTemplateRepo(db *gorm.DB) NotificationTemplateRepo {
+	return &templateRepo{db: db}
+}
+
+func (r *templateRepo) Create(ctx context.Context, t *model.NotificationTemplate) error {
+	return r.db.WithContext(ctx).Create(t).Error
+}
+
+func (r *templateRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.NotificationTemplate, error) {
+	var t model.NotificationTemplate
+	if err := r.db.WithContext(ctx).First(&t, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (r *templateRepo) GetByCode(ctx context.Context, code string) (*model.NotificationTemplate, error) {
+	var t model.NotificationTemplate
+	if err := r.db.WithContext(ctx).Where("code = ?", code).First(&t).Error; err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (r *templateRepo) List(ctx context.Context, page, pageSize int, keyword string) ([]*model.NotificationTemplate, int64, error) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 20
+	}
+
+	query := r.db.WithContext(ctx).Model(&model.NotificationTemplate{})
+	if keyword != "" {
+		query = query.Where("name ILIKE ? OR code ILIKE ?", "%"+keyword+"%", "%"+keyword+"%")
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var list []*model.NotificationTemplate
+	if err := query.Order("created_at DESC").
+		Offset((page - 1) * pageSize).
+		Limit(pageSize).
+		Find(&list).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return list, total, nil
+}
+
+func (r *templateRepo) Update(ctx context.Context, t *model.NotificationTemplate) error {
+	return r.db.WithContext(ctx).Save(t).Error
+}
+
+func (r *templateRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	result := r.db.WithContext(ctx).Delete(&model.NotificationTemplate{}, "id = ?", id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// MarshalChannels 序列化渠道列表为 JSON 字符串
+func MarshalChannels(channels []string) string {
+	data, _ := json.Marshal(channels)
+	return string(data)
+}
+
+// UnmarshalChannels 反序列化渠道列表
+func UnmarshalChannels(s string) []string {
+	var channels []string
+	_ = json.Unmarshal([]byte(s), &channels)
+	return channels
+}
+
+// FormatError 格式化 repo 错误信息
+func FormatError(op string, err error) error {
+	return fmt.Errorf("notification repo %s: %w", op, err)
+}

--- a/backend/internal/notification/service/channel.go
+++ b/backend/internal/notification/service/channel.go
@@ -1,0 +1,267 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/go-mail/mail"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"go.uber.org/zap"
+)
+
+// NotificationChannel 通知渠道接口（插件化，未来可扩展短信、企业微信等）
+type NotificationChannel interface {
+	Type() string // "in_app", "email", "websocket"
+	Send(ctx context.Context, msg *NotificationMessage) error
+	IsAvailable() bool
+}
+
+// NotificationMessage 通知消息体
+type NotificationMessage struct {
+	UserID     uuid.UUID
+	Username   string
+	Email      string
+	Title      string
+	Content    string
+	Category   string
+	Priority   string
+	ActionURL  string
+	SenderID   *uuid.UUID
+	SenderName string
+}
+
+// InAppChannel 站内消息渠道
+type InAppChannel struct {
+	notificationRepo repo.NotificationRepo
+}
+
+// NewInAppChannel 创建站内消息渠道
+func NewInAppChannel(repo repo.NotificationRepo) *InAppChannel {
+	return &InAppChannel{notificationRepo: repo}
+}
+
+func (c *InAppChannel) Type() string      { return "in_app" }
+func (c *InAppChannel) IsAvailable() bool { return true }
+
+func (c *InAppChannel) Send(ctx context.Context, msg *NotificationMessage) error {
+	n := &model.Notification{
+		ID:         uuid.New(),
+		UserID:     msg.UserID,
+		Title:      msg.Title,
+		Content:    msg.Content,
+		Category:   msg.Category,
+		Priority:   msg.Priority,
+		ActionURL:  msg.ActionURL,
+		SenderID:   msg.SenderID,
+		SenderName: msg.SenderName,
+		IsRead:     false,
+	}
+	return c.notificationRepo.Create(ctx, n)
+}
+
+// EmailChannel 邮件渠道
+type EmailChannel struct {
+	smtpHost string
+	smtpPort int
+	username string
+	password string
+	from     string
+}
+
+// NewEmailChannel 创建邮件渠道
+func NewEmailChannel(host string, port int, username, password, from string) *EmailChannel {
+	return &EmailChannel{
+		smtpHost: host,
+		smtpPort: port,
+		username: username,
+		password: password,
+		from:     from,
+	}
+}
+
+func (c *EmailChannel) Type() string { return "email" }
+
+func (c *EmailChannel) IsAvailable() bool {
+	return c.smtpHost != "" && c.smtpPort > 0 && c.from != ""
+}
+
+func (c *EmailChannel) Send(ctx context.Context, msg *NotificationMessage) error {
+	if msg.Email == "" {
+		return fmt.Errorf("email address is empty for user %s", msg.UserID)
+	}
+
+	m := mail.NewMessage()
+	m.SetHeader("From", c.from)
+	m.SetHeader("To", msg.Email)
+	m.SetHeader("Subject", msg.Title)
+	m.SetBody("text/plain", msg.Content)
+
+	d := mail.NewDialer(c.smtpHost, c.smtpPort, c.username, c.password)
+	if err := d.DialAndSend(m); err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+	return nil
+}
+
+// WebSocketChannel WebSocket 实时推送渠道
+type WebSocketChannel struct {
+	hub HubManager
+}
+
+// NewWebSocketChannel 创建 WebSocket 渠道
+func NewWebSocketChannel(hub HubManager) *WebSocketChannel {
+	return &WebSocketChannel{hub: hub}
+}
+
+func (c *WebSocketChannel) Type() string      { return "websocket" }
+func (c *WebSocketChannel) IsAvailable() bool { return c.hub != nil }
+
+func (c *WebSocketChannel) Send(ctx context.Context, msg *NotificationMessage) error {
+	notification := map[string]interface{}{
+		"type": "notification",
+		"data": map[string]interface{}{
+			"title":      msg.Title,
+			"content":    msg.Content,
+			"category":   msg.Category,
+			"priority":   msg.Priority,
+			"action_url": msg.ActionURL,
+			"sender": map[string]string{
+				"id":   "",
+				"name": msg.SenderName,
+			},
+		},
+	}
+
+	// Hub 的 PushToUser 会处理 JSON 序列化
+	return c.hub.PushToUser(msg.UserID, notification)
+}
+
+// ChannelRegistry 渠道注册表
+type ChannelRegistry struct {
+	channels map[string]NotificationChannel
+}
+
+// NewChannelRegistry 创建渠道注册表
+func NewChannelRegistry() *ChannelRegistry {
+	return &ChannelRegistry{
+		channels: make(map[string]NotificationChannel),
+	}
+}
+
+// Register 注册渠道
+func (r *ChannelRegistry) Register(channel NotificationChannel) {
+	r.channels[channel.Type()] = channel
+}
+
+// Get 获取渠道
+func (r *ChannelRegistry) Get(channelType string) (NotificationChannel, bool) {
+	ch, ok := r.channels[channelType]
+	return ch, ok
+}
+
+// SendViaChannels 通过指定渠道发送通知
+func (r *ChannelRegistry) SendViaChannels(ctx context.Context, msg *NotificationMessage, channels []string) []error {
+	var errs []error
+	for _, chType := range channels {
+		ch, ok := r.Get(chType)
+		if !ok {
+			logger.Warn("notification channel not found",
+				zap.String("channel", chType))
+			errs = append(errs, fmt.Errorf("unsupported channel: %s", chType))
+			continue
+		}
+		if !ch.IsAvailable() {
+			logger.Warn("notification channel not available",
+				zap.String("channel", chType))
+			continue
+		}
+		if err := ch.Send(ctx, msg); err != nil {
+			logger.Error("send notification via channel failed",
+				zap.String("channel", chType),
+				zap.String("user_id", msg.UserID.String()),
+				zap.Error(err))
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+// HubManager WebSocket 连接管理器接口
+type HubManager interface {
+	RegisterClient(userID uuid.UUID, conn *websocket.Conn)
+	UnregisterClient(userID uuid.UUID, conn *websocket.Conn)
+	PushToUser(userID uuid.UUID, message interface{}) error
+	PushToChannel(channel string, message interface{}) error
+	GetOnlineUsers() []uuid.UUID
+}
+
+// Hub WebSocket Hub 实现
+type Hub struct {
+	clients map[uuid.UUID]map[*websocket.Conn]bool // 一个用户可能有多个连接
+}
+
+// NewHub 创建 Hub
+func NewHub() *Hub {
+	return &Hub{
+		clients: make(map[uuid.UUID]map[*websocket.Conn]bool),
+	}
+}
+
+// RegisterClient 注册客户端连接
+func (h *Hub) RegisterClient(userID uuid.UUID, conn *websocket.Conn) {
+	if _, ok := h.clients[userID]; !ok {
+		h.clients[userID] = make(map[*websocket.Conn]bool)
+	}
+	h.clients[userID][conn] = true
+	logger.Info("websocket client registered",
+		zap.String("user_id", userID.String()),
+		zap.Int("connections", len(h.clients[userID])))
+}
+
+// UnregisterClient 注销客户端连接
+func (h *Hub) UnregisterClient(userID uuid.UUID, conn *websocket.Conn) {
+	if conns, ok := h.clients[userID]; ok {
+		delete(conns, conn)
+		if len(conns) == 0 {
+			delete(h.clients, userID)
+		}
+		logger.Info("websocket client unregistered",
+			zap.String("user_id", userID.String()))
+	}
+}
+
+// PushToUser 向指定用户推送消息（所有连接）
+func (h *Hub) PushToUser(userID uuid.UUID, message interface{}) error {
+	conns, ok := h.clients[userID]
+	if !ok || len(conns) == 0 {
+		return nil // 用户不在线，静默跳过
+	}
+
+	for conn := range conns {
+		if err := conn.WriteJSON(message); err != nil {
+			logger.Error("websocket push failed",
+				zap.String("user_id", userID.String()),
+				zap.Error(err))
+		}
+	}
+	return nil
+}
+
+// PushToChannel 向频道推送消息（目前不支持，预留）
+func (h *Hub) PushToChannel(channel string, message interface{}) error {
+	// 预留：未来实现频道订阅功能
+	return nil
+}
+
+// GetOnlineUsers 获取在线用户列表
+func (h *Hub) GetOnlineUsers() []uuid.UUID {
+	users := make([]uuid.UUID, 0, len(h.clients))
+	for userID := range h.clients {
+		users = append(users, userID)
+	}
+	return users
+}

--- a/backend/internal/notification/service/channel.go
+++ b/backend/internal/notification/service/channel.go
@@ -203,7 +203,7 @@ type HubManager interface {
 // Hub WebSocket Hub 实现
 type Hub struct {
 	mu      sync.RWMutex
-	writeMu sync.Mutex // 序列化 WebSocket 写入，防止并发写同一连接
+	writeMu sync.Mutex                             // 序列化 WebSocket 写入，防止并发写同一连接
 	clients map[uuid.UUID]map[*websocket.Conn]bool // 一个用户可能有多个连接
 }
 

--- a/backend/internal/notification/service/channel.go
+++ b/backend/internal/notification/service/channel.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
 	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
@@ -201,6 +202,8 @@ type HubManager interface {
 
 // Hub WebSocket Hub 实现
 type Hub struct {
+	mu      sync.RWMutex
+	writeMu sync.Mutex // 序列化 WebSocket 写入，防止并发写同一连接
 	clients map[uuid.UUID]map[*websocket.Conn]bool // 一个用户可能有多个连接
 }
 
@@ -213,6 +216,8 @@ func NewHub() *Hub {
 
 // RegisterClient 注册客户端连接
 func (h *Hub) RegisterClient(userID uuid.UUID, conn *websocket.Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if _, ok := h.clients[userID]; !ok {
 		h.clients[userID] = make(map[*websocket.Conn]bool)
 	}
@@ -224,6 +229,8 @@ func (h *Hub) RegisterClient(userID uuid.UUID, conn *websocket.Conn) {
 
 // UnregisterClient 注销客户端连接
 func (h *Hub) UnregisterClient(userID uuid.UUID, conn *websocket.Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if conns, ok := h.clients[userID]; ok {
 		delete(conns, conn)
 		if len(conns) == 0 {
@@ -236,12 +243,23 @@ func (h *Hub) UnregisterClient(userID uuid.UUID, conn *websocket.Conn) {
 
 // PushToUser 向指定用户推送消息（所有连接）
 func (h *Hub) PushToUser(userID uuid.UUID, message interface{}) error {
+	h.mu.RLock()
 	conns, ok := h.clients[userID]
 	if !ok || len(conns) == 0 {
+		h.mu.RUnlock()
 		return nil // 用户不在线，静默跳过
 	}
-
+	// 复制连接列表，避免在 I/O 期间持有锁
+	connList := make([]*websocket.Conn, 0, len(conns))
 	for conn := range conns {
+		connList = append(connList, conn)
+	}
+	h.mu.RUnlock()
+
+	// 序列化写入：gorilla/websocket 不支持并发写同一连接
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
+	for _, conn := range connList {
 		if err := conn.WriteJSON(message); err != nil {
 			logger.Error("websocket push failed",
 				zap.String("user_id", userID.String()),
@@ -259,6 +277,8 @@ func (h *Hub) PushToChannel(channel string, message interface{}) error {
 
 // GetOnlineUsers 获取在线用户列表
 func (h *Hub) GetOnlineUsers() []uuid.UUID {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	users := make([]uuid.UUID, 0, len(h.clients))
 	for userID := range h.clients {
 		users = append(users, userID)

--- a/backend/internal/notification/service/event_listener.go
+++ b/backend/internal/notification/service/event_listener.go
@@ -81,23 +81,37 @@ func (l *EventListener) onTaskAssigned(ctx context.Context, event events.Event) 
 
 // sendNotification 渲染模板并通过渠道发送通知
 func (l *EventListener) sendNotification(ctx context.Context, userID uuid.UUID, templateCode string, variables map[string]interface{}, category string) error {
-	// 尝试渲染模板，如果模板不存在则使用默认内容
-	rendered, err := l.templateEngine.Render(ctx, templateCode, variables)
+	// 查询模板一次，同时用于渲染和获取渠道配置
+	tpl, err := l.templateRepo.GetByCode(ctx, templateCode)
+
+	var rendered *dto.TestTemplateResponse
+	channels := []string{"in_app", "websocket"}
+
 	if err != nil {
-		logger.Warn("template render failed, using fallback",
+		// 模板不存在，使用默认内容
+		logger.Warn("template not found, using fallback",
 			zap.String("template_code", templateCode),
 			zap.Error(err))
 		rendered = &dto.TestTemplateResponse{
 			Title:   "新通知",
 			Content: fmt.Sprintf("您有一条新的 %s 通知", category),
 		}
-	}
-
-	// 获取模板配置的渠道
-	channels := []string{"in_app", "websocket"}
-	tpl, err := l.templateRepo.GetByCode(ctx, templateCode)
-	if err == nil && tpl.Channels != "" {
-		channels = tpl.GetChannels()
+	} else {
+		// 从已查出的模板渲染，避免重复查库
+		rendered, err = l.templateEngine.RenderTemplate(tpl, variables)
+		if err != nil {
+			logger.Warn("template render failed, using fallback",
+				zap.String("template_code", templateCode),
+				zap.Error(err))
+			rendered = &dto.TestTemplateResponse{
+				Title:   "新通知",
+				Content: fmt.Sprintf("您有一条新的 %s 通知", category),
+			}
+		}
+		// 使用模板配置的渠道
+		if tpl.Channels != "" {
+			channels = tpl.GetChannels()
+		}
 	}
 
 	// 通过渠道发送通知（in_app 渠道会自动创建站内通知，避免重复创建）

--- a/backend/internal/notification/service/event_listener.go
+++ b/backend/internal/notification/service/event_listener.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/events"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// EventListener 事件总线监听器，监听业务事件并自动发送通知
+type EventListener struct {
+	notificationRepo repo.NotificationRepo
+	templateRepo     repo.NotificationTemplateRepo
+	templateEngine   TemplateEngine
+	channelRegistry  *ChannelRegistry
+	hub              HubManager
+}
+
+// NewEventListener 创建事件监听器
+func NewEventListener(
+	notificationRepo repo.NotificationRepo,
+	templateRepo repo.NotificationTemplateRepo,
+	templateEngine TemplateEngine,
+	channelRegistry *ChannelRegistry,
+	hub HubManager,
+) *EventListener {
+	return &EventListener{
+		notificationRepo: notificationRepo,
+		templateRepo:     templateRepo,
+		templateEngine:   templateEngine,
+		channelRegistry:  channelRegistry,
+		hub:              hub,
+	}
+}
+
+// RegisterAll 注册所有事件监听
+func (l *EventListener) RegisterAll(eventBus *events.EventBus) {
+	eventBus.Subscribe("task.created", l.onTaskCreated)
+	eventBus.Subscribe("task.assigned", l.onTaskAssigned)
+}
+
+// onTaskCreated 处理流程任务创建事件
+func (l *EventListener) onTaskCreated(ctx context.Context, event events.Event) error {
+	taskEvent, ok := event.(events.TaskCreatedEvent)
+	if !ok {
+		return fmt.Errorf("invalid event type for task.created")
+	}
+
+	if taskEvent.AssigneeID == uuid.Nil {
+		return nil
+	}
+
+	templateCode := "FLOW_TASK_CREATED"
+	variables := map[string]interface{}{
+		"task_name": taskEvent.NodeName,
+		"node_name": taskEvent.NodeName,
+		"task_type": taskEvent.TaskType,
+	}
+
+	return l.sendNotification(ctx, taskEvent.AssigneeID, templateCode, variables, "task")
+}
+
+// onTaskAssigned 处理任务转办事件
+func (l *EventListener) onTaskAssigned(ctx context.Context, event events.Event) error {
+	taskEvent, ok := event.(events.TaskAssignedEvent)
+	if !ok {
+		return fmt.Errorf("invalid event type for task.assigned")
+	}
+
+	if taskEvent.NewAssigneeID == uuid.Nil {
+		return nil
+	}
+
+	templateCode := "TASK_ASSIGNED"
+	variables := map[string]interface{}{
+		"task_id":     taskEvent.TaskID.String(),
+		"instance_id": taskEvent.InstanceID.String(),
+	}
+
+	return l.sendNotification(ctx, taskEvent.NewAssigneeID, templateCode, variables, "task")
+}
+
+// sendNotification 渲染模板并通过渠道发送通知
+func (l *EventListener) sendNotification(ctx context.Context, userID uuid.UUID, templateCode string, variables map[string]interface{}, category string) error {
+	// 尝试渲染模板，如果模板不存在则使用默认内容
+	rendered, err := l.templateEngine.Render(ctx, templateCode, variables)
+	if err != nil {
+		logger.Warn("template render failed, using fallback",
+			zap.String("template_code", templateCode),
+			zap.Error(err))
+		rendered = &dto.TestTemplateResponse{
+			Title:   "新通知",
+			Content: fmt.Sprintf("您有一条新的 %s 通知", category),
+		}
+	}
+
+	// 获取模板配置的渠道
+	channels := []string{"in_app", "websocket"}
+	tpl, err := l.templateRepo.GetByCode(ctx, templateCode)
+	if err == nil && tpl.Channels != "" {
+		channels = tpl.GetChannels()
+	}
+
+	// 发送站内通知
+	n := &model.Notification{
+		ID:       uuid.New(),
+		UserID:   userID,
+		Title:    rendered.Title,
+		Content:  rendered.Content,
+		Category: category,
+		Priority: "normal",
+		IsRead:   false,
+	}
+	if err := l.notificationRepo.Create(ctx, n); err != nil {
+		return fmt.Errorf("create notification: %w", err)
+	}
+
+	// WebSocket 实时推送
+	msg := &NotificationMessage{
+		UserID:   userID,
+		Title:    rendered.Title,
+		Content:  rendered.Content,
+		Category: category,
+	}
+	l.channelRegistry.SendViaChannels(ctx, msg, channels)
+
+	return nil
+}

--- a/backend/internal/notification/service/event_listener.go
+++ b/backend/internal/notification/service/event_listener.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
-	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
 	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
 	"github.com/Yogdunana/StarByte/backend/pkg/events"
 	"github.com/Yogdunana/StarByte/backend/pkg/logger"
@@ -107,28 +106,20 @@ func (l *EventListener) sendNotification(ctx context.Context, userID uuid.UUID, 
 		channels = tpl.GetChannels()
 	}
 
-	// 发送站内通知
-	n := &model.Notification{
-		ID:       uuid.New(),
-		UserID:   userID,
-		Title:    rendered.Title,
-		Content:  rendered.Content,
-		Category: category,
-		Priority: "normal",
-		IsRead:   false,
-	}
-	if err := l.notificationRepo.Create(ctx, n); err != nil {
-		return fmt.Errorf("create notification: %w", err)
-	}
-
-	// WebSocket 实时推送
+	// 通过渠道发送通知（in_app 渠道会自动创建站内通知，避免重复创建）
 	msg := &NotificationMessage{
 		UserID:   userID,
 		Title:    rendered.Title,
 		Content:  rendered.Content,
 		Category: category,
+		Priority: "normal",
 	}
-	l.channelRegistry.SendViaChannels(ctx, msg, channels)
+	if errs := l.channelRegistry.SendViaChannels(ctx, msg, channels); len(errs) > 0 {
+		logger.Error("send notification via channels failed",
+			zap.String("template_code", templateCode),
+			zap.String("user_id", userID.String()),
+			zap.Int("error_count", len(errs)))
+	}
 
 	return nil
 }

--- a/backend/internal/notification/service/event_listener.go
+++ b/backend/internal/notification/service/event_listener.go
@@ -14,27 +14,21 @@ import (
 
 // EventListener 事件总线监听器，监听业务事件并自动发送通知
 type EventListener struct {
-	notificationRepo repo.NotificationRepo
-	templateRepo     repo.NotificationTemplateRepo
-	templateEngine   TemplateEngine
-	channelRegistry  *ChannelRegistry
-	hub              HubManager
+	templateRepo    repo.NotificationTemplateRepo
+	templateEngine  TemplateEngine
+	channelRegistry *ChannelRegistry
 }
 
 // NewEventListener 创建事件监听器
 func NewEventListener(
-	notificationRepo repo.NotificationRepo,
 	templateRepo repo.NotificationTemplateRepo,
 	templateEngine TemplateEngine,
 	channelRegistry *ChannelRegistry,
-	hub HubManager,
 ) *EventListener {
 	return &EventListener{
-		notificationRepo: notificationRepo,
-		templateRepo:     templateRepo,
-		templateEngine:   templateEngine,
-		channelRegistry:  channelRegistry,
-		hub:              hub,
+		templateRepo:    templateRepo,
+		templateEngine:  templateEngine,
+		channelRegistry: channelRegistry,
 	}
 }
 

--- a/backend/internal/notification/service/notification_service.go
+++ b/backend/internal/notification/service/notification_service.go
@@ -55,33 +55,42 @@ func (s *notificationService) Send(ctx context.Context, req *dto.SendNotificatio
 		return err
 	}
 
-	// 2. 确定发送渠道
+	// 2. 获取模板配置（渠道 + 分类），仅在渠道未指定时查询
+	category := "system"
 	channels := req.Channels
 	if len(channels) == 0 {
 		tpl, err := s.templateRepo.GetByCode(ctx, req.TemplateCode)
-		if err == nil && tpl.Channels != "" {
-			channels = tpl.GetChannels()
+		if err == nil {
+			if tpl.Category != "" {
+				category = tpl.Category
+			}
+			if tpl.Channels != "" {
+				channels = tpl.GetChannels()
+			}
 		}
 		if len(channels) == 0 {
 			channels = []string{"in_app", "websocket"}
 		}
 	}
 
-	// 3. 为每个用户发送通知
+	// 3. 为每个用户发送通知（收集所有错误，不因单个用户失败而中断）
+	var sendErrs []error
 	for _, userID := range req.UserIDs {
 		msg := &NotificationMessage{
 			UserID:   userID,
 			Title:    rendered.Title,
 			Content:  rendered.Content,
-			Category: "system",
+			Category: category,
 			Priority: "normal",
 		}
-		errs := s.channelRegistry.SendViaChannels(ctx, msg, channels)
-		if len(errs) > 0 {
-			return fmt.Errorf("send notification to user %s: %w", userID, errs[0])
+		if errs := s.channelRegistry.SendViaChannels(ctx, msg, channels); len(errs) > 0 {
+			sendErrs = append(sendErrs, fmt.Errorf("user %s: %w", userID, errs[0]))
 		}
 	}
-
+	if len(sendErrs) > 0 {
+		return fmt.Errorf("send notification failed, %d/%d users failed: %w",
+			len(sendErrs), len(req.UserIDs), sendErrs[0])
+	}
 	return nil
 }
 
@@ -162,6 +171,13 @@ func (s *notificationService) Broadcast(ctx context.Context, req *dto.BroadcastN
 	}
 
 	// 通过 channelRegistry 发送非 in_app 渠道（websocket、email 等）
+	// 过滤掉 in_app，因为已经通过 BatchCreate 批量创建了
+	var otherChannels []string
+	for _, ch := range channels {
+		if ch != "in_app" {
+			otherChannels = append(otherChannels, ch)
+		}
+	}
 	for _, userID := range onlineUserIDs {
 		msg := &NotificationMessage{
 			UserID:   userID,
@@ -169,13 +185,6 @@ func (s *notificationService) Broadcast(ctx context.Context, req *dto.BroadcastN
 			Content:  req.Content,
 			Category: req.Category,
 			Priority: req.Priority,
-		}
-		// 过滤掉 in_app，因为已经通过 BatchCreate 批量创建了
-		var otherChannels []string
-		for _, ch := range channels {
-			if ch != "in_app" {
-				otherChannels = append(otherChannels, ch)
-			}
 		}
 		if len(otherChannels) > 0 {
 			if errs := s.channelRegistry.SendViaChannels(ctx, msg, otherChannels); len(errs) > 0 {

--- a/backend/internal/notification/service/notification_service.go
+++ b/backend/internal/notification/service/notification_service.go
@@ -7,8 +7,10 @@ import (
 	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
 	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 )
 
 // NotificationService 通知服务接口
@@ -133,25 +135,33 @@ func (s *notificationService) Broadcast(ctx context.Context, req *dto.BroadcastN
 		channels = []string{"in_app", "websocket"}
 	}
 
-	// 批量创建站内通知
-	var notifications []*model.Notification
-	for _, userID := range onlineUserIDs {
-		notifications = append(notifications, &model.Notification{
-			ID:       uuid.New(),
-			UserID:   userID,
-			Title:    req.Title,
-			Content:  req.Content,
-			Category: req.Category,
-			Priority: req.Priority,
-			IsRead:   false,
-		})
+	// 批量创建站内通知（仅在 channels 包含 in_app 时）
+	hasInApp := false
+	for _, ch := range channels {
+		if ch == "in_app" {
+			hasInApp = true
+			break
+		}
+	}
+	if hasInApp && len(onlineUserIDs) > 0 {
+		var notifications []*model.Notification
+		for _, userID := range onlineUserIDs {
+			notifications = append(notifications, &model.Notification{
+				ID:       uuid.New(),
+				UserID:   userID,
+				Title:    req.Title,
+				Content:  req.Content,
+				Category: req.Category,
+				Priority: req.Priority,
+				IsRead:   false,
+			})
+		}
+		if err := s.notificationRepo.BatchCreate(ctx, notifications); err != nil {
+			return fmt.Errorf("batch create notifications: %w", err)
+		}
 	}
 
-	if err := s.notificationRepo.BatchCreate(ctx, notifications); err != nil {
-		return fmt.Errorf("batch create notifications: %w", err)
-	}
-
-	// WebSocket 实时推送
+	// 通过 channelRegistry 发送非 in_app 渠道（websocket、email 等）
 	for _, userID := range onlineUserIDs {
 		msg := &NotificationMessage{
 			UserID:   userID,
@@ -160,12 +170,19 @@ func (s *notificationService) Broadcast(ctx context.Context, req *dto.BroadcastN
 			Category: req.Category,
 			Priority: req.Priority,
 		}
-		for _, chType := range channels {
-			if chType == "websocket" {
-				ch, ok := s.channelRegistry.Get("websocket")
-				if ok && ch.IsAvailable() {
-					_ = ch.Send(ctx, msg)
-				}
+		// 过滤掉 in_app，因为已经通过 BatchCreate 批量创建了
+		var otherChannels []string
+		for _, ch := range channels {
+			if ch != "in_app" {
+				otherChannels = append(otherChannels, ch)
+			}
+		}
+		if len(otherChannels) > 0 {
+			if errs := s.channelRegistry.SendViaChannels(ctx, msg, otherChannels); len(errs) > 0 {
+				// 广播场景下不因个别渠道失败而中断
+				logger.Error("broadcast notification via channels failed",
+					zap.String("user_id", userID.String()),
+					zap.Int("error_count", len(errs)))
 			}
 		}
 	}

--- a/backend/internal/notification/service/notification_service.go
+++ b/backend/internal/notification/service/notification_service.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+// NotificationService 通知服务接口
+type NotificationService interface {
+	Send(ctx context.Context, req *dto.SendNotificationRequest) error
+	BatchSend(ctx context.Context, reqs []*dto.SendNotificationRequest) error
+	ListByUser(ctx context.Context, userID uuid.UUID, req *dto.ListNotificationsRequest) ([]*model.Notification, int64, error)
+	MarkAsRead(ctx context.Context, userID uuid.UUID, ids []uuid.UUID) error
+	MarkAllAsRead(ctx context.Context, userID uuid.UUID, category string) error
+	Delete(ctx context.Context, userID uuid.UUID, id uuid.UUID) error
+	GetUnreadCount(ctx context.Context, userID uuid.UUID) (int64, error)
+	Broadcast(ctx context.Context, req *dto.BroadcastNotificationRequest, onlineUserIDs []uuid.UUID) error
+}
+
+type notificationService struct {
+	notificationRepo repo.NotificationRepo
+	templateRepo     repo.NotificationTemplateRepo
+	templateEngine   TemplateEngine
+	channelRegistry  *ChannelRegistry
+}
+
+// NewNotificationService 创建通知服务
+func NewNotificationService(
+	notificationRepo repo.NotificationRepo,
+	templateRepo repo.NotificationTemplateRepo,
+	templateEngine TemplateEngine,
+	channelRegistry *ChannelRegistry,
+) NotificationService {
+	return &notificationService{
+		notificationRepo: notificationRepo,
+		templateRepo:     templateRepo,
+		templateEngine:   templateEngine,
+		channelRegistry:  channelRegistry,
+	}
+}
+
+// Send 发送通知（通过模板渲染 + 多渠道分发）
+func (s *notificationService) Send(ctx context.Context, req *dto.SendNotificationRequest) error {
+	// 1. 渲染模板
+	rendered, err := s.templateEngine.Render(ctx, req.TemplateCode, req.Variables)
+	if err != nil {
+		return err
+	}
+
+	// 2. 确定发送渠道
+	channels := req.Channels
+	if len(channels) == 0 {
+		tpl, err := s.templateRepo.GetByCode(ctx, req.TemplateCode)
+		if err == nil && tpl.Channels != "" {
+			channels = tpl.GetChannels()
+		}
+		if len(channels) == 0 {
+			channels = []string{"in_app", "websocket"}
+		}
+	}
+
+	// 3. 为每个用户发送通知
+	for _, userID := range req.UserIDs {
+		msg := &NotificationMessage{
+			UserID:   userID,
+			Title:    rendered.Title,
+			Content:  rendered.Content,
+			Category: "system",
+			Priority: "normal",
+		}
+		errs := s.channelRegistry.SendViaChannels(ctx, msg, channels)
+		if len(errs) > 0 {
+			return fmt.Errorf("send notification to user %s: %w", userID, errs[0])
+		}
+	}
+
+	return nil
+}
+
+// BatchSend 批量发送通知
+func (s *notificationService) BatchSend(ctx context.Context, reqs []*dto.SendNotificationRequest) error {
+	for _, req := range reqs {
+		if err := s.Send(ctx, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ListByUser 查询用户通知列表
+func (s *notificationService) ListByUser(ctx context.Context, userID uuid.UUID, req *dto.ListNotificationsRequest) ([]*model.Notification, int64, error) {
+	return s.notificationRepo.ListByUser(ctx, userID, req.Page, req.PageSize, req.Category, req.UnreadOnly)
+}
+
+// MarkAsRead 标记通知为已读
+func (s *notificationService) MarkAsRead(ctx context.Context, userID uuid.UUID, ids []uuid.UUID) error {
+	return s.notificationRepo.MarkAsRead(ctx, userID, ids)
+}
+
+// MarkAllAsRead 标记用户全部通知为已读
+func (s *notificationService) MarkAllAsRead(ctx context.Context, userID uuid.UUID, category string) error {
+	return s.notificationRepo.MarkAllAsRead(ctx, userID, category)
+}
+
+// Delete 删除通知
+func (s *notificationService) Delete(ctx context.Context, userID uuid.UUID, id uuid.UUID) error {
+	// 先检查通知是否属于该用户
+	n, err := s.notificationRepo.GetByID(ctx, id)
+	if err != nil {
+		return response.NewError(response.CodeNotificationNotFound, "通知不存在")
+	}
+	if n.UserID != userID {
+		return response.NewError(response.CodeNotificationNoAccess, "无权操作该通知")
+	}
+	return s.notificationRepo.Delete(ctx, userID, id)
+}
+
+// GetUnreadCount 获取用户未读通知数
+func (s *notificationService) GetUnreadCount(ctx context.Context, userID uuid.UUID) (int64, error) {
+	return s.notificationRepo.GetUnreadCount(ctx, userID)
+}
+
+// Broadcast 广播通知（给所有在线用户）
+func (s *notificationService) Broadcast(ctx context.Context, req *dto.BroadcastNotificationRequest, onlineUserIDs []uuid.UUID) error {
+	channels := req.Channels
+	if len(channels) == 0 {
+		channels = []string{"in_app", "websocket"}
+	}
+
+	// 批量创建站内通知
+	var notifications []*model.Notification
+	for _, userID := range onlineUserIDs {
+		notifications = append(notifications, &model.Notification{
+			ID:       uuid.New(),
+			UserID:   userID,
+			Title:    req.Title,
+			Content:  req.Content,
+			Category: req.Category,
+			Priority: req.Priority,
+			IsRead:   false,
+		})
+	}
+
+	if err := s.notificationRepo.BatchCreate(ctx, notifications); err != nil {
+		return fmt.Errorf("batch create notifications: %w", err)
+	}
+
+	// WebSocket 实时推送
+	for _, userID := range onlineUserIDs {
+		msg := &NotificationMessage{
+			UserID:   userID,
+			Title:    req.Title,
+			Content:  req.Content,
+			Category: req.Category,
+			Priority: req.Priority,
+		}
+		for _, chType := range channels {
+			if chType == "websocket" {
+				ch, ok := s.channelRegistry.Get("websocket")
+				if ok && ch.IsAvailable() {
+					_ = ch.Send(ctx, msg)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/backend/internal/notification/service/notification_service.go
+++ b/backend/internal/notification/service/notification_service.go
@@ -49,31 +49,34 @@ func NewNotificationService(
 
 // Send 发送通知（通过模板渲染 + 多渠道分发）
 func (s *notificationService) Send(ctx context.Context, req *dto.SendNotificationRequest) error {
-	// 1. 渲染模板
-	rendered, err := s.templateEngine.Render(ctx, req.TemplateCode, req.Variables)
+	// 1. 查询模板一次，用于渲染 + 获取渠道和分类
+	tpl, err := s.templateRepo.GetByCode(ctx, req.TemplateCode)
+	if err != nil {
+		return response.NewError(response.CodeNotificationTplNotFound, "通知模板不存在")
+	}
+
+	// 2. 渲染模板
+	rendered, err := s.templateEngine.RenderTemplate(tpl, req.Variables)
 	if err != nil {
 		return err
 	}
 
-	// 2. 获取模板配置（渠道 + 分类），仅在渠道未指定时查询
+	// 3. 确定分类和渠道
 	category := "system"
+	if tpl.Category != "" {
+		category = tpl.Category
+	}
 	channels := req.Channels
 	if len(channels) == 0 {
-		tpl, err := s.templateRepo.GetByCode(ctx, req.TemplateCode)
-		if err == nil {
-			if tpl.Category != "" {
-				category = tpl.Category
-			}
-			if tpl.Channels != "" {
-				channels = tpl.GetChannels()
-			}
+		if tpl.Channels != "" {
+			channels = tpl.GetChannels()
 		}
 		if len(channels) == 0 {
 			channels = []string{"in_app", "websocket"}
 		}
 	}
 
-	// 3. 为每个用户发送通知（收集所有错误，不因单个用户失败而中断）
+	// 4. 为每个用户发送通知（收集所有错误，不因单个用户失败而中断）
 	var sendErrs []error
 	for _, userID := range req.UserIDs {
 		msg := &NotificationMessage{

--- a/backend/internal/notification/service/template_engine.go
+++ b/backend/internal/notification/service/template_engine.go
@@ -16,6 +16,8 @@ import (
 // TemplateEngine 通知模板引擎接口
 type TemplateEngine interface {
 	Render(ctx context.Context, templateCode string, variables map[string]interface{}) (*dto.TestTemplateResponse, error)
+	// RenderTemplate 直接渲染已查出的模板，避免重复查库
+	RenderTemplate(tpl *model.NotificationTemplate, variables map[string]interface{}) (*dto.TestTemplateResponse, error)
 	Validate(ctx context.Context, templateCode string, variables map[string]interface{}) error
 }
 
@@ -34,8 +36,12 @@ func (e *templateEngine) Render(ctx context.Context, templateCode string, variab
 	if err != nil {
 		return nil, response.NewError(response.CodeNotificationTplNotFound, "通知模板不存在")
 	}
+	return e.RenderTemplate(tpl, variables)
+}
 
-	if tpl.Status != 0 {
+// RenderTemplate 直接渲染已查出的模板
+func (e *templateEngine) RenderTemplate(tpl *model.NotificationTemplate, variables map[string]interface{}) (*dto.TestTemplateResponse, error) {
+	if tpl.Status != model.TemplateStatusEnabled {
 		return nil, response.NewError(response.CodeNotificationTplNotFound, "通知模板已禁用")
 	}
 

--- a/backend/internal/notification/service/template_engine.go
+++ b/backend/internal/notification/service/template_engine.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"text/template"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+)
+
+// TemplateEngine 通知模板引擎接口
+type TemplateEngine interface {
+	Render(ctx context.Context, templateCode string, variables map[string]interface{}) (*dto.TestTemplateResponse, error)
+	Validate(ctx context.Context, templateCode string, variables map[string]interface{}) error
+}
+
+type templateEngine struct {
+	templateRepo repo.NotificationTemplateRepo
+}
+
+// NewTemplateEngine 创建模板引擎
+func NewTemplateEngine(templateRepo repo.NotificationTemplateRepo) TemplateEngine {
+	return &templateEngine{templateRepo: templateRepo}
+}
+
+// Render 渲染模板，返回标题和内容
+func (e *templateEngine) Render(ctx context.Context, templateCode string, variables map[string]interface{}) (*dto.TestTemplateResponse, error) {
+	tpl, err := e.templateRepo.GetByCode(ctx, templateCode)
+	if err != nil {
+		return nil, response.NewError(response.CodeNotificationTplNotFound, "通知模板不存在")
+	}
+
+	if tpl.Status != 0 {
+		return nil, response.NewError(response.CodeNotificationTplNotFound, "通知模板已禁用")
+	}
+
+	// 渲染标题
+	titleBuf, err := renderTemplate(tpl.TitleTemplate, variables)
+	if err != nil {
+		return nil, response.NewError(response.CodeNotificationRenderFail,
+			fmt.Sprintf("模板渲染失败（标题）: %v", err))
+	}
+
+	// 渲染内容
+	bodyBuf, err := renderTemplate(tpl.BodyTemplate, variables)
+	if err != nil {
+		return nil, response.NewError(response.CodeNotificationRenderFail,
+			fmt.Sprintf("模板渲染失败（内容）: %v", err))
+	}
+
+	return &dto.TestTemplateResponse{
+		Title:   titleBuf.String(),
+		Content: bodyBuf.String(),
+	}, nil
+}
+
+// Validate 校验模板变量是否完整
+func (e *templateEngine) Validate(ctx context.Context, templateCode string, variables map[string]interface{}) error {
+	_, err := e.Render(ctx, templateCode, variables)
+	return err
+}
+
+// renderTemplate 使用 text/template 渲染模板字符串
+func renderTemplate(tplText string, variables map[string]interface{}) (*bytes.Buffer, error) {
+	t, err := template.New("notification").Parse(tplText)
+	if err != nil {
+		return nil, fmt.Errorf("parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, variables); err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+
+	return &buf, nil
+}
+
+// TemplateToResponse 将模板模型转为响应 DTO
+func TemplateToResponse(t *model.NotificationTemplate) *dto.NotificationTemplateResponse {
+	var channels []string
+	_ = json.Unmarshal([]byte(t.Channels), &channels)
+
+	var schema map[string]string
+	_ = json.Unmarshal([]byte(t.VariablesSchema), &schema)
+
+	return &dto.NotificationTemplateResponse{
+		ID:              t.ID.String(),
+		Code:            t.Code,
+		Name:            t.Name,
+		TitleTemplate:   t.TitleTemplate,
+		BodyTemplate:    t.BodyTemplate,
+		Channels:        channels,
+		Category:        t.Category,
+		VariablesSchema: schema,
+		Status:          t.Status,
+		CreatedAt:       t.CreatedAt,
+		UpdatedAt:       t.UpdatedAt,
+	}
+}

--- a/backend/internal/notification/service/template_service.go
+++ b/backend/internal/notification/service/template_service.go
@@ -51,7 +51,7 @@ func (s *templateService) Create(ctx context.Context, req *dto.CreateTemplateReq
 		TitleTemplate: req.TitleTemplate,
 		BodyTemplate:  req.BodyTemplate,
 		Category:      req.Category,
-		Status:        0,
+		Status:        model.TemplateStatusEnabled,
 	}
 	tpl.SetChannels(req.Channels)
 	tpl.SetVariablesSchema(req.VariablesSchema)

--- a/backend/internal/notification/service/template_service.go
+++ b/backend/internal/notification/service/template_service.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+// TemplateService 通知模板管理服务接口
+type TemplateService interface {
+	Create(ctx context.Context, req *dto.CreateTemplateRequest) (*dto.NotificationTemplateResponse, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*dto.NotificationTemplateResponse, error)
+	List(ctx context.Context, req *dto.ListTemplatesRequest) ([]*dto.NotificationTemplateResponse, int64, error)
+	Update(ctx context.Context, id uuid.UUID, req *dto.UpdateTemplateRequest) (*dto.NotificationTemplateResponse, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	Test(ctx context.Context, id uuid.UUID, req *dto.TestTemplateRequest) (*dto.TestTemplateResponse, error)
+}
+
+type templateService struct {
+	templateRepo   repo.NotificationTemplateRepo
+	templateEngine TemplateEngine
+}
+
+// NewTemplateService 创建模板服务
+func NewTemplateService(
+	templateRepo repo.NotificationTemplateRepo,
+	templateEngine TemplateEngine,
+) TemplateService {
+	return &templateService{
+		templateRepo:   templateRepo,
+		templateEngine: templateEngine,
+	}
+}
+
+func (s *templateService) Create(ctx context.Context, req *dto.CreateTemplateRequest) (*dto.NotificationTemplateResponse, error) {
+	// 检查 code 是否已存在
+	existing, err := s.templateRepo.GetByCode(ctx, req.Code)
+	if err == nil && existing != nil {
+		return nil, response.NewError(response.CodeNotificationTplExists, "模板 Code 已存在")
+	}
+
+	tpl := &model.NotificationTemplate{
+		ID:            uuid.New(),
+		Code:          req.Code,
+		Name:          req.Name,
+		TitleTemplate: req.TitleTemplate,
+		BodyTemplate:  req.BodyTemplate,
+		Category:      req.Category,
+		Status:        0,
+	}
+	tpl.SetChannels(req.Channels)
+	tpl.SetVariablesSchema(req.VariablesSchema)
+
+	if err := s.templateRepo.Create(ctx, tpl); err != nil {
+		return nil, fmt.Errorf("create template: %w", err)
+	}
+
+	return TemplateToResponse(tpl), nil
+}
+
+func (s *templateService) GetByID(ctx context.Context, id uuid.UUID) (*dto.NotificationTemplateResponse, error) {
+	tpl, err := s.templateRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, response.NewError(response.CodeNotificationTplNotFound, "通知模板不存在")
+	}
+	return TemplateToResponse(tpl), nil
+}
+
+func (s *templateService) List(ctx context.Context, req *dto.ListTemplatesRequest) ([]*dto.NotificationTemplateResponse, int64, error) {
+	list, total, err := s.templateRepo.List(ctx, req.Page, req.PageSize, req.Keyword)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list templates: %w", err)
+	}
+
+	result := make([]*dto.NotificationTemplateResponse, 0, len(list))
+	for _, tpl := range list {
+		result = append(result, TemplateToResponse(tpl))
+	}
+	return result, total, nil
+}
+
+func (s *templateService) Update(ctx context.Context, id uuid.UUID, req *dto.UpdateTemplateRequest) (*dto.NotificationTemplateResponse, error) {
+	tpl, err := s.templateRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, response.NewError(response.CodeNotificationTplNotFound, "通知模板不存在")
+	}
+
+	if req.Name != nil {
+		tpl.Name = *req.Name
+	}
+	if req.TitleTemplate != nil {
+		tpl.TitleTemplate = *req.TitleTemplate
+	}
+	if req.BodyTemplate != nil {
+		tpl.BodyTemplate = *req.BodyTemplate
+	}
+	if req.Category != nil {
+		tpl.Category = *req.Category
+	}
+	if req.Channels != nil {
+		tpl.SetChannels(req.Channels)
+	}
+	if req.VariablesSchema != nil {
+		tpl.SetVariablesSchema(req.VariablesSchema)
+	}
+	if req.Status != nil {
+		tpl.Status = *req.Status
+	}
+
+	if err := s.templateRepo.Update(ctx, tpl); err != nil {
+		return nil, fmt.Errorf("update template: %w", err)
+	}
+
+	return TemplateToResponse(tpl), nil
+}
+
+func (s *templateService) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := s.templateRepo.Delete(ctx, id); err != nil {
+		return response.NewError(response.CodeNotificationTplNotFound, "通知模板不存在")
+	}
+	return nil
+}
+
+func (s *templateService) Test(ctx context.Context, id uuid.UUID, req *dto.TestTemplateRequest) (*dto.TestTemplateResponse, error) {
+	tpl, err := s.templateRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, response.NewError(response.CodeNotificationTplNotFound, "通知模板不存在")
+	}
+	return s.templateEngine.Render(ctx, tpl.Code, req.Variables)
+}
+
+// channelsToJSON 将渠道列表序列化为 JSON 字符串
+func channelsToJSON(channels []string) string {
+	data, _ := json.Marshal(channels)
+	return string(data)
+}
+
+// schemaToJSON 将变量 schema 序列化为 JSON 字符串
+func schemaToJSON(schema map[string]string) string {
+	data, _ := json.Marshal(schema)
+	return string(data)
+}

--- a/backend/internal/notification/service/template_service.go
+++ b/backend/internal/notification/service/template_service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
@@ -133,16 +132,4 @@ func (s *templateService) Test(ctx context.Context, id uuid.UUID, req *dto.TestT
 		return nil, response.NewError(response.CodeNotificationTplNotFound, "通知模板不存在")
 	}
 	return s.templateEngine.Render(ctx, tpl.Code, req.Variables)
-}
-
-// channelsToJSON 将渠道列表序列化为 JSON 字符串
-func channelsToJSON(channels []string) string {
-	data, _ := json.Marshal(channels)
-	return string(data)
-}
-
-// schemaToJSON 将变量 schema 序列化为 JSON 字符串
-func schemaToJSON(schema map[string]string) string {
-	data, _ := json.Marshal(schema)
-	return string(data)
 }

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -96,8 +96,14 @@ const (
 	CodeStatsInvalidParam     = 11002 // 统计参数无效
 
 	// ===== Notification module (12000-12999) =====
-	CodeNotificationNotFound  = 12001 // 通知不存在
-	CodeNotificationTplExists = 12002 // 通知模板已存在
+	CodeNotificationNotFound    = 12001 // 通知不存在
+	CodeNotificationTplExists   = 12002 // 通知模板已存在
+	CodeNotificationTplNotFound = 12003 // 通知模板不存在
+	CodeNotificationRenderFail  = 12004 // 模板渲染失败（变量缺失）
+	CodeNotificationWSAuthFail  = 12005 // WebSocket 认证失败
+	CodeNotificationEmailFail   = 12006 // 邮件发送失败
+	CodeNotificationBadChannel  = 12007 // 不支持的通知渠道
+	CodeNotificationNoAccess    = 12008 // 无权操作该通知
 )
 
 // ModuleRanges maps each module name to its error-code range [min, max].

--- a/frontend/src/api/notification.ts
+++ b/frontend/src/api/notification.ts
@@ -5,80 +5,105 @@ import type {
   ListNotificationParams,
   CreateNotificationTemplateParams,
   UpdateNotificationTemplateParams,
+  TestTemplateParams,
+  TestTemplateResult,
+  SendNotificationParams,
+  BroadcastNotificationParams,
+  ListTemplateParams,
   PageResponse,
 } from '@/types/api';
 
 // ============================================================
-// 通知
+// 用户通知
 // ============================================================
 
-// 获取通知列表
+/** 获取通知列表（分页） */
 export function getNotificationList(
   params: ListNotificationParams,
 ): Promise<PageResponse<Notification>> {
   return request.get('/notifications', { params });
 }
 
-// 获取未读数量
+/** 获取未读数量 */
 export function getUnreadCount(): Promise<{ count: number }> {
-  return request.get('/notifications/unread-count');
+  return request.get('/notifications/unread/count');
 }
 
-// 获取通知详情
-export function getNotificationDetail(id: string): Promise<Notification> {
-  return request.get(`/notifications/${id}`);
-}
-
-// 标记为已读
+/** 标记单条通知为已读 */
 export function markAsRead(id: string): Promise<void> {
   return request.post(`/notifications/${id}/read`);
 }
 
-// 全部标记为已读
-export function markAllAsRead(): Promise<void> {
-  return request.post('/notifications/read-all');
+/** 全部标记为已读 */
+export function markAllAsRead(category?: string): Promise<void> {
+  return request.post('/notifications/read-all', { category });
 }
 
-// 删除通知
+/** 删除通知 */
 export function deleteNotification(id: string): Promise<void> {
   return request.delete(`/notifications/${id}`);
 }
 
 // ============================================================
-// 通知模板
+// 管理员通知操作
 // ============================================================
 
-// 获取模板列表
-export function getNotificationTemplateList(params: {
-  page?: number;
-  page_size?: number;
-  type?: number;
-  status?: number;
-}): Promise<PageResponse<NotificationTemplate>> {
-  return request.get('/notifications/templates', { params });
+/** 通过模板向指定用户发送通知 */
+export function sendNotification(
+  data: SendNotificationParams,
+): Promise<void> {
+  return request.post('/system/notifications/send', data);
 }
 
-// 获取模板详情
-export function getNotificationTemplateDetail(id: string): Promise<NotificationTemplate> {
-  return request.get(`/notifications/templates/${id}`);
+/** 向所有在线用户广播通知 */
+export function broadcastNotification(
+  data: BroadcastNotificationParams,
+): Promise<void> {
+  return request.post('/system/notifications/broadcast', data);
 }
 
-// 创建模板
+// ============================================================
+// 通知模板管理
+// ============================================================
+
+/** 获取模板列表（分页） */
+export function getNotificationTemplateList(
+  params: ListTemplateParams,
+): Promise<PageResponse<NotificationTemplate>> {
+  return request.get('/notification-templates', { params });
+}
+
+/** 获取模板详情 */
+export function getNotificationTemplateDetail(
+  id: string,
+): Promise<NotificationTemplate> {
+  return request.get(`/notification-templates/${id}`);
+}
+
+/** 创建模板 */
 export function createNotificationTemplate(
   data: CreateNotificationTemplateParams,
 ): Promise<NotificationTemplate> {
-  return request.post('/notifications/templates', data);
+  return request.post('/notification-templates', data);
 }
 
-// 更新模板
+/** 更新模板 */
 export function updateNotificationTemplate(
   id: string,
   data: UpdateNotificationTemplateParams,
 ): Promise<NotificationTemplate> {
-  return request.put(`/notifications/templates/${id}`, data);
+  return request.put(`/notification-templates/${id}`, data);
 }
 
-// 删除模板
+/** 删除模板 */
 export function deleteNotificationTemplate(id: string): Promise<void> {
-  return request.delete(`/notifications/templates/${id}`);
+  return request.delete(`/notification-templates/${id}`);
+}
+
+/** 测试模板渲染 */
+export function testNotificationTemplate(
+  id: string,
+  data: TestTemplateParams,
+): Promise<TestTemplateResult> {
+  return request.post(`/notification-templates/${id}/test`, data);
 }

--- a/frontend/src/components/NotificationBell/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell/NotificationBell.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useCallback } from 'react';
+import { Badge, Popover, List, Typography, Button, Empty, Tag, Tooltip } from 'antd';
+import { BellOutlined, CheckOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch } from '@/store';
+import {
+  selectUnreadCount,
+  selectRecentNotifications,
+  selectWSConnected,
+  fetchRecentNotifications,
+  fetchUnreadCount,
+  markAllNotificationsAsRead,
+  markNotificationAsRead,
+} from '@/store/slices/notificationSlice';
+import type { Notification, NotificationPriority, NotificationCategory } from '@/types/api';
+
+const { Text } = Typography;
+
+/** 优先级标签颜色映射 */
+const priorityColorMap: Record<string, string> = {
+  urgent: 'red',
+  high: 'orange',
+  normal: 'blue',
+  low: 'default',
+};
+
+/** 分类中文映射 */
+const categoryLabelMap: Record<string, string> = {
+  system: '系统',
+  task: '任务',
+  meeting: '会议',
+  approval: '审批',
+  interview: '面试',
+  other: '其他',
+};
+
+/** 格式化时间为相对时间 */
+function formatRelativeTime(dateStr: string): string {
+  if (!dateStr) return '';
+  const date = new Date(dateStr);
+  const now = Date.now();
+  const diff = now - date.getTime();
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes} 分钟前`;
+  if (hours < 24) return `${hours} 小时前`;
+  if (days < 7) return `${days} 天前`;
+  return date.toLocaleDateString('zh-CN');
+}
+
+const NotificationBell: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const unreadCount = useSelector(selectUnreadCount);
+  const recentNotifications = useSelector(selectRecentNotifications);
+  const wsConnected = useSelector(selectWSConnected);
+
+  // 首次挂载时拉取未读计数
+  useEffect(() => {
+    dispatch(fetchUnreadCount());
+    dispatch(fetchRecentNotifications());
+  }, [dispatch]);
+
+  const handleMarkRead = useCallback(
+    (id: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      dispatch(markNotificationAsRead(id));
+    },
+    [dispatch],
+  );
+
+  const handleMarkAllRead = useCallback(() => {
+    dispatch(markAllNotificationsAsRead());
+  }, [dispatch]);
+
+  const handleViewAll = useCallback(() => {
+    navigate('/notification/list');
+  }, [navigate]);
+
+  const handleNotificationClick = useCallback(
+    (notification: Notification) => {
+      // 如果有 action_url 跳转
+      if (notification.action_url) {
+        navigate(notification.action_url);
+      } else {
+        navigate('/notification/list');
+      }
+      // 标记已读
+      if (!notification.is_read) {
+        dispatch(markNotificationAsRead(notification.id));
+      }
+    },
+    [dispatch, navigate],
+  );
+
+  const renderNotificationItem = (item: Notification) => (
+    <List.Item
+      style={{
+        cursor: 'pointer',
+        padding: '8px 12px',
+        background: item.is_read ? 'transparent' : 'rgba(24, 144, 255, 0.06)',
+      }}
+      onClick={() => handleNotificationClick(item)}
+    >
+      <div style={{ width: '100%' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+          <Text strong={!item.is_read} style={{ fontSize: 13 }}>
+            {item.title}
+          </Text>
+          {!item.is_read && (
+            <Tooltip title="标记已读">
+              <Button
+                type="text"
+                size="small"
+                icon={<CheckOutlined />}
+                onClick={(e) => handleMarkRead(item.id, e)}
+              />
+            </Tooltip>
+          )}
+        </div>
+        <Text type="secondary" style={{ fontSize: 12, display: 'block' }} ellipsis>
+          {item.content}
+        </Text>
+        <div style={{ display: 'flex', gap: 6, marginTop: 4, alignItems: 'center' }}>
+          <Tag color={priorityColorMap[item.priority as NotificationPriority] || 'default'} style={{ fontSize: 11 }}>
+            {categoryLabelMap[item.category as NotificationCategory] || item.category}
+          </Tag>
+          <Text type="secondary" style={{ fontSize: 11 }}>
+            {formatRelativeTime(item.created_at)}
+          </Text>
+        </div>
+      </div>
+    </List.Item>
+  );
+
+  const content = (
+    <div style={{ width: 360 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px 4px 8px' }}>
+        <Text strong>消息通知</Text>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <Tooltip title={wsConnected ? '已连接' : '未连接'}>
+            <Badge status={wsConnected ? 'success' : 'default'} />
+          </Tooltip>
+          {unreadCount > 0 && (
+            <Button type="link" size="small" icon={<CheckOutlined />} onClick={handleMarkAllRead}>
+              全部已读
+            </Button>
+          )}
+        </div>
+      </div>
+      {recentNotifications.length === 0 ? (
+        <Empty description="暂无通知" image={Empty.PRESENTED_IMAGE_SIMPLE} style={{ padding: 20 }} />
+      ) : (
+        <List
+          dataSource={recentNotifications.slice(0, 10)}
+          renderItem={renderNotificationItem}
+          style={{ maxHeight: 400, overflowY: 'auto' }}
+        />
+      )}
+      <div style={{ textAlign: 'center', borderTop: '1px solid #f0f0f0', padding: '8px 0' }}>
+        <Button type="link" onClick={handleViewAll} style={{ fontSize: 13 }}>
+          查看全部通知
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <Popover
+      content={content}
+      trigger="click"
+      placement="bottomRight"
+      arrow={false}
+      onOpenChange={(open) => {
+        if (open) {
+          dispatch(fetchRecentNotifications());
+        }
+      }}
+    >
+      <Tooltip title="消息通知">
+        <Badge count={unreadCount} size="small" offset={[-2, 2]}>
+          <BellOutlined style={{ fontSize: 18, cursor: 'pointer' }} />
+        </Badge>
+      </Tooltip>
+    </Popover>
+  );
+};
+
+export default NotificationBell;

--- a/frontend/src/components/NotificationBell/index.ts
+++ b/frontend/src/components/NotificationBell/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NotificationBell';

--- a/frontend/src/hooks/useNotificationWebSocket.ts
+++ b/frontend/src/hooks/useNotificationWebSocket.ts
@@ -8,7 +8,7 @@ import {
 } from '@/store/slices/notificationSlice';
 import { selectIsAuthenticated } from '@/store/slices/authSlice';
 import { getToken } from '@/utils/storage';
-import type { WSNotificationMessage } from '@/types/api';
+import type { WSNotificationMessage, NotificationCategory, NotificationPriority } from '@/types/api';
 import type { AppDispatch } from '@/store';
 
 /** 重连最大次数 */
@@ -96,8 +96,8 @@ export function useNotificationWebSocket(): void {
               id: '', // WebSocket 通知可能没有 ID，后续 fetch 会补全
               title: msg.data.title || '',
               content: msg.data.content || '',
-              category: (msg.data.category as any) || 'other',
-              priority: (msg.data.priority as any) || 'normal',
+              category: (msg.data.category as NotificationCategory) || 'other',
+              priority: (msg.data.priority as NotificationPriority) || 'normal',
               is_read: false,
               action_url: msg.data.action_url || '',
               sender: msg.data.sender || { id: '', name: '系统' },

--- a/frontend/src/hooks/useNotificationWebSocket.ts
+++ b/frontend/src/hooks/useNotificationWebSocket.ts
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  addNotification,
+  setWSConnected,
+  fetchUnreadCount,
+  fetchRecentNotifications,
+} from '@/store/slices/notificationSlice';
+import { selectIsAuthenticated } from '@/store/slices/authSlice';
+import { getToken } from '@/utils/storage';
+import type { WSNotificationMessage } from '@/types/api';
+import type { AppDispatch } from '@/store';
+
+/** 重连最大次数 */
+const MAX_RECONNECT = 5;
+/** 重连基础延迟（毫秒） */
+const RECONNECT_BASE_DELAY = 2000;
+/** 心跳间隔（毫秒） */
+const HEARTBEAT_INTERVAL = 30000;
+
+/** 构建 WebSocket URL */
+function buildWSUrl(token: string): string {
+  const wsBase = import.meta.env.VITE_WS_URL || '/ws';
+  const wsPath = `${wsBase}/notifications`;
+  let url: string;
+
+  if (wsPath.startsWith('ws://') || wsPath.startsWith('wss://')) {
+    url = wsPath;
+  } else {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const host = window.location.host;
+    url = `${protocol}//${host}${wsPath}`;
+  }
+
+  url += `?token=${encodeURIComponent(token)}`;
+  return url;
+}
+
+/**
+ * 通知 WebSocket 连接 Hook
+ *
+ * - 自动在用户登录后建立 WebSocket 连接
+ * - 收到新通知时 dispatch 到 Redux store
+ * - 支持自动重连（指数退避）
+ * - 支持心跳检测
+ * - 登出/Token 失效时自动断开
+ */
+export function useNotificationWebSocket(): void {
+  const dispatch = useDispatch<AppDispatch>();
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectCount = useRef(0);
+  const heartbeatTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const shouldConnect = useRef(false);
+
+  /** 清理心跳和重连定时器 */
+  const clearTimers = useCallback(() => {
+    if (heartbeatTimer.current) {
+      clearInterval(heartbeatTimer.current);
+      heartbeatTimer.current = null;
+    }
+    if (reconnectTimer.current) {
+      clearTimeout(reconnectTimer.current);
+      reconnectTimer.current = null;
+    }
+  }, []);
+
+  /** 主动断开连接 */
+  const disconnect = useCallback(() => {
+    shouldConnect.current = false;
+    clearTimers();
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      if (wsRef.current.readyState === WebSocket.OPEN) {
+        wsRef.current.close(1000, 'user disconnect');
+      }
+      wsRef.current = null;
+    }
+    dispatch(setWSConnected(false));
+  }, [clearTimers, dispatch]);
+
+  /** 处理收到的 WebSocket 消息 */
+  const handleMessage = useCallback(
+    (event: MessageEvent) => {
+      try {
+        const msg: WSNotificationMessage = JSON.parse(event.data);
+
+        switch (msg.type) {
+          case 'notification': {
+            // 构建完整的 Notification 对象
+            const notification = {
+              id: '', // WebSocket 通知可能没有 ID，后续 fetch 会补全
+              title: msg.data.title || '',
+              content: msg.data.content || '',
+              category: (msg.data.category as any) || 'other',
+              priority: (msg.data.priority as any) || 'normal',
+              is_read: false,
+              action_url: msg.data.action_url || '',
+              sender: msg.data.sender || { id: '', name: '系统' },
+              created_at: new Date().toISOString(),
+            };
+            dispatch(addNotification(notification));
+            break;
+          }
+          case 'auth_result': {
+            // 认证结果已在 onopen 后处理
+            break;
+          }
+          case 'pong': {
+            // 心跳回应，无需处理
+            break;
+          }
+          default:
+            break;
+        }
+      } catch {
+        // 忽略无法解析的消息
+      }
+    },
+    [dispatch],
+  );
+
+  /** 建立连接 */
+  const connect = useCallback(() => {
+    const token = getToken();
+    if (!token) return;
+
+    const url = buildWSUrl(token);
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      shouldConnect.current = true;
+      reconnectCount.current = 0;
+      dispatch(setWSConnected(true));
+
+      // 拉取最新未读数和最近通知
+      dispatch(fetchUnreadCount());
+      dispatch(fetchRecentNotifications());
+
+      // 启动心跳
+      heartbeatTimer.current = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'ping' }));
+        }
+      }, HEARTBEAT_INTERVAL);
+    };
+
+    ws.onmessage = handleMessage;
+
+    ws.onclose = (event: CloseEvent) => {
+      dispatch(setWSConnected(false));
+      clearTimers();
+
+      // 非正常关闭且仍有 Token → 自动重连
+      if (shouldConnect.current && event.code !== 1000 && reconnectCount.current < MAX_RECONNECT) {
+        const delay = RECONNECT_BASE_DELAY * Math.pow(2, reconnectCount.current);
+        reconnectCount.current += 1;
+        reconnectTimer.current = setTimeout(() => {
+          connect();
+        }, delay);
+      }
+    };
+
+    ws.onerror = () => {
+      dispatch(setWSConnected(false));
+    };
+  }, [dispatch, handleMessage, clearTimers]);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      connect();
+    } else {
+      disconnect();
+    }
+
+    return () => {
+      disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated]);
+
+  // 页面卸载时清理
+  useEffect(() => {
+    return () => {
+      disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/frontend/src/layouts/MainLayout/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout/MainLayout.tsx
@@ -14,6 +14,7 @@ import {
   ReadOutlined,
   BarChartOutlined,
   SettingOutlined,
+  BellOutlined,
 } from '@ant-design/icons';
 
 import TopBar from './components/TopBar';
@@ -36,6 +37,7 @@ const iconMap: Record<string, React.FC> = {
   ReadOutlined,
   BarChartOutlined,
   SettingOutlined,
+  BellOutlined,
 };
 
 export interface MainLayoutProps {

--- a/frontend/src/layouts/MainLayout/components/TopBar.tsx
+++ b/frontend/src/layouts/MainLayout/components/TopBar.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Layout, Avatar, Dropdown, Badge, Breadcrumb, Tooltip } from 'antd';
+import { Layout, Avatar, Dropdown, Breadcrumb } from 'antd';
 import {
   MenuFoldOutlined,
   MenuUnfoldOutlined,
-  BellOutlined,
   UserOutlined,
   LogoutOutlined,
   SettingOutlined,
@@ -15,8 +14,11 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { toggleCollapsed } from '@/store/slices/appSlice';
 import { selectCurrentUser, clearUser } from '@/store/slices/userSlice';
 import { logout as logoutAction } from '@/store/slices/authSlice';
+import { clearNotifications } from '@/store/slices/notificationSlice';
 import { logout as logoutApi } from '@/api/auth';
 import { removeToken } from '@/utils/storage';
+import { useNotificationWebSocket } from '@/hooks/useNotificationWebSocket';
+import NotificationBell from '@/components/NotificationBell';
 import type { AppDispatch } from '@/store';
 
 const { Header: AntHeader } = Layout;
@@ -32,6 +34,9 @@ const TopBar: React.FC<TopBarProps> = () => {
   const collapsed = useSelector((state: { app: { collapsed: boolean } }) => state.app.collapsed);
   const currentUser = useSelector(selectCurrentUser);
 
+  // 初始化通知 WebSocket 连接
+  useNotificationWebSocket();
+
   const handleLogout = async () => {
     try {
       await logoutApi();
@@ -40,6 +45,7 @@ const TopBar: React.FC<TopBarProps> = () => {
     }
     dispatch(logoutAction());
     dispatch(clearUser());
+    dispatch(clearNotifications());
     removeToken();
     navigate('/login', { replace: true });
   };
@@ -94,11 +100,7 @@ const TopBar: React.FC<TopBarProps> = () => {
       </div>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-        <Tooltip title="消息通知">
-          <Badge count={0} size="small">
-            <BellOutlined style={{ fontSize: 18, cursor: 'pointer' }} />
-          </Badge>
-        </Tooltip>
+        <NotificationBell />
 
         <Dropdown menu={{ items: userMenuItems }} placement="bottomRight">
           <div style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: 8 }}>

--- a/frontend/src/pages/notification/NotificationList.tsx
+++ b/frontend/src/pages/notification/NotificationList.tsx
@@ -1,0 +1,391 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Card,
+  Table,
+  Button,
+  Select,
+  Space,
+  Tag,
+  Drawer,
+  Typography,
+  message,
+  Popconfirm,
+  Switch,
+  Badge,
+} from 'antd';
+import {
+  CheckOutlined,
+  DeleteOutlined,
+  ReloadOutlined,
+  EyeOutlined,
+} from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import type { AppDispatch } from '@/store';
+import {
+  fetchUnreadCount,
+  markAllNotificationsAsRead,
+} from '@/store/slices/notificationSlice';
+import {
+  getNotificationList,
+  markAsRead,
+  markAllAsRead,
+  deleteNotification,
+} from '@/api/notification';
+import type { Notification, NotificationCategory } from '@/types/api';
+
+const { Text, Paragraph, Title } = Typography;
+
+/** 分类选项 */
+const categoryOptions = [
+  { label: '全部', value: '' },
+  { label: '系统', value: 'system' },
+  { label: '任务', value: 'task' },
+  { label: '会议', value: 'meeting' },
+  { label: '审批', value: 'approval' },
+  { label: '面试', value: 'interview' },
+  { label: '其他', value: 'other' },
+];
+
+/** 分类标签颜色映射 */
+const categoryColorMap: Record<string, string> = {
+  system: 'blue',
+  task: 'green',
+  meeting: 'purple',
+  approval: 'orange',
+  interview: 'cyan',
+  other: 'default',
+};
+
+/** 分类中文映射 */
+const categoryLabelMap: Record<string, string> = {
+  system: '系统',
+  task: '任务',
+  meeting: '会议',
+  approval: '审批',
+  interview: '面试',
+  other: '其他',
+};
+
+/** 优先级颜色映射 */
+const priorityColorMap: Record<string, string> = {
+  urgent: 'red',
+  high: 'orange',
+  normal: 'blue',
+  low: 'default',
+};
+
+/** 优先级中文映射 */
+const priorityLabelMap: Record<string, string> = {
+  urgent: '紧急',
+  high: '高',
+  normal: '普通',
+  low: '低',
+};
+
+const NotificationList: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<Notification[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [category, setCategory] = useState<string>('');
+  const [unreadOnly, setUnreadOnly] = useState(false);
+  const [drawerVisible, setDrawerVisible] = useState(false);
+  const [currentNotification, setCurrentNotification] = useState<Notification | null>(null);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getNotificationList({
+        page,
+        page_size: pageSize,
+        category: (category || undefined) as NotificationCategory,
+        unread_only: unreadOnly || undefined,
+      });
+      setData(res.list);
+      setTotal(res.total);
+    } catch {
+      message.error('加载通知列表失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize, category, unreadOnly]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // 标记单条已读
+  const handleMarkRead = async (record: Notification) => {
+    try {
+      await markAsRead(record.id);
+      // 更新本地数据
+      setData((prev) =>
+        prev.map((item) =>
+          item.id === record.id ? { ...item, is_read: true } : item,
+        ),
+      );
+      dispatch(fetchUnreadCount());
+      message.success('已标记为已读');
+    } catch {
+      message.error('标记已读失败');
+    }
+  };
+
+  // 全部已读
+  const handleMarkAllRead = async () => {
+    try {
+      await markAllAsRead(category || undefined);
+      dispatch(markAllNotificationsAsRead());
+      loadData();
+      message.success('已全部标记为已读');
+    } catch {
+      message.error('操作失败');
+    }
+  };
+
+  // 删除
+  const handleDelete = async (record: Notification) => {
+    try {
+      await deleteNotification(record.id);
+      setData((prev) => prev.filter((item) => item.id !== record.id));
+      setTotal((prev) => prev - 1);
+      dispatch(fetchUnreadCount());
+      message.success('删除成功');
+    } catch {
+      message.error('删除失败');
+    }
+  };
+
+  // 查看详情
+  const handleViewDetail = (record: Notification) => {
+    setCurrentNotification(record);
+    setDrawerVisible(true);
+    if (!record.is_read) {
+      handleMarkRead(record);
+    }
+  };
+
+  // 点击通知跳转
+  const handleAction = (record: Notification) => {
+    if (record.action_url) {
+      navigate(record.action_url);
+    }
+  };
+
+  const columns: ColumnsType<Notification> = [
+    {
+      title: '状态',
+      dataIndex: 'is_read',
+      key: 'is_read',
+      width: 70,
+      render: (isRead: boolean) =>
+        isRead ? <Tag>已读</Tag> : <Badge status="error" text="未读" />,
+    },
+    {
+      title: '标题',
+      dataIndex: 'title',
+      key: 'title',
+      width: 200,
+      render: (text: string, record: Notification) => (
+        <Text
+          strong={!record.is_read}
+          style={{ cursor: 'pointer' }}
+          onClick={() => handleViewDetail(record)}
+        >
+          {text}
+        </Text>
+      ),
+    },
+    {
+      title: '分类',
+      dataIndex: 'category',
+      key: 'category',
+      width: 90,
+      render: (cat: string) => (
+        <Tag color={categoryColorMap[cat] || 'default'}>
+          {categoryLabelMap[cat as NotificationCategory] || cat}
+        </Tag>
+      ),
+    },
+    {
+      title: '优先级',
+      dataIndex: 'priority',
+      key: 'priority',
+      width: 80,
+      render: (priority: string) => (
+        <Tag color={priorityColorMap[priority] || 'default'}>
+          {priorityLabelMap[priority] || priority}
+        </Tag>
+      ),
+    },
+    {
+      title: '发送者',
+      key: 'sender',
+      width: 100,
+      render: (_: unknown, record: Notification) =>
+        record.sender?.name || '-',
+    },
+    {
+      title: '时间',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      width: 160,
+      render: (time: string) =>
+        new Date(time).toLocaleString('zh-CN', { hour12: false }),
+    },
+    {
+      title: '操作',
+      key: 'action',
+      width: 150,
+      fixed: 'right',
+      render: (_: unknown, record: Notification) => (
+        <Space>
+          <Button
+            type="link"
+            size="small"
+            icon={<EyeOutlined />}
+            onClick={() => handleViewDetail(record)}
+          >
+            查看
+          </Button>
+          {!record.is_read && (
+            <Button
+              type="link"
+              size="small"
+              icon={<CheckOutlined />}
+              onClick={() => handleMarkRead(record)}
+            >
+              已读
+            </Button>
+          )}
+          <Popconfirm
+            title="确认删除此通知？"
+            onConfirm={() => handleDelete(record)}
+          >
+            <Button type="link" size="small" danger icon={<DeleteOutlined />}>
+              删除
+            </Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Card>
+      {/* 工具栏 */}
+      <div style={{ marginBottom: 16, display: 'flex', gap: 12, alignItems: 'center' }}>
+        <Select
+          value={category}
+          onChange={(val) => {
+            setCategory(val);
+            setPage(1);
+          }}
+          style={{ width: 120 }}
+          options={categoryOptions}
+        />
+        <Space>
+          <Text>仅未读</Text>
+          <Switch
+            checked={unreadOnly}
+            onChange={(checked) => {
+              setUnreadOnly(checked);
+              setPage(1);
+            }}
+          />
+        </Space>
+        <Button icon={<ReloadOutlined />} onClick={loadData}>
+          刷新
+        </Button>
+        <div style={{ flex: 1 }} />
+        <Button
+          type="primary"
+          icon={<CheckOutlined />}
+          onClick={handleMarkAllRead}
+          disabled={total === 0}
+        >
+          全部已读
+        </Button>
+      </div>
+
+      {/* 表格 */}
+      <Table
+        columns={columns}
+        dataSource={data}
+        rowKey="id"
+        loading={loading}
+        scroll={{ x: 900 }}
+        pagination={{
+          current: page,
+          pageSize,
+          total,
+          showSizeChanger: true,
+          showQuickJumper: true,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (p, ps) => {
+            setPage(p);
+            setPageSize(ps);
+          },
+        }}
+      />
+
+      {/* 详情抽屉 */}
+      <Drawer
+        title="通知详情"
+        open={drawerVisible}
+        onClose={() => setDrawerVisible(false)}
+        width={480}
+      >
+        {currentNotification && (
+          <div>
+            <div style={{ marginBottom: 16, display: 'flex', gap: 8 }}>
+              <Tag color={categoryColorMap[currentNotification.category] || 'default'}>
+                {categoryLabelMap[currentNotification.category as NotificationCategory] || currentNotification.category}
+              </Tag>
+              <Tag color={priorityColorMap[currentNotification.priority] || 'default'}>
+                {priorityLabelMap[currentNotification.priority] || currentNotification.priority}
+              </Tag>
+              {currentNotification.is_read ? (
+                <Tag>已读</Tag>
+              ) : (
+                <Badge status="error" text="未读" />
+              )}
+            </div>
+
+            <Title level={5}>{currentNotification.title}</Title>
+
+            <div style={{ marginBottom: 16 }}>
+              <Text type="secondary">
+                发送者：{currentNotification.sender?.name || '系统'}
+              </Text>
+              <br />
+              <Text type="secondary">
+                时间：{new Date(currentNotification.created_at).toLocaleString('zh-CN', { hour12: false })}
+              </Text>
+            </div>
+
+            <Paragraph style={{ whiteSpace: 'pre-wrap' }}>
+              {currentNotification.content}
+            </Paragraph>
+
+            {currentNotification.action_url && (
+              <Button
+                type="primary"
+                onClick={() => handleAction(currentNotification)}
+              >
+                查看详情
+              </Button>
+            )}
+          </div>
+        )}
+      </Drawer>
+    </Card>
+  );
+};
+
+export default NotificationList;

--- a/frontend/src/pages/notification/TemplateList.tsx
+++ b/frontend/src/pages/notification/TemplateList.tsx
@@ -1,0 +1,481 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Card,
+  Table,
+  Button,
+  Input,
+  Space,
+  Modal,
+  Form,
+  message,
+  Tag,
+  Select,
+  Drawer,
+  Typography,
+  Popconfirm,
+} from 'antd';
+import {
+  PlusOutlined,
+  SearchOutlined,
+  EditOutlined,
+  DeleteOutlined,
+  ReloadOutlined,
+  ExperimentOutlined,
+} from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import {
+  getNotificationTemplateList,
+  createNotificationTemplate,
+  updateNotificationTemplate,
+  deleteNotificationTemplate,
+  testNotificationTemplate,
+} from '@/api/notification';
+import type { NotificationTemplate, CreateNotificationTemplateParams } from '@/types/api';
+
+const { Text, Paragraph } = Typography;
+const { TextArea } = Input;
+
+/** 通知渠道选项 */
+const channelOptions = [
+  { label: '站内消息', value: 'in_app' },
+  { label: '邮件', value: 'email' },
+  { label: 'WebSocket', value: 'websocket' },
+];
+
+/** 模板状态映射 */
+const statusMap: Record<number, { color: string; text: string }> = {
+  0: { color: 'default', text: '禁用' },
+  1: { color: 'success', text: '启用' },
+};
+
+/** 渠道标签颜色映射 */
+const channelColorMap: Record<string, string> = {
+  in_app: 'blue',
+  email: 'green',
+  websocket: 'purple',
+};
+
+const TemplateList: React.FC = () => {
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<NotificationTemplate[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [keyword, setKeyword] = useState('');
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<NotificationTemplate | null>(null);
+  const [testDrawerVisible, setTestDrawerVisible] = useState(false);
+  const [testingTemplate, setTestingTemplate] = useState<NotificationTemplate | null>(null);
+  const [testResult, setTestResult] = useState<{ title: string; content: string } | null>(null);
+  const [testLoading, setTestLoading] = useState(false);
+  const [form] = Form.useForm();
+  const [testForm] = Form.useForm();
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getNotificationTemplateList({
+        page,
+        page_size: pageSize,
+        keyword: keyword || undefined,
+      });
+      setData(res.list);
+      setTotal(res.total);
+    } catch {
+      message.error('加载模板列表失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize, keyword]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // 搜索
+  const handleSearch = () => {
+    setPage(1);
+    loadData();
+  };
+
+  // 重置
+  const handleReset = () => {
+    setKeyword('');
+    setPage(1);
+    loadData();
+  };
+
+  // 新增
+  const handleAdd = () => {
+    setEditingTemplate(null);
+    form.resetFields();
+    form.setFieldsValue({
+      channels: ['in_app'],
+      status: 1,
+    });
+    setModalVisible(true);
+  };
+
+  // 编辑
+  const handleEdit = (record: NotificationTemplate) => {
+    setEditingTemplate(record);
+    form.setFieldsValue({
+      code: record.code,
+      name: record.name,
+      title_template: record.title_template,
+      body_template: record.body_template,
+      channels: record.channels,
+      category: record.category,
+      status: record.status,
+    });
+    setModalVisible(true);
+  };
+
+  // 删除
+  const handleDelete = async (record: NotificationTemplate) => {
+    try {
+      await deleteNotificationTemplate(record.id);
+      message.success('删除成功');
+      loadData();
+    } catch {
+      message.error('删除失败');
+    }
+  };
+
+  // 提交表单
+  const handleSubmit = async () => {
+    try {
+      const values = await form.validateFields();
+      // variables_schema 需要转为对象
+      const params: CreateNotificationTemplateParams = {
+        ...values,
+        variables_schema: {},
+      };
+      if (editingTemplate) {
+        await updateNotificationTemplate(editingTemplate.id, params);
+        message.success('更新成功');
+      } else {
+        await createNotificationTemplate(params);
+        message.success('创建成功');
+      }
+      setModalVisible(false);
+      loadData();
+    } catch (error: any) {
+      if (error.errorFields) return;
+      message.error(editingTemplate ? '更新失败' : '创建失败');
+    }
+  };
+
+  // 打开测试弹窗
+  const handleTest = (record: NotificationTemplate) => {
+    setTestingTemplate(record);
+    setTestResult(null);
+    testForm.resetFields();
+    setTestDrawerVisible(true);
+  };
+
+  // 执行测试
+  const handleRunTest = async () => {
+    if (!testingTemplate) return;
+    setTestLoading(true);
+    try {
+      const values = await testForm.validateFields();
+      // 解析 JSON 格式的变量
+      let variables: Record<string, unknown> = {};
+      const rawStr = values.variables_raw as string;
+      if (rawStr && rawStr.trim()) {
+        try {
+          variables = JSON.parse(rawStr);
+        } catch {
+          message.error('变量 JSON 格式不正确');
+          setTestLoading(false);
+          return;
+        }
+      }
+      const result = await testNotificationTemplate(testingTemplate.id, {
+        variables,
+      });
+      setTestResult(result);
+    } catch (error: any) {
+      if (error.errorFields) return;
+      message.error('测试失败');
+    } finally {
+      setTestLoading(false);
+    }
+  };
+
+  const columns: ColumnsType<NotificationTemplate> = [
+    {
+      title: '编码',
+      dataIndex: 'code',
+      key: 'code',
+      width: 180,
+      render: (code: string) => <Text code>{code}</Text>,
+    },
+    {
+      title: '名称',
+      dataIndex: 'name',
+      key: 'name',
+      width: 160,
+    },
+    {
+      title: '分类',
+      dataIndex: 'category',
+      key: 'category',
+      width: 100,
+      render: (cat: string) => cat || '-',
+    },
+    {
+      title: '渠道',
+      dataIndex: 'channels',
+      key: 'channels',
+      width: 200,
+      render: (channels: string[]) => (
+        <Space wrap size={[4, 4]}>
+          {channels?.map((ch) => (
+            <Tag key={ch} color={channelColorMap[ch] || 'default'}>
+              {ch}
+            </Tag>
+          ))}
+        </Space>
+      ),
+    },
+    {
+      title: '状态',
+      dataIndex: 'status',
+      key: 'status',
+      width: 80,
+      render: (status: number) => {
+        const info = statusMap[status] || statusMap[0];
+        return <Tag color={info.color}>{info.text}</Tag>;
+      },
+    },
+    {
+      title: '创建时间',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      width: 160,
+      render: (time: string) =>
+        new Date(time).toLocaleString('zh-CN', { hour12: false }),
+    },
+    {
+      title: '操作',
+      key: 'action',
+      width: 200,
+      fixed: 'right',
+      render: (_: unknown, record: NotificationTemplate) => (
+        <Space>
+          <Button
+            type="link"
+            size="small"
+            icon={<ExperimentOutlined />}
+            onClick={() => handleTest(record)}
+          >
+            测试
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => handleEdit(record)}
+          >
+            编辑
+          </Button>
+          <Popconfirm
+            title="确认删除此模板？"
+            onConfirm={() => handleDelete(record)}
+          >
+            <Button type="link" size="small" danger icon={<DeleteOutlined />}>
+              删除
+            </Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Card>
+      {/* 搜索栏 */}
+      <div style={{ marginBottom: 16, display: 'flex', gap: 12, alignItems: 'center' }}>
+        <Input
+          placeholder="搜索模板编码/名称"
+          prefix={<SearchOutlined />}
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          style={{ width: 240 }}
+          onPressEnter={handleSearch}
+        />
+        <Space>
+          <Button type="primary" onClick={handleSearch}>
+            搜索
+          </Button>
+          <Button icon={<ReloadOutlined />} onClick={handleReset}>
+            重置
+          </Button>
+        </Space>
+        <div style={{ flex: 1 }} />
+        <Button type="primary" icon={<PlusOutlined />} onClick={handleAdd}>
+          新增模板
+        </Button>
+      </div>
+
+      {/* 表格 */}
+      <Table
+        columns={columns}
+        dataSource={data}
+        rowKey="id"
+        loading={loading}
+        scroll={{ x: 1100 }}
+        pagination={{
+          current: page,
+          pageSize,
+          total,
+          showSizeChanger: true,
+          showQuickJumper: true,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (p, ps) => {
+            setPage(p);
+            setPageSize(ps);
+          },
+        }}
+      />
+
+      {/* 新增/编辑弹窗 */}
+      <Modal
+        title={editingTemplate ? '编辑模板' : '新增模板'}
+        open={modalVisible}
+        onOk={handleSubmit}
+        onCancel={() => setModalVisible(false)}
+        width={640}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item
+            name="code"
+            label="模板编码"
+            rules={[
+              { required: true, message: '请输入模板编码' },
+              { pattern: /^[a-z][a-z0-9_]*$/, message: '只能包含小写字母、数字和下划线' },
+            ]}
+          >
+            <Input
+              placeholder="如: task_assigned"
+              disabled={!!editingTemplate}
+            />
+          </Form.Item>
+          <Form.Item
+            name="name"
+            label="模板名称"
+            rules={[{ required: true, message: '请输入模板名称' }]}
+          >
+            <Input placeholder="如: 任务分配通知" />
+          </Form.Item>
+          <Form.Item
+            name="title_template"
+            label="标题模板"
+            rules={[{ required: true, message: '请输入标题模板' }]}
+            extra="使用 {{.变量名}} 引用变量，如：{{.TaskName}} 已分配给您"
+          >
+            <Input placeholder="如：{{.TaskName}} 已分配给您" />
+          </Form.Item>
+          <Form.Item
+            name="body_template"
+            label="正文模板"
+            rules={[{ required: true, message: '请输入正文模板' }]}
+            extra="支持多行文本，使用 {{.变量名}} 引用变量"
+          >
+            <TextArea
+              rows={5}
+              placeholder={'如：任务 "{{.TaskName}}" 已分配给您。\n截止时间：{{.DueDate}}\n请及时处理。'}
+            />
+          </Form.Item>
+          <Form.Item
+            name="channels"
+            label="通知渠道"
+            rules={[{ required: true, message: '请至少选择一个渠道' }]}
+          >
+            <Select
+              mode="multiple"
+              placeholder="选择通知渠道"
+              options={channelOptions}
+            />
+          </Form.Item>
+          <Form.Item name="category" label="分类">
+            <Select
+              placeholder="选择分类"
+              allowClear
+              options={[
+                { label: '系统', value: 'system' },
+                { label: '任务', value: 'task' },
+                { label: '会议', value: 'meeting' },
+                { label: '审批', value: 'approval' },
+                { label: '面试', value: 'interview' },
+                { label: '其他', value: 'other' },
+              ]}
+            />
+          </Form.Item>
+          {editingTemplate && (
+            <Form.Item name="status" label="状态">
+              <Select
+                options={[
+                  { label: '禁用', value: 0 },
+                  { label: '启用', value: 1 },
+                ]}
+              />
+            </Form.Item>
+          )}
+        </Form>
+      </Modal>
+
+      {/* 测试模板抽屉 */}
+      <Drawer
+        title="测试模板渲染"
+        open={testDrawerVisible}
+        onClose={() => setTestDrawerVisible(false)}
+        width={560}
+        extra={
+          <Button
+            type="primary"
+            loading={testLoading}
+            onClick={handleRunTest}
+            icon={<ExperimentOutlined />}
+          >
+            执行测试
+          </Button>
+        }
+      >
+        {testingTemplate && (
+          <div>
+            <div style={{ marginBottom: 16 }}>
+              <Text type="secondary">模板：</Text>
+              <Text code>{testingTemplate.code}</Text>
+              <Text>（{testingTemplate.name}）</Text>
+            </div>
+            <Form form={testForm} layout="vertical">
+              <Form.Item label="测试变量（JSON 格式）" name="variables_raw">
+                <TextArea
+                  rows={6}
+                  placeholder={'输入 JSON 格式的变量，如：\n{"TaskName": "完成需求文档", "DueDate": "2024-12-31"}'}
+                />
+              </Form.Item>
+            </Form>
+            {testResult && (
+              <div style={{ marginTop: 16 }}>
+                <Text strong>渲染结果：</Text>
+                <div style={{ marginTop: 8, padding: 16, background: '#f5f5f5', borderRadius: 6 }}>
+                  <Text strong>标题：</Text>
+                  <Paragraph>{testResult.title}</Paragraph>
+                  <Text strong>正文：</Text>
+                  <Paragraph style={{ whiteSpace: 'pre-wrap' }}>{testResult.content}</Paragraph>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </Drawer>
+    </Card>
+  );
+};
+
+export default TemplateList;

--- a/frontend/src/pages/notification/TemplateList.tsx
+++ b/frontend/src/pages/notification/TemplateList.tsx
@@ -160,8 +160,8 @@ const TemplateList: React.FC = () => {
       }
       setModalVisible(false);
       loadData();
-    } catch (error: any) {
-      if (error.errorFields) return;
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'errorFields' in error) return;
       message.error(editingTemplate ? '更新失败' : '创建失败');
     }
   };
@@ -196,8 +196,8 @@ const TemplateList: React.FC = () => {
         variables,
       });
       setTestResult(result);
-    } catch (error: any) {
-      if (error.errorFields) return;
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'errorFields' in error) return;
       message.error('测试失败');
     } finally {
       setTestLoading(false);

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -13,6 +13,8 @@ import PermissionRoute from '@/router/guards/PermissionRoute';
 const Login = lazy(() => import('@/pages/login/Login'));
 const Dashboard = lazy(() => import('@/pages/dashboard/Dashboard'));
 const UserList = lazy(() => import('@/pages/user/UserList'));
+const NotificationList = lazy(() => import('@/pages/notification/NotificationList'));
+const TemplateList = lazy(() => import('@/pages/notification/TemplateList'));
 const Forbidden = lazy(() => import('@/pages/error/Forbidden'));
 
 // 懒加载 fallback
@@ -89,6 +91,22 @@ const routes: AppRouteObject[] = [
             path: 'list',
             element: lazyGuarded(UserList, 'user:read'),
             meta: { title: '用户列表', permission: 'user:read' },
+          },
+        ],
+      },
+      {
+        path: 'notification',
+        meta: { title: '通知管理', icon: 'BellOutlined' },
+        children: [
+          {
+            path: 'list',
+            element: lazyWrap(NotificationList),
+            meta: { title: '通知列表' },
+          },
+          {
+            path: 'templates',
+            element: lazyGuarded(TemplateList, 'notification:template:read'),
+            meta: { title: '模板管理', permission: 'notification:template:read' },
           },
         ],
       },

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -2,12 +2,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './slices/authSlice';
 import userReducer from './slices/userSlice';
 import appReducer from './slices/appSlice';
+import notificationReducer from './slices/notificationSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     user: userReducer,
     app: appReducer,
+    notification: notificationReducer,
   },
   devTools: process.env.NODE_ENV !== 'production',
 });

--- a/frontend/src/store/slices/notificationSlice.ts
+++ b/frontend/src/store/slices/notificationSlice.ts
@@ -1,0 +1,162 @@
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import {
+  getUnreadCount,
+  getNotificationList,
+  markAsRead as markAsReadApi,
+  markAllAsRead as markAllAsReadApi,
+} from '@/api/notification';
+import type { Notification, ListNotificationParams } from '@/types/api';
+import type { RootState } from '@/store';
+
+interface NotificationState {
+  unreadCount: number;
+  recentNotifications: Notification[];
+  wsConnected: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: NotificationState = {
+  unreadCount: 0,
+  recentNotifications: [],
+  wsConnected: false,
+  loading: false,
+  error: null,
+};
+
+/** 拉取未读通知数量 */
+export const fetchUnreadCount = createAsyncThunk(
+  'notification/fetchUnreadCount',
+  async () => {
+    const res = await getUnreadCount();
+    return res.count;
+  },
+);
+
+/** 拉取最近通知（前 10 条，用于铃铛下拉） */
+export const fetchRecentNotifications = createAsyncThunk(
+  'notification/fetchRecentNotifications',
+  async (_, { rejectWithValue }) => {
+    try {
+      const params: ListNotificationParams = { page: 1, page_size: 10 };
+      const res = await getNotificationList(params);
+      return res.list;
+    } catch (error: any) {
+      return rejectWithValue(error.message || '获取通知失败');
+    }
+  },
+);
+
+/** 标记单条已读 */
+export const markNotificationAsRead = createAsyncThunk(
+  'notification/markAsRead',
+  async (id: string, { rejectWithValue }) => {
+    try {
+      await markAsReadApi(id);
+      return id;
+    } catch (error: any) {
+      return rejectWithValue(error.message || '标记已读失败');
+    }
+  },
+);
+
+/** 全部标记已读 */
+export const markAllNotificationsAsRead = createAsyncThunk(
+  'notification/markAllAsRead',
+  async (category?: string) => {
+    await markAllAsReadApi(category);
+  },
+);
+
+const notificationSlice = createSlice({
+  name: 'notification',
+  initialState,
+  reducers: {
+    /** WebSocket 收到新通知时添加到列表头部 */
+    addNotification(state, action: PayloadAction<Notification>) {
+      state.recentNotifications.unshift(action.payload);
+      // 保持最多 20 条
+      if (state.recentNotifications.length > 20) {
+        state.recentNotifications = state.recentNotifications.slice(0, 20);
+      }
+      state.unreadCount += 1;
+    },
+    /** 设置 WebSocket 连接状态 */
+    setWSConnected(state, action: PayloadAction<boolean>) {
+      state.wsConnected = action.payload;
+    },
+    /** 清空通知（登出时调用） */
+    clearNotifications(state) {
+      state.unreadCount = 0;
+      state.recentNotifications = [];
+      state.wsConnected = false;
+      state.error = null;
+    },
+    /** 通知列表中某条标记为已读（UI 即时更新） */
+    markReadInList(state, action: PayloadAction<string>) {
+      const n = state.recentNotifications.find((item) => item.id === action.payload);
+      if (n && !n.is_read) {
+        n.is_read = true;
+        state.unreadCount = Math.max(0, state.unreadCount - 1);
+      }
+    },
+    /** 全部已读（UI 即时更新） */
+    markAllReadInList(state) {
+      state.recentNotifications.forEach((n) => {
+        n.is_read = true;
+      });
+      state.unreadCount = 0;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // 未读计数
+      .addCase(fetchUnreadCount.fulfilled, (state, action: PayloadAction<number>) => {
+        state.unreadCount = action.payload;
+      })
+      // 最近通知
+      .addCase(fetchRecentNotifications.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchRecentNotifications.fulfilled, (state, action: PayloadAction<Notification[]>) => {
+        state.loading = false;
+        state.recentNotifications = action.payload;
+      })
+      .addCase(fetchRecentNotifications.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload as string;
+      })
+      // 标记已读
+      .addCase(markNotificationAsRead.fulfilled, (state, action: PayloadAction<string>) => {
+        const n = state.recentNotifications.find((item) => item.id === action.payload);
+        if (n && !n.is_read) {
+          n.is_read = true;
+          state.unreadCount = Math.max(0, state.unreadCount - 1);
+        }
+      })
+      // 全部已读
+      .addCase(markAllNotificationsAsRead.fulfilled, (state) => {
+        state.recentNotifications.forEach((n) => {
+          n.is_read = true;
+        });
+        state.unreadCount = 0;
+      });
+  },
+});
+
+export const {
+  addNotification,
+  setWSConnected,
+  clearNotifications,
+  markReadInList,
+  markAllReadInList,
+} = notificationSlice.actions;
+
+export const selectUnreadCount = (state: RootState) => state.notification.unreadCount;
+export const selectRecentNotifications = (state: RootState) => state.notification.recentNotifications;
+export const selectWSConnected = (state: RootState) => state.notification.wsConnected;
+export const selectNotificationLoading = (state: RootState) => state.notification.loading;
+export const selectNotificationError = (state: RootState) => state.notification.error;
+
+export default notificationSlice.reducer;

--- a/frontend/src/store/slices/notificationSlice.ts
+++ b/frontend/src/store/slices/notificationSlice.ts
@@ -41,8 +41,8 @@ export const fetchRecentNotifications = createAsyncThunk(
       const params: ListNotificationParams = { page: 1, page_size: 10 };
       const res = await getNotificationList(params);
       return res.list;
-    } catch (error: any) {
-      return rejectWithValue(error.message || '获取通知失败');
+    } catch (error: unknown) {
+      return rejectWithValue(error instanceof Error ? error.message : '获取通知失败');
     }
   },
 );
@@ -54,8 +54,8 @@ export const markNotificationAsRead = createAsyncThunk(
     try {
       await markAsReadApi(id);
       return id;
-    } catch (error: any) {
-      return rejectWithValue(error.message || '标记已读失败');
+    } catch (error: unknown) {
+      return rejectWithValue(error instanceof Error ? error.message : '标记已读失败');
     }
   },
 );

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -586,55 +586,125 @@ export interface ListInternshipParams extends ListParams {
 // 通知
 // ============================================================
 
-export type NotificationType = 1 | 2 | 3 | 4;
-// 1=系统通知 2=任务通知 3=会议通知 4=审核通知
+/** 通知优先级 */
+export type NotificationPriority = 'low' | 'normal' | 'high' | 'urgent';
 
+/** 通知分类 */
+export type NotificationCategory =
+  | 'system'
+  | 'task'
+  | 'meeting'
+  | 'approval'
+  | 'interview'
+  | 'other';
+
+/** 通知发送者信息 */
+export interface NotificationSender {
+  id: string;
+  name: string;
+}
+
+/** 通知实体 */
 export interface Notification {
   id: string;
   title: string;
   content: string;
-  type: NotificationType;
+  category: NotificationCategory;
+  priority: NotificationPriority;
   is_read: boolean;
-  sender_id?: string;
-  sender_name?: string;
-  related_type?: string;
-  related_id?: string;
+  action_url: string;
+  sender: NotificationSender;
   created_at: string;
 }
 
+/** 通知模板实体 */
 export interface NotificationTemplate {
   id: string;
-  name: string;
   code: string;
+  name: string;
   title_template: string;
-  content_template: string;
-  type: number;
-  variables: string[];
-  status: number;
+  body_template: string;
+  channels: string[];
+  category: string;
+  variables_schema: Record<string, string>;
+  status: number; // 0=禁用 1=启用
   created_at: string;
   updated_at: string;
 }
 
+/** 通知列表查询参数 */
 export interface ListNotificationParams extends ListParams {
-  type?: NotificationType;
-  is_read?: boolean;
+  category?: NotificationCategory;
+  unread_only?: boolean;
 }
 
+/** 创建通知模板参数 */
 export interface CreateNotificationTemplateParams {
-  name: string;
   code: string;
+  name: string;
   title_template: string;
-  content_template: string;
-  type: number;
-  variables?: string[];
+  body_template: string;
+  channels: string[];
+  category?: string;
+  variables_schema?: Record<string, string>;
 }
 
+/** 更新通知模板参数 */
 export interface UpdateNotificationTemplateParams {
   name?: string;
   title_template?: string;
-  content_template?: string;
+  body_template?: string;
+  channels?: string[];
+  category?: string;
+  variables_schema?: Record<string, string>;
   status?: number;
-  variables?: string[];
+}
+
+/** 测试模板参数 */
+export interface TestTemplateParams {
+  variables: Record<string, unknown>;
+}
+
+/** 测试模板结果 */
+export interface TestTemplateResult {
+  title: string;
+  content: string;
+}
+
+/** 管理员发送通知参数 */
+export interface SendNotificationParams {
+  user_ids: string[];
+  template_code: string;
+  variables?: Record<string, unknown>;
+  channels?: string[];
+}
+
+/** 广播通知参数 */
+export interface BroadcastNotificationParams {
+  title: string;
+  content: string;
+  category?: string;
+  priority?: NotificationPriority;
+  channels?: string[];
+}
+
+/** 模板列表查询参数 */
+export interface ListTemplateParams extends ListParams {
+  keyword?: string;
+}
+
+/** WebSocket 实时通知消息 */
+export interface WSNotificationMessage {
+  type: 'notification' | 'auth_result' | 'pong' | 'connected';
+  data: {
+    title?: string;
+    content?: string;
+    category?: string;
+    priority?: string;
+    action_url?: string;
+    sender?: { id: string; name: string };
+    success?: boolean;
+  };
 }
 
 // ============================================================


### PR DESCRIPTION
## 概述

实现 Issue #4 的消息通知系统，支持站内消息、WebSocket 实时推送和邮件通知三个渠道，包含模板引擎和事件驱动架构。

## 后端实现

### 四层架构

| 层级 | 文件 | 职责 |
|------|------|------|
| **Model** | `model/notification.go` | Notification / NotificationTemplate 数据模型 |
| **DTO** | `dto/notification.go` | 请求/响应数据传输对象 |
| **Repo** | `repo/notification_repo.go` | 通知 CRUD + 模板 CRUD + 未读计数 |
| **Service** | `service/notification_service.go` | 通知发送、列表、已读标记、删除 |
| **Service** | `service/channel.go` | 通知渠道接口（in_app/email/websocket）+ 渠道注册表 |
| **Service** | `service/template_engine.go` | Go text/template 模板渲染 + 变量校验 |
| **Service** | `template_service.go` | 模板 CRUD + 渲染测试 |
| **Service** | `event_listener.go` | 监听 EventBus 事件 → 自动触发通知 |
| **Handler** | `handler/notification_handler.go` | 通知列表/未读计数/标记已读/删除/管理员发送/广播 |
| **Handler** | `handler/template_handler.go` | 模板 CRUD + 渲染测试 |
| **Handler** | `handler/websocket_handler.go` | WebSocket 端点（JWT 认证 + 心跳 + 读写协程） |
| **Handler** | `handler/routes.go` | 路由注册 |

### API 路由

```
# 用户通知
GET    /api/v1/notifications           # 通知列表（分页/分类/未读筛选）
GET    /api/v1/notifications/unread/count  # 未读数量
POST   /api/v1/notifications/:id/read   # 标记已读
POST   /api/v1/notifications/read-all    # 全部已读
DELETE /api/v1/notifications/:id         # 删除通知

# 管理员通知
POST   /api/v1/system/notifications/send      # 通过模板发送
POST   /api/v1/system/notifications/broadcast  # 广播通知

# 模板管理
GET    /api/v1/notification-templates          # 模板列表
POST   /api/v1/notification-templates          # 创建模板
GET    /api/v1/notification-templates/:id      # 模板详情
PUT    /api/v1/notification-templates/:id      # 更新模板
DELETE /api/v1/notification-templates/:id      # 删除模板
POST   /api/v1/notification-templates/:id/test # 测试渲染

# WebSocket
GET    /ws/notifications?token=<JWT>  # 实时通知推送
```

### 通知渠道接口设计

```go
type NotificationChannel interface {
    Type() string         // "in_app" | "email" | "websocket"
    Send(ctx context.Context, msg *NotificationMessage) error
    IsAvailable() bool
}
```

插件化设计，未来可扩展短信、企业微信等渠道。

### WebSocket Hub

- JWT 认证（支持 query param 和 Authorization header）
- 心跳检测（30s ping/pong）
- 连接注册/注销管理
- 支持单用户多连接

### 错误码

| 错误码 | 说明 |
|--------|------|
| 12001 | 通知不存在 |
| 12002 | 通知模板已存在 |
| 12003 | 通知模板不存在 |
| 12004 | 模板渲染失败 |
| 12005 | WebSocket 认证失败 |
| 12006 | 邮件发送失败 |
| 12007 | 不支持的通知渠道 |
| 12008 | 无权操作该通知 |

## 前端实现

| 文件 | 职责 |
|------|------|
| `api/notification.ts` | 通知/模板 API 封装（对齐后端路由） |
| `types/api.ts` | Notification/NotificationTemplate 类型对齐后端 DTO |
| `store/slices/notificationSlice.ts` | Redux slice：未读计数/最近通知/WS 状态 |
| `hooks/useNotificationWebSocket.ts` | WebSocket Hook：自动连接/重连/心跳/消息分发 |
| `components/NotificationBell/` | 通知铃铛组件：Badge + Popover 最近通知列表 |
| `pages/notification/NotificationList.tsx` | 通知列表页：分类筛选/未读筛选/标记已读/删除/详情抽屉 |
| `pages/notification/TemplateList.tsx` | 模板管理页：模板 CRUD + 渲染测试（JSON 变量输入） |
| `layouts/MainLayout/components/TopBar.tsx` | 集成通知铃铛 + WebSocket 初始化 |
| `router/routes.tsx` | 新增 /notification/list + /notification/templates 路由 |

## 测试验证

- [x] 后端 `go build ./...` 编译通过
- [x] 后端 `go vet ./internal/notification/...` 通过
- [x] 后端 `gofmt` 格式化通过
- [x] 前端 `tsc --noEmit` 类型检查通过
- [x] 前端 `vite build` 构建通过

## 关联 Issue

Closes #4