### PR TITLE
feat(workflow): 前端流程设计器（React Flow）+ 草稿图 API

### DIFF
--- a/backend/internal/workflow/dto/workflow_dto.go
+++ b/backend/internal/workflow/dto/workflow_dto.go
@@ -29,6 +29,11 @@ type PublishDefinitionRequest struct {
 	GraphData *GraphData `json:"graph_data" binding:"required"`
 }
 
+// SaveDraftRequest is the body for PUT /api/v1/workflow/definitions/:id/draft.
+type SaveDraftRequest struct {
+	GraphData *GraphData `json:"graph_data" binding:"required"`
+}
+
 // GraphData represents the React Flow graph structure stored in bpmn_data.
 type GraphData struct {
 	Nodes []GraphNode `json:"nodes"`
@@ -51,9 +56,12 @@ type GraphPosition struct {
 
 // GraphEdge represents a connection between two nodes.
 type GraphEdge struct {
-	ID     string `json:"id"`
-	Source string `json:"source"`
-	Target string `json:"target"`
+	ID           string                 `json:"id"`
+	Source       string                 `json:"source"`
+	Target       string                 `json:"target"`
+	SourceHandle string                 `json:"sourceHandle,omitempty"`
+	Label        string                 `json:"label,omitempty"`
+	Data         map[string]interface{} `json:"data,omitempty"`
 }
 
 // DefinitionResponse is the response for a single flow definition.
@@ -64,6 +72,7 @@ type DefinitionResponse struct {
 	Description string     `json:"description"`
 	Category    string     `json:"category"`
 	Status      int        `json:"status"`
+	DraftGraph  *GraphData `json:"draft_graph"`
 	CreatedBy   *uuid.UUID `json:"created_by"`
 	UpdatedBy   *uuid.UUID `json:"updated_by"`
 	CreatedAt   time.Time  `json:"created_at"`
@@ -179,6 +188,13 @@ type HistoryResponse struct {
 
 // ToDefinitionResponse converts FlowDefinition model to DefinitionResponse.
 func ToDefinitionResponse(def *model.FlowDefinition) DefinitionResponse {
+	var draft *GraphData
+	if len(def.DraftGraph) > 0 {
+		var graph GraphData
+		if err := json.Unmarshal(def.DraftGraph, &graph); err == nil {
+			draft = &graph
+		}
+	}
 	return DefinitionResponse{
 		ID:          def.ID,
 		Key:         def.Key,
@@ -186,6 +202,7 @@ func ToDefinitionResponse(def *model.FlowDefinition) DefinitionResponse {
 		Description: def.Description,
 		Category:    def.Category,
 		Status:      def.Status,
+		DraftGraph:  draft,
 		CreatedBy:   def.CreatedBy,
 		UpdatedBy:   def.UpdatedBy,
 		CreatedAt:   def.CreatedAt,

--- a/backend/internal/workflow/handler/definition_handler.go
+++ b/backend/internal/workflow/handler/definition_handler.go
@@ -219,6 +219,45 @@ func (h *DefinitionHandler) Publish(c *gin.Context) {
 	response.OK(c, dto.ToVersionResponse(version))
 }
 
+// SaveDraft 保存流程定义草稿图
+// @Summary 保存流程定义草稿图
+// @Description 保存未发布的工作稿 graph_data，已发布定义也可保存下一版草稿
+// @Tags 流程定义
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param id path string true "流程定义ID"
+// @Param request body dto.SaveDraftRequest true "草稿流程图数据"
+// @Success 200 {object} response.Response{data=dto.DefinitionResponse}
+// @Router /workflow/definitions/{id}/draft [put]
+func (h *DefinitionHandler) SaveDraft(c *gin.Context) {
+	id, err := parseUUIDParam(c, "id", "无效的流程定义ID")
+	if err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+
+	var req dto.SaveDraftRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, parseBindingError(err))
+		return
+	}
+
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	def, err := h.defService.SaveDraft(c.Request.Context(), id, &req, userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	response.OK(c, dto.ToDefinitionResponse(def))
+}
+
 // ListVersions 获取版本列表
 // @Summary 获取流程定义版本列表
 // @Description 获取指定流程定义的所有版本

--- a/backend/internal/workflow/handler/definition_handler_test.go
+++ b/backend/internal/workflow/handler/definition_handler_test.go
@@ -29,6 +29,7 @@ type mockDefService struct {
 	publishFunc      func(ctx context.Context, id uuid.UUID, req *dto.PublishDefinitionRequest, userID uuid.UUID) (*model.FlowDefinitionVersion, error)
 	listVersionsFunc func(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error)
 	getVersionFunc   func(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error)
+	saveDraftFunc    func(ctx context.Context, id uuid.UUID, req *dto.SaveDraftRequest, userID uuid.UUID) (*model.FlowDefinition, error)
 }
 
 func (m *mockDefService) Create(ctx context.Context, req *dto.CreateDefinitionRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
@@ -85,6 +86,13 @@ func (m *mockDefService) GetVersionByID(ctx context.Context, id uuid.UUID) (*mod
 		return m.getVersionFunc(ctx, id)
 	}
 	return nil, nil
+}
+
+func (m *mockDefService) SaveDraft(ctx context.Context, id uuid.UUID, req *dto.SaveDraftRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
+	if m.saveDraftFunc != nil {
+		return m.saveDraftFunc(ctx, id, req, userID)
+	}
+	return &model.FlowDefinition{ID: id}, nil
 }
 
 // Compile-time check.
@@ -386,6 +394,58 @@ func TestDefinitionHandler_GetVersionByID_Success(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDefinitionHandler_SaveDraft_Success(t *testing.T) {
+	defID := uuid.New()
+	userID := uuid.New()
+	saved := false
+
+	svc := &mockDefService{
+		saveDraftFunc: func(ctx context.Context, id uuid.UUID, req *dto.SaveDraftRequest, uid uuid.UUID) (*model.FlowDefinition, error) {
+			saved = true
+			assert.Equal(t, defID, id)
+			assert.Equal(t, userID, uid)
+			require.NotNil(t, req.GraphData)
+			assert.Len(t, req.GraphData.Nodes, 1)
+			assert.Equal(t, "branch_1", req.GraphData.Edges[0].SourceHandle)
+			return &model.FlowDefinition{ID: id, Name: "草稿流程"}, nil
+		},
+	}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.PUT("/definitions/:id/draft", func(c *gin.Context) {
+		setAuthUser(c, userID.String())
+		h.SaveDraft(c)
+	})
+
+	body := `{"graph_data":{"nodes":[{"id":"n1","type":"start","position":{"x":0,"y":0},"data":{"name":"开始"}}],"edges":[{"id":"e1","source":"n1","target":"n2","sourceHandle":"branch_1","label":"通过"}]}}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/definitions/"+defID.String()+"/draft", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, saved)
+}
+
+func TestDefinitionHandler_SaveDraft_MissingGraphData(t *testing.T) {
+	svc := &mockDefService{}
+	h := NewDefinitionHandler(svc)
+
+	r := setupRouter()
+	r.PUT("/definitions/:id/draft", func(c *gin.Context) {
+		setAuthUser(c, uuid.New().String())
+		h.SaveDraft(c)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/definitions/"+uuid.New().String()+"/draft", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestDefinitionHandler_GetVersionByID_WrongDefinition(t *testing.T) {

--- a/backend/internal/workflow/handler/routes.go
+++ b/backend/internal/workflow/handler/routes.go
@@ -16,7 +16,7 @@ import (
 //	PUT    /definitions/:id          更新流程定义
 //	DELETE /definitions/:id          删除流程定义
 //	POST   /definitions/:id/publish  发布流程定义
-	PUT    /definitions/:id/draft    保存流程草稿图
+//	PUT    /definitions/:id/draft    保存流程草稿图
 //	GET    /definitions/:id/versions 版本列表
 //	GET    /definitions/:id/versions/:versionId 版本详情
 //

--- a/backend/internal/workflow/handler/routes.go
+++ b/backend/internal/workflow/handler/routes.go
@@ -16,6 +16,7 @@ import (
 //	PUT    /definitions/:id          更新流程定义
 //	DELETE /definitions/:id          删除流程定义
 //	POST   /definitions/:id/publish  发布流程定义
+	PUT    /definitions/:id/draft    保存流程草稿图
 //	GET    /definitions/:id/versions 版本列表
 //	GET    /definitions/:id/versions/:versionId 版本详情
 //
@@ -55,6 +56,7 @@ func RegisterRoutes(
 			defs.PUT("/:id", defHandler.Update)
 			defs.DELETE("/:id", defHandler.Delete)
 			defs.POST("/:id/publish", defHandler.Publish)
+			defs.PUT("/:id/draft", defHandler.SaveDraft)
 			defs.GET("/:id/versions", defHandler.ListVersions)
 			defs.GET("/:id/versions/:versionId", defHandler.GetVersionByID)
 		}

--- a/backend/internal/workflow/model/workflow.go
+++ b/backend/internal/workflow/model/workflow.go
@@ -17,6 +17,7 @@ type FlowDefinition struct {
 	Description string     `gorm:"type:text" json:"description"`
 	Category    string     `gorm:"type:varchar(50);default:custom" json:"category"`
 	Status      int        `gorm:"type:smallint;default:0;index" json:"status"`
+	DraftGraph  []byte     `gorm:"type:jsonb" json:"draft_graph"`
 	CreatedBy   *uuid.UUID `gorm:"type:uuid" json:"created_by"`
 	UpdatedBy   *uuid.UUID `gorm:"type:uuid" json:"updated_by"`
 	CreatedAt   time.Time  `json:"created_at"`

--- a/backend/internal/workflow/service/definition_service.go
+++ b/backend/internal/workflow/service/definition_service.go
@@ -215,6 +215,37 @@ func (s *definitionServiceImpl) Publish(ctx context.Context, id uuid.UUID, req *
 	return ver, nil
 }
 
+// SaveDraft stores a working-copy graph on the definition.
+// Allowed for both draft and published definitions (next-version WIP).
+func (s *definitionServiceImpl) SaveDraft(ctx context.Context, id uuid.UUID, req *dto.SaveDraftRequest, userID uuid.UUID) (*model.FlowDefinition, error) {
+	def, err := s.defRepo.GetByID(ctx, id)
+	if err != nil || def == nil {
+		return nil, response.NewAppError(response.CodeWorkflowNotFound,
+			"流程定义不存在")
+	}
+
+	if req == nil || req.GraphData == nil {
+		return nil, response.NewAppError(response.CodeBadRequest, "graph_data 不能为空")
+	}
+
+	graphData, err := json.Marshal(req.GraphData)
+	if err != nil {
+		return nil, response.NewAppErrorf(response.CodeWorkflowInvalidNode,
+			"failed to marshal draft graph: %v", err)
+	}
+
+	def.DraftGraph = graphData
+	def.UpdatedBy = &userID
+	def.UpdatedAt = time.Now()
+
+	if err := s.defRepo.Update(ctx, nil, def); err != nil {
+		return nil, response.NewAppErrorf(response.CodeInternalError,
+			"failed to save draft graph: %v", err)
+	}
+
+	return def, nil
+}
+
 // ListVersions returns all versions of a definition.
 func (s *definitionServiceImpl) ListVersions(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error) {
 	versions, err := s.defRepo.ListVersions(ctx, definitionID)

--- a/backend/internal/workflow/service/interfaces.go
+++ b/backend/internal/workflow/service/interfaces.go
@@ -16,6 +16,7 @@ type DefinitionService interface {
 	Delete(ctx context.Context, id uuid.UUID) error
 	List(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.FlowDefinition, int64, error)
 	Publish(ctx context.Context, id uuid.UUID, req *dto.PublishDefinitionRequest, userID uuid.UUID) (*model.FlowDefinitionVersion, error)
+	SaveDraft(ctx context.Context, id uuid.UUID, req *dto.SaveDraftRequest, userID uuid.UUID) (*model.FlowDefinition, error)
 	ListVersions(ctx context.Context, definitionID uuid.UUID) ([]model.FlowDefinitionVersion, error)
 	GetVersionByID(ctx context.Context, id uuid.UUID) (*model.FlowDefinitionVersion, error)
 }

--- a/backend/internal/workflow/service/service_test.go
+++ b/backend/internal/workflow/service/service_test.go
@@ -249,6 +249,51 @@ func TestDefinitionService_Update_AlreadyPublished(t *testing.T) {
 	assert.Contains(t, err.Error(), "已发布")
 }
 
+func TestDefinitionService_SaveDraft(t *testing.T) {
+	repo := newMockDefRepoSvc()
+	userID := uuid.New()
+	def := &model.FlowDefinition{ID: uuid.New(), Key: "test", Name: "草稿", Status: 0}
+	repo.defs[def.ID] = def
+
+	svc := NewDefinitionService(repo, nil)
+	req := &dto.SaveDraftRequest{
+		GraphData: &dto.GraphData{
+			Nodes: []dto.GraphNode{{ID: "start", Type: "start", Position: dto.GraphPosition{X: 10, Y: 20}}},
+			Edges: []dto.GraphEdge{},
+		},
+	}
+
+	updated, err := svc.SaveDraft(context.Background(), def.ID, req, userID)
+	require.NoError(t, err)
+	assert.Equal(t, userID, *updated.UpdatedBy)
+	require.NotEmpty(t, updated.DraftGraph)
+	assert.Contains(t, string(updated.DraftGraph), `"start"`)
+}
+
+func TestDefinitionService_SaveDraft_PublishedAllowed(t *testing.T) {
+	repo := newMockDefRepoSvc()
+	def := &model.FlowDefinition{ID: uuid.New(), Key: "test", Name: "已发布", Status: 1}
+	repo.defs[def.ID] = def
+
+	svc := NewDefinitionService(repo, nil)
+	req := &dto.SaveDraftRequest{GraphData: &dto.GraphData{Nodes: []dto.GraphNode{}, Edges: []dto.GraphEdge{}}}
+
+	updated, err := svc.SaveDraft(context.Background(), def.ID, req, uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, 1, updated.Status)
+	require.NotEmpty(t, updated.DraftGraph)
+}
+
+func TestDefinitionService_SaveDraft_NotFound(t *testing.T) {
+	svc := NewDefinitionService(newMockDefRepoSvc(), nil)
+	req := &dto.SaveDraftRequest{GraphData: &dto.GraphData{}}
+	_, err := svc.SaveDraft(context.Background(), uuid.New(), req, uuid.New())
+	require.Error(t, err)
+	appErr, ok := err.(*response.AppError)
+	require.True(t, ok)
+	assert.Equal(t, response.CodeWorkflowNotFound, appErr.Code)
+}
+
 func TestDefinitionService_Delete(t *testing.T) {
 	repo := newMockDefRepoSvc()
 	defID := uuid.New()

--- a/backend/migrations/000007_workflow_draft_graph.down.sql
+++ b/backend/migrations/000007_workflow_draft_graph.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE flow_definitions DROP COLUMN IF EXISTS draft_graph;

--- a/backend/migrations/000007_workflow_draft_graph.up.sql
+++ b/backend/migrations/000007_workflow_draft_graph.up.sql
@@ -1,0 +1,6 @@
+-- ============================================================
+-- 000007_workflow_draft_graph.up.sql
+-- 流程定义增加服务端草稿图，供设计器保存未发布版本
+-- ============================================================
+
+ALTER TABLE flow_definitions ADD COLUMN IF NOT EXISTS draft_graph JSONB;

--- a/frontend/src/api/workflow.ts
+++ b/frontend/src/api/workflow.ts
@@ -1,94 +1,46 @@
 import request from './request';
+import type { PageResponse } from '@/types/api';
 import type {
-  FlowDefinition,
-  FlowInstance,
-  FlowTask,
-  FlowTaskHistory,
-  ListFlowDefinitionParams,
-  ListFlowInstanceParams,
-  ListFlowTaskParams,
-  StartFlowParams,
-  ApproveTaskParams,
-  PageResponse,
-} from '@/types/api';
+  CreateDefinitionPayload,
+  FlowDefinitionDTO,
+  FlowGraphData,
+  FlowVersionDTO,
+  PublishGraphData,
+} from '@/types/workflow';
 
-// ============================================================
-// 流程定义
-// ============================================================
-
-// 获取流程定义列表
-export function getFlowDefinitionList(
-  params: ListFlowDefinitionParams,
-): Promise<PageResponse<FlowDefinition>> {
+export function getFlowDefinitionList(params: {
+  page?: number;
+  page_size?: number;
+  keyword?: string;
+  category?: string;
+  status?: number;
+}): Promise<PageResponse<FlowDefinitionDTO>> {
   return request.get('/workflow/definitions', { params });
 }
 
-// 获取流程定义详情
-export function getFlowDefinitionDetail(id: string): Promise<FlowDefinition> {
+export function getFlowDefinitionDetail(id: string): Promise<FlowDefinitionDTO> {
   return request.get(`/workflow/definitions/${id}`);
 }
 
-// 发布流程
-export function publishFlowDefinition(id: string): Promise<FlowDefinition> {
-  return request.post(`/workflow/definitions/${id}/publish`);
+export function createFlowDefinition(data: CreateDefinitionPayload): Promise<FlowDefinitionDTO> {
+  return request.post('/workflow/definitions', data);
 }
 
-// 停用流程
-export function deactivateFlowDefinition(id: string): Promise<FlowDefinition> {
-  return request.post(`/workflow/definitions/${id}/deactivate`);
+export function saveFlowDraft(id: string, graphData: FlowGraphData): Promise<FlowDefinitionDTO> {
+  return request.put(`/workflow/definitions/${id}/draft`, { graph_data: graphData });
 }
 
-// ============================================================
-// 流程实例
-// ============================================================
-
-// 发起流程
-export function startFlow(data: StartFlowParams): Promise<FlowInstance> {
-  return request.post('/workflow/instances/start', data);
+export function publishFlowDefinition(
+  id: string,
+  graphData: PublishGraphData,
+): Promise<FlowVersionDTO> {
+  return request.post(`/workflow/definitions/${id}/publish`, { graph_data: graphData });
 }
 
-// 获取流程实例列表
-export function getFlowInstanceList(
-  params: ListFlowInstanceParams,
-): Promise<PageResponse<FlowInstance>> {
-  return request.get('/workflow/instances', { params });
+export function listFlowVersions(id: string): Promise<FlowVersionDTO[]> {
+  return request.get(`/workflow/definitions/${id}/versions`);
 }
 
-// 获取我发起的流程
-export function getMyFlowInstances(params: ListFlowInstanceParams): Promise<PageResponse<FlowInstance>> {
-  return request.get('/workflow/instances/my', { params });
-}
-
-// 获取流程实例详情
-export function getFlowInstanceDetail(id: string): Promise<FlowInstance> {
-  return request.get(`/workflow/instances/${id}`);
-}
-
-// 获取流程实例历史
-export function getFlowInstanceHistory(instanceId: string): Promise<FlowTaskHistory[]> {
-  return request.get(`/workflow/instances/${instanceId}/history`);
-}
-
-// ============================================================
-// 流程任务
-// ============================================================
-
-// 获取待办任务
-export function getMyTodoTasks(params: ListFlowTaskParams): Promise<PageResponse<FlowTask>> {
-  return request.get('/workflow/tasks/todo', { params });
-}
-
-// 获取已办任务
-export function getMyDoneTasks(params: ListFlowTaskParams): Promise<PageResponse<FlowTask>> {
-  return request.get('/workflow/tasks/done', { params });
-}
-
-// 获取任务详情
-export function getFlowTaskDetail(id: string): Promise<FlowTask> {
-  return request.get(`/workflow/tasks/${id}`);
-}
-
-// 审批任务
-export function approveFlowTask(data: ApproveTaskParams): Promise<void> {
-  return request.post('/workflow/tasks/approve', data);
+export function getFlowVersion(id: string, versionId: string): Promise<FlowVersionDTO> {
+  return request.get(`/workflow/definitions/${id}/versions/${versionId}`);
 }

--- a/frontend/src/api/workflow.ts
+++ b/frontend/src/api/workflow.ts
@@ -1,5 +1,5 @@
 import request from './request';
-import type { PageResponse } from '@/types/api';
+import type { PageResponse, Role } from '@/types/api';
 import type {
   CreateDefinitionPayload,
   FlowDefinitionDTO,
@@ -43,4 +43,8 @@ export function listFlowVersions(id: string): Promise<FlowVersionDTO[]> {
 
 export function getFlowVersion(id: string, versionId: string): Promise<FlowVersionDTO> {
   return request.get(`/workflow/definitions/${id}/versions/${versionId}`);
+}
+
+export function getWorkflowRoleList(): Promise<PageResponse<Role>> {
+  return request.get('/system/roles', { params: { page: 1, page_size: 100 } });
 }

--- a/frontend/src/pages/workflow/designer/DesignerCanvas.tsx
+++ b/frontend/src/pages/workflow/designer/DesignerCanvas.tsx
@@ -51,9 +51,17 @@ const DesignerCanvasInner: React.FC<DesignerCanvasProps> = ({
     (event: React.DragEvent) => {
       event.preventDefault();
       if (previewMode) return;
-      const type = event.dataTransfer.getData(DND_TYPE) as DesignerNodeType;
-      if (!type) return;
-      const position = screenToFlowPosition({ x: event.clientX, y: event.clientY });
+      const type = (event.dataTransfer.getData(DND_TYPE) ||
+        event.dataTransfer.getData('text/plain')) as DesignerNodeType;
+      if (!type || !type.trim()) return;
+      const bounds = wrapperRef.current?.getBoundingClientRect();
+      const instance = instanceRef.current;
+      const position = instance && bounds
+        ? instance.project({
+            x: event.clientX - bounds.left,
+            y: event.clientY - bounds.top,
+          })
+        : screenToFlowPosition({ x: event.clientX, y: event.clientY });
       onDropNode({
         id: createNodeId(type),
         type,
@@ -65,15 +73,16 @@ const DesignerCanvasInner: React.FC<DesignerCanvasProps> = ({
   );
 
   return (
-    <div className="designer-canvas" ref={wrapperRef}>
+    <div className={`designer-canvas${previewMode ? ' is-preview' : ''}`} ref={wrapperRef}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={designerNodeTypes}
         onInit={(instance) => {
           instanceRef.current = instance;
+          instance.fitView();
         }}
-        onNodesChange={previewMode ? undefined : onNodesChange}
+        onNodesChange={onNodesChange}
         onEdgesChange={previewMode ? undefined : onEdgesChange}
         onConnect={(connection) => {
           if (!previewMode) onConnect(connection);
@@ -89,7 +98,6 @@ const DesignerCanvasInner: React.FC<DesignerCanvasProps> = ({
         nodesDraggable={!previewMode}
         nodesConnectable={!previewMode}
         elementsSelectable
-        fitView
         minZoom={0.4}
         maxZoom={1.6}
         deleteKeyCode={previewMode ? null : ['Backspace', 'Delete']}

--- a/frontend/src/pages/workflow/designer/DesignerCanvas.tsx
+++ b/frontend/src/pages/workflow/designer/DesignerCanvas.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useRef } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  type Connection,
+  type EdgeChange,
+  type NodeChange,
+  type ReactFlowInstance,
+  useReactFlow,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { DND_TYPE } from './constants';
+import { designerNodeTypes } from './nodes/nodeTypes';
+import {
+  createNodeId,
+  defaultNodeData,
+  type DesignerRFEdge,
+  type DesignerRFNode,
+} from './utils/flowConvert';
+import type { DesignerNodeType } from '@/types/workflow';
+
+interface DesignerCanvasProps {
+  nodes: DesignerRFNode[];
+  edges: DesignerRFEdge[];
+  previewMode: boolean;
+  onNodesChange: (changes: NodeChange[]) => void;
+  onEdgesChange: (changes: EdgeChange[]) => void;
+  onConnect: (connection: Connection) => void;
+  onNodeClick: (nodeId: string | null) => void;
+  onDropNode: (node: DesignerRFNode) => void;
+  onDragStop: () => void;
+}
+
+const DesignerCanvasInner: React.FC<DesignerCanvasProps> = ({
+  nodes,
+  edges,
+  previewMode,
+  onNodesChange,
+  onEdgesChange,
+  onConnect,
+  onNodeClick,
+  onDropNode,
+  onDragStop,
+}) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const instanceRef = useRef<ReactFlowInstance | null>(null);
+  const { screenToFlowPosition } = useReactFlow();
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      if (previewMode) return;
+      const type = event.dataTransfer.getData(DND_TYPE) as DesignerNodeType;
+      if (!type) return;
+      const position = screenToFlowPosition({ x: event.clientX, y: event.clientY });
+      onDropNode({
+        id: createNodeId(type),
+        type,
+        position,
+        data: defaultNodeData(type),
+      });
+    },
+    [onDropNode, previewMode, screenToFlowPosition],
+  );
+
+  return (
+    <div className="designer-canvas" ref={wrapperRef}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={designerNodeTypes}
+        onInit={(instance) => {
+          instanceRef.current = instance;
+        }}
+        onNodesChange={previewMode ? undefined : onNodesChange}
+        onEdgesChange={previewMode ? undefined : onEdgesChange}
+        onConnect={(connection) => {
+          if (!previewMode) onConnect(connection);
+        }}
+        onNodeClick={(_, node) => onNodeClick(node.id)}
+        onPaneClick={() => onNodeClick(null)}
+        onNodeDragStop={onDragStop}
+        onDrop={handleDrop}
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = 'move';
+        }}
+        nodesDraggable={!previewMode}
+        nodesConnectable={!previewMode}
+        elementsSelectable
+        fitView
+        minZoom={0.4}
+        maxZoom={1.6}
+        deleteKeyCode={previewMode ? null : ['Backspace', 'Delete']}
+      >
+        <Background />
+        <Controls />
+        <MiniMap />
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default DesignerCanvasInner;

--- a/frontend/src/pages/workflow/designer/DesignerModals.tsx
+++ b/frontend/src/pages/workflow/designer/DesignerModals.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { Form, Input, Modal, Select, Table } from 'antd';
+import { getFlowDefinitionList } from '@/api/workflow';
+import type { CreateDefinitionPayload, FlowDefinitionDTO } from '@/types/workflow';
+
+interface CreateModalProps {
+  open: boolean;
+  confirmLoading?: boolean;
+  onCancel: () => void;
+  onOk: (payload: CreateDefinitionPayload) => void;
+}
+
+export const CreateDefinitionModal: React.FC<CreateModalProps> = ({
+  open,
+  confirmLoading,
+  onCancel,
+  onOk,
+}) => {
+  const [form] = Form.useForm<CreateDefinitionPayload>();
+
+  useEffect(() => {
+    if (open) {
+      form.setFieldsValue({
+        key: `flow_${Date.now()}`,
+        name: '',
+        description: '',
+        category: 'custom',
+      });
+    }
+  }, [open, form]);
+
+  return (
+    <Modal
+      title="创建流程定义"
+      open={open}
+      confirmLoading={confirmLoading}
+      onCancel={onCancel}
+      onOk={() => form.validateFields().then(onOk)}
+    >
+      <Form form={form} layout="vertical">
+        <Form.Item name="name" label="流程名称" rules={[{ required: true, message: '请输入名称' }]}>
+          <Input />
+        </Form.Item>
+        <Form.Item name="key" label="流程标识" rules={[{ required: true, message: '请输入标识' }]}>
+          <Input />
+        </Form.Item>
+        <Form.Item name="category" label="分类">
+          <Select
+            options={[
+              { label: '自定义', value: 'custom' },
+              { label: '面试', value: 'interview' },
+              { label: '会员', value: 'member' },
+              { label: '任务', value: 'task' },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item name="description" label="描述">
+          <Input.TextArea rows={3} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+interface OpenModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onSelect: (id: string) => void;
+}
+
+export const OpenDefinitionModal: React.FC<OpenModalProps> = ({ open, onCancel, onSelect }) => {
+  const [loading, setLoading] = useState(false);
+  const [list, setList] = useState<FlowDefinitionDTO[]>([]);
+  const [keyword, setKeyword] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    getFlowDefinitionList({ page: 1, page_size: 50, keyword })
+      .then((res) => setList(res.list ?? []))
+      .catch(() => setList([]))
+      .finally(() => setLoading(false));
+  }, [open, keyword]);
+
+  return (
+    <Modal title="打开已有流程" open={open} onCancel={onCancel} footer={null} width={720}>
+      <Input.Search
+        placeholder="搜索名称或标识"
+        allowClear
+        onSearch={setKeyword}
+        style={{ marginBottom: 12 }}
+      />
+      <Table<FlowDefinitionDTO>
+        rowKey="id"
+        loading={loading}
+        dataSource={list}
+        size="small"
+        pagination={false}
+        onRow={(record) => ({
+          onClick: () => onSelect(record.id),
+        })}
+        columns={[
+          { title: '名称', dataIndex: 'name' },
+          { title: '标识', dataIndex: 'key' },
+          {
+            title: '状态',
+            dataIndex: 'status',
+            render: (status: number) => (status === 1 ? '已发布' : status === 2 ? '已停用' : '草稿'),
+          },
+        ]}
+      />
+    </Modal>
+  );
+};

--- a/frontend/src/pages/workflow/designer/DesignerPage.tsx
+++ b/frontend/src/pages/workflow/designer/DesignerPage.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { message, Modal } from 'antd';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { ReactFlowProvider, addEdge, applyEdgeChanges, applyNodeChanges } from 'reactflow';
+import type { Connection, EdgeChange, NodeChange } from 'reactflow';
+import type { CreateDefinitionPayload } from '@/types/workflow';
+import type { AppDispatch } from '@/store';
+import {
+  resetDesigner,
+  selectPreviewMode,
+  selectSelectedNodeId,
+  setDefinitionMeta,
+  setDirty,
+  setPreviewMode,
+  setSelectedNodeId,
+} from '@/store/slices/workflowSlice';
+import DesignerToolbar from './DesignerToolbar';
+import NodePanel from './NodePanel';
+import PropertyPanel from './panels/PropertyPanel';
+import DesignerCanvas from './DesignerCanvas';
+import { CreateDefinitionModal, OpenDefinitionModal } from './DesignerModals';
+import { useUndoRedo } from './hooks/useUndoRedo';
+import { useDesignerHotkeys } from './hooks/useDesignerHotkeys';
+import { loadDefinitionGraph, persistDraft, persistPublish } from './hooks/useDesignerPersistence';
+import { downloadGraphJson, parseImportedGraph } from './utils/graphIO';
+import { toFlowGraph, fromFlowGraph, type DesignerRFEdge, type DesignerRFNode } from './utils/flowConvert';
+import type { ConditionConfig, DesignerNodeData } from '@/types/workflow';
+import './designer.css';
+
+const DesignerPageInner: React.FC = () => {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const dispatch = useDispatch<AppDispatch>();
+  const previewMode = useSelector(selectPreviewMode);
+  const selectedNodeId = useSelector(selectSelectedNodeId);
+  const [nodes, setNodes] = useState<DesignerRFNode[]>([]);
+  const [edges, setEdges] = useState<DesignerRFEdge[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [openOpen, setOpenOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState<'draft' | 'publish' | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const { takeSnapshot, undo, redo, resetHistory, canUndo, canRedo } = useUndoRedo(
+    nodes,
+    edges,
+    setNodes,
+    setEdges,
+  );
+
+  useEffect(() => {
+    dispatch(resetDesigner());
+    if (!id) return;
+    loadDefinitionGraph(id)
+      .then((result) => {
+        const converted = fromFlowGraph(result.graph);
+        setNodes(converted.nodes);
+        setEdges(converted.edges);
+        resetHistory();
+        dispatch(setDefinitionMeta({
+          id,
+          name: result.name,
+          key: result.key,
+          status: result.status,
+        }));
+      })
+      .catch(() => message.error('加载流程失败'));
+    // resetHistory 仅重置栈，不作为加载触发条件
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, dispatch]);
+
+  useDesignerHotkeys(undo, redo);
+
+  const selectedNode = nodes.find((node) => node.id === selectedNodeId) ?? null;
+  const graph = useMemo(() => toFlowGraph(nodes, edges), [nodes, edges]);
+
+  const applyGraph = (next: { nodes: DesignerRFNode[]; edges: DesignerRFEdge[] }) => {
+    takeSnapshot();
+    setNodes(next.nodes);
+    setEdges(next.edges);
+    dispatch(setDirty(true));
+  };
+
+  const handleNodesChange = (changes: NodeChange[]) => {
+    setNodes((current) => applyNodeChanges(changes, current) as DesignerRFNode[]);
+    dispatch(setDirty(true));
+  };
+
+  const handleEdgesChange = (changes: EdgeChange[]) => {
+    const structural = changes.some((item) => item.type === 'remove' || item.type === 'add');
+    if (structural) takeSnapshot();
+    setEdges((current) => applyEdgeChanges(changes, current));
+    dispatch(setDirty(true));
+  };
+
+  const handleConnect = (connection: Connection) => {
+    takeSnapshot();
+    const sourceNode = nodes.find((node) => node.id === connection.source);
+    const branches = (sourceNode?.data.config as ConditionConfig | undefined)?.branches;
+    const branch = branches?.find((item) => item.id === connection.sourceHandle);
+    setEdges((current) =>
+      addEdge(
+        {
+          ...connection,
+          id: `e_${Date.now().toString(36)}`,
+          label: branch?.expression || branch?.label,
+          data: branch?.expression ? { condition: branch.expression } : undefined,
+        },
+        current,
+      ),
+    );
+    dispatch(setDirty(true));
+  };
+
+  const handleChangeData = (nodeId: string, data: DesignerNodeData) => {
+    takeSnapshot();
+    setNodes((current) => current.map((node) => (node.id === nodeId ? { ...node, data } : node)));
+    const config = data.config as ConditionConfig;
+    if (config.branches) {
+      setEdges((current) =>
+        current.map((edge) => {
+          const branch = config.branches.find((item) => item.id === edge.sourceHandle);
+          if (!branch || edge.source !== nodeId) return edge;
+          return { ...edge, label: branch.expression || branch.label, data: { condition: branch.expression } };
+        }),
+      );
+    }
+    dispatch(setDirty(true));
+  };
+
+  const handleRetarget = (branchId: string, targetId: string) => {
+    if (!selectedNodeId) return;
+    takeSnapshot();
+    setEdges((current) => {
+      const others = current.filter(
+        (edge) => !(edge.source === selectedNodeId && edge.sourceHandle === branchId),
+      );
+      if (!targetId) return others;
+      return [
+        ...others,
+        {
+          id: `e_${selectedNodeId}_${branchId}`,
+          source: selectedNodeId,
+          target: targetId,
+          sourceHandle: branchId,
+        },
+      ];
+    });
+  };
+
+  const runSave = async (payload?: CreateDefinitionPayload) => {
+    setSaving(true);
+    try {
+      const nextId = await persistDraft(id ?? null, graph, payload);
+      dispatch(setDirty(false));
+      if (!id) navigate(`/workflow/designer/${nextId}`, { replace: true });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'NEED_CREATE') {
+        setPendingAction('draft');
+        setCreateOpen(true);
+        return;
+      }
+      message.error(error instanceof Error ? error.message : '保存失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const runPublish = async (payload?: CreateDefinitionPayload) => {
+    setPublishing(true);
+    try {
+      let defId = id;
+      if (!defId) {
+        defId = await persistDraft(null, graph, payload);
+        navigate(`/workflow/designer/${defId}`, { replace: true });
+      }
+      await persistPublish(defId, graph);
+      dispatch(setDirty(false));
+    } catch (error) {
+      if (error instanceof Error && error.message === 'NEED_CREATE') {
+        setPendingAction('publish');
+        setCreateOpen(true);
+        return;
+      }
+      message.error(error instanceof Error ? error.message : '发布失败');
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  const onCreateOk = async (payload: CreateDefinitionPayload) => {
+    setCreateOpen(false);
+    if (pendingAction === 'publish') await runPublish(payload);
+    else await runSave(payload);
+    setPendingAction(null);
+  };
+
+  const handleImportFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+    file.text().then((text) => {
+      try {
+        const imported = parseImportedGraph(text);
+        Modal.confirm({
+          title: '导入将替换当前画布',
+          onOk: () => applyGraph(fromFlowGraph(imported)),
+        });
+      } catch (error) {
+        message.error(error instanceof Error ? error.message : '导入失败');
+      }
+    });
+  };
+
+  const edgeTargets = useMemo(() => {
+    const map: Record<string, string> = {};
+    edges.forEach((edge) => {
+      if (edge.source === selectedNodeId && edge.sourceHandle) {
+        map[edge.sourceHandle] = edge.target;
+      }
+    });
+    return map;
+  }, [edges, selectedNodeId]);
+
+  return (
+    <div className="designer-page">
+      <DesignerToolbar
+        title={id ? '流程设计' : '新建流程'}
+        previewMode={previewMode}
+        saving={saving}
+        publishing={publishing}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        onSaveDraft={() => runSave()}
+        onPublish={() => runPublish()}
+        onTogglePreview={() => dispatch(setPreviewMode(!previewMode))}
+        onImport={() => fileRef.current?.click()}
+        onExport={() => downloadGraphJson(graph, `workflow-${id || 'draft'}.json`)}
+        onUndo={undo}
+        onRedo={redo}
+        onOpen={() => setOpenOpen(true)}
+        onNew={() => navigate('/workflow/designer')}
+      />
+      <div className="designer-body">
+        <NodePanel disabled={previewMode} />
+        <DesignerCanvas
+          nodes={nodes}
+          edges={edges}
+          previewMode={previewMode}
+          onNodesChange={handleNodesChange}
+          onEdgesChange={handleEdgesChange}
+          onConnect={handleConnect}
+          onNodeClick={(nodeId) => dispatch(setSelectedNodeId(nodeId))}
+          onDropNode={(node) => applyGraph({ nodes: [...nodes, node], edges })}
+          onDragStop={() => takeSnapshot()}
+        />
+        <PropertyPanel
+          node={selectedNode}
+          nodeOptions={nodes.filter((n) => n.id !== selectedNodeId).map((n) => ({ label: n.data.name, value: n.id }))}
+          edgeTargets={edgeTargets}
+          disabled={previewMode}
+          onChangeData={handleChangeData}
+          onRetarget={handleRetarget}
+        />
+      </div>
+      <input ref={fileRef} type="file" accept="application/json" hidden onChange={handleImportFile} />
+      <CreateDefinitionModal
+        open={createOpen}
+        confirmLoading={saving || publishing}
+        onCancel={() => setCreateOpen(false)}
+        onOk={onCreateOk}
+      />
+      <OpenDefinitionModal
+        open={openOpen}
+        onCancel={() => setOpenOpen(false)}
+        onSelect={(nextId) => {
+          setOpenOpen(false);
+          navigate(`/workflow/designer/${nextId}`);
+        }}
+      />
+    </div>
+  );
+};
+
+const DesignerPage: React.FC = () => (
+  <ReactFlowProvider>
+    <DesignerPageInner />
+  </ReactFlowProvider>
+);
+
+export default DesignerPage;

--- a/frontend/src/pages/workflow/designer/DesignerPage.tsx
+++ b/frontend/src/pages/workflow/designer/DesignerPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { ReactFlowProvider, addEdge, applyEdgeChanges, applyNodeChanges } from 'reactflow';
 import type { Connection, EdgeChange, NodeChange } from 'reactflow';
-import type { CreateDefinitionPayload } from '@/types/workflow';
+import type { ConditionConfig, CreateDefinitionPayload, DesignerNodeData } from '@/types/workflow';
 import type { AppDispatch } from '@/store';
 import {
   resetDesigner,
@@ -23,9 +23,15 @@ import { CreateDefinitionModal, OpenDefinitionModal } from './DesignerModals';
 import { useUndoRedo } from './hooks/useUndoRedo';
 import { useDesignerHotkeys } from './hooks/useDesignerHotkeys';
 import { loadDefinitionGraph, persistDraft, persistPublish } from './hooks/useDesignerPersistence';
+import { addNodeOfType, applyImportedGraph } from './hooks/useDesignerNodes';
 import { downloadGraphJson, parseImportedGraph } from './utils/graphIO';
-import { toFlowGraph, fromFlowGraph, type DesignerRFEdge, type DesignerRFNode } from './utils/flowConvert';
-import type { ConditionConfig, DesignerNodeData } from '@/types/workflow';
+import {
+  appendNode,
+  toFlowGraph,
+  fromFlowGraph,
+  type DesignerRFEdge,
+  type DesignerRFNode,
+} from './utils/flowConvert';
 import './designer.css';
 
 const DesignerPageInner: React.FC = () => {
@@ -66,9 +72,7 @@ const DesignerPageInner: React.FC = () => {
         }));
       })
       .catch(() => message.error('加载流程失败'));
-    // resetHistory 仅重置栈，不作为加载触发条件
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, dispatch]);
+  }, [id, dispatch, resetHistory]);
 
   useDesignerHotkeys(undo, redo);
 
@@ -76,13 +80,12 @@ const DesignerPageInner: React.FC = () => {
   const graph = useMemo(() => toFlowGraph(nodes, edges), [nodes, edges]);
 
   const applyGraph = (next: { nodes: DesignerRFNode[]; edges: DesignerRFEdge[] }) => {
-    takeSnapshot();
-    setNodes(next.nodes);
-    setEdges(next.edges);
+    applyImportedGraph(setNodes, setEdges, takeSnapshot, next);
     dispatch(setDirty(true));
   };
 
   const handleNodesChange = (changes: NodeChange[]) => {
+    if (previewMode) return;
     setNodes((current) => applyNodeChanges(changes, current) as DesignerRFNode[]);
     dispatch(setDirty(true));
   };
@@ -243,7 +246,10 @@ const DesignerPageInner: React.FC = () => {
         onNew={() => navigate('/workflow/designer')}
       />
       <div className="designer-body">
-        <NodePanel disabled={previewMode} />
+        <NodePanel
+          disabled={previewMode}
+          onAddNode={(type) => { addNodeOfType(setNodes, takeSnapshot, type); dispatch(setDirty(true)); }}
+        />
         <DesignerCanvas
           nodes={nodes}
           edges={edges}
@@ -252,7 +258,7 @@ const DesignerPageInner: React.FC = () => {
           onEdgesChange={handleEdgesChange}
           onConnect={handleConnect}
           onNodeClick={(nodeId) => dispatch(setSelectedNodeId(nodeId))}
-          onDropNode={(node) => applyGraph({ nodes: [...nodes, node], edges })}
+          onDropNode={(node) => { takeSnapshot(); setNodes((c) => appendNode(c, node)); dispatch(setDirty(true)); }}
           onDragStop={() => takeSnapshot()}
         />
         <PropertyPanel

--- a/frontend/src/pages/workflow/designer/DesignerToolbar.tsx
+++ b/frontend/src/pages/workflow/designer/DesignerToolbar.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Button, Space, Tag } from 'antd';
+import {
+  SaveOutlined,
+  CloudUploadOutlined,
+  EyeOutlined,
+  ImportOutlined,
+  ExportOutlined,
+  UndoOutlined,
+  RedoOutlined,
+  FolderOpenOutlined,
+  PlusOutlined,
+} from '@ant-design/icons';
+
+interface DesignerToolbarProps {
+  title: string;
+  previewMode: boolean;
+  saving: boolean;
+  publishing: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  onSaveDraft: () => void;
+  onPublish: () => void;
+  onTogglePreview: () => void;
+  onImport: () => void;
+  onExport: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onOpen: () => void;
+  onNew: () => void;
+}
+
+const DesignerToolbar: React.FC<DesignerToolbarProps> = ({
+  title,
+  previewMode,
+  saving,
+  publishing,
+  canUndo,
+  canRedo,
+  onSaveDraft,
+  onPublish,
+  onTogglePreview,
+  onImport,
+  onExport,
+  onUndo,
+  onRedo,
+  onOpen,
+  onNew,
+}) => (
+  <div className="designer-toolbar">
+    <Space>
+      <strong>{title || '未命名流程'}</strong>
+      {previewMode && <Tag color="blue">预览</Tag>}
+    </Space>
+    <Space wrap>
+      <Button icon={<PlusOutlined />} onClick={onNew}>
+        新建
+      </Button>
+      <Button icon={<FolderOpenOutlined />} onClick={onOpen}>
+        打开
+      </Button>
+      <Button icon={<SaveOutlined />} loading={saving} onClick={onSaveDraft}>
+        保存草稿
+      </Button>
+      <Button type="primary" icon={<CloudUploadOutlined />} loading={publishing} onClick={onPublish}>
+        发布
+      </Button>
+      <Button icon={<EyeOutlined />} onClick={onTogglePreview}>
+        {previewMode ? '返回编辑' : '预览'}
+      </Button>
+      <Button icon={<ImportOutlined />} disabled={previewMode} onClick={onImport}>
+        导入
+      </Button>
+      <Button icon={<ExportOutlined />} onClick={onExport}>
+        导出
+      </Button>
+      <Button icon={<UndoOutlined />} disabled={previewMode || !canUndo} onClick={onUndo}>
+        撤销
+      </Button>
+      <Button icon={<RedoOutlined />} disabled={previewMode || !canRedo} onClick={onRedo}>
+        重做
+      </Button>
+    </Space>
+  </div>
+);
+
+export default DesignerToolbar;

--- a/frontend/src/pages/workflow/designer/NodePanel.tsx
+++ b/frontend/src/pages/workflow/designer/NodePanel.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { NODE_PALETTE, DND_TYPE } from './constants';
+import type { DesignerNodeType } from '@/types/workflow';
+
+interface NodePanelProps {
+  disabled?: boolean;
+}
+
+const NodePanel: React.FC<NodePanelProps> = ({ disabled }) => {
+  const onDragStart = (event: React.DragEvent, type: DesignerNodeType) => {
+    if (disabled) return;
+    event.dataTransfer.setData(DND_TYPE, type);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  return (
+    <div className="designer-side-panel">
+      <h4>节点面板</h4>
+      <div className="node-palette">
+        {NODE_PALETTE.map((item) => (
+          <div
+            key={item.type}
+            className="node-palette-item"
+            draggable={!disabled}
+            onDragStart={(event) => onDragStart(event, item.type)}
+            style={{ borderColor: item.color, opacity: disabled ? 0.5 : 1 }}
+          >
+            <span className="node-palette-dot" style={{ background: item.color }} />
+            {item.label}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default NodePanel;

--- a/frontend/src/pages/workflow/designer/NodePanel.tsx
+++ b/frontend/src/pages/workflow/designer/NodePanel.tsx
@@ -4,12 +4,14 @@ import type { DesignerNodeType } from '@/types/workflow';
 
 interface NodePanelProps {
   disabled?: boolean;
+  onAddNode?: (type: DesignerNodeType) => void;
 }
 
-const NodePanel: React.FC<NodePanelProps> = ({ disabled }) => {
+const NodePanel: React.FC<NodePanelProps> = ({ disabled, onAddNode }) => {
   const onDragStart = (event: React.DragEvent, type: DesignerNodeType) => {
     if (disabled) return;
     event.dataTransfer.setData(DND_TYPE, type);
+    event.dataTransfer.setData('text/plain', type);
     event.dataTransfer.effectAllowed = 'move';
   };
 
@@ -23,6 +25,9 @@ const NodePanel: React.FC<NodePanelProps> = ({ disabled }) => {
             className="node-palette-item"
             draggable={!disabled}
             onDragStart={(event) => onDragStart(event, item.type)}
+            onClick={() => {
+              if (!disabled) onAddNode?.(item.type);
+            }}
             style={{ borderColor: item.color, opacity: disabled ? 0.5 : 1 }}
           >
             <span className="node-palette-dot" style={{ background: item.color }} />

--- a/frontend/src/pages/workflow/designer/constants.ts
+++ b/frontend/src/pages/workflow/designer/constants.ts
@@ -1,0 +1,47 @@
+import type { DesignerNodeType } from '@/types/workflow';
+
+export interface NodePaletteItem {
+  type: DesignerNodeType;
+  label: string;
+  color: string;
+  shape: 'circle' | 'rect' | 'diamond';
+}
+
+export const NODE_PALETTE: NodePaletteItem[] = [
+  { type: 'start', label: '开始', color: '#52c41a', shape: 'circle' },
+  { type: 'end', label: '结束', color: '#ff4d4f', shape: 'circle' },
+  { type: 'approval', label: '审批', color: '#1677ff', shape: 'rect' },
+  { type: 'condition', label: '条件', color: '#faad14', shape: 'diamond' },
+  { type: 'parallel', label: '并行', color: '#722ed1', shape: 'rect' },
+  { type: 'merge', label: '合并', color: '#8c8c8c', shape: 'rect' },
+  { type: 'timer', label: '定时器', color: '#fa8c16', shape: 'rect' },
+  { type: 'notify', label: '通知', color: '#13c2c2', shape: 'rect' },
+];
+
+export const NODE_META: Record<DesignerNodeType, NodePaletteItem> = NODE_PALETTE.reduce(
+  (acc, item) => {
+    acc[item.type] = item;
+    return acc;
+  },
+  {} as Record<DesignerNodeType, NodePaletteItem>,
+);
+
+export const CONDITION_VARIABLES = [
+  'applicant.name',
+  'applicant.dept_id',
+  'interview.score',
+  'interview.result',
+  'initiator.id',
+];
+
+export const CONDITION_OPERATORS = ['==', '!=', '>', '<', '>=', '<='] as const;
+
+export const NOTIFY_TEMPLATES = [
+  { label: '默认通知', value: 'default' },
+  { label: '审批待办', value: 'approval_todo' },
+  { label: '审批结果', value: 'approval_result' },
+];
+
+export const DND_TYPE = 'application/starbyte-flow-node';
+
+export const HISTORY_LIMIT = 50;

--- a/frontend/src/pages/workflow/designer/designer.css
+++ b/frontend/src/pages/workflow/designer/designer.css
@@ -42,6 +42,12 @@
 .designer-canvas {
   height: 100%;
   background: #fafafa;
+  position: relative;
+}
+
+.designer-canvas.is-preview .react-flow__node,
+.designer-canvas.is-preview .react-flow__handle {
+  pointer-events: none;
 }
 
 .node-palette {

--- a/frontend/src/pages/workflow/designer/designer.css
+++ b/frontend/src/pages/workflow/designer/designer.css
@@ -1,0 +1,73 @@
+.designer-page {
+  margin: -24px;
+  height: calc(100vh - 96px);
+  min-width: 1280px;
+  display: flex;
+  flex-direction: column;
+  background: #f5f5f5;
+}
+
+.designer-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px;
+  background: #fff;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.designer-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 200px 1fr 280px;
+  min-height: 0;
+}
+
+.designer-side-panel {
+  background: #fff;
+  border-right: 1px solid #f0f0f0;
+  padding: 12px;
+  overflow: auto;
+}
+
+.designer-side-panel:last-child {
+  border-right: 0;
+  border-left: 1px solid #f0f0f0;
+}
+
+.designer-side-panel h4 {
+  margin-bottom: 12px;
+}
+
+.designer-canvas {
+  height: 100%;
+  background: #fafafa;
+}
+
+.node-palette {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.node-palette-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
+  background: #fff;
+  cursor: grab;
+  user-select: none;
+}
+
+.node-palette-item:active {
+  cursor: grabbing;
+}
+
+.node-palette-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}

--- a/frontend/src/pages/workflow/designer/hooks/useDesignerHotkeys.ts
+++ b/frontend/src/pages/workflow/designer/hooks/useDesignerHotkeys.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+export function useDesignerHotkeys(undo: () => void, redo: () => void): void {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
+        event.preventDefault();
+        if (event.shiftKey) redo();
+        else undo();
+      }
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'y') {
+        event.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [undo, redo]);
+}

--- a/frontend/src/pages/workflow/designer/hooks/useDesignerNodes.ts
+++ b/frontend/src/pages/workflow/designer/hooks/useDesignerNodes.ts
@@ -1,0 +1,36 @@
+import type { Dispatch, SetStateAction } from 'react';
+import type { DesignerNodeType } from '@/types/workflow';
+import {
+  appendNode,
+  createNodeId,
+  defaultNodeData,
+  type DesignerRFEdge,
+  type DesignerRFNode,
+} from '../utils/flowConvert';
+
+export function addNodeOfType(
+  setNodes: Dispatch<SetStateAction<DesignerRFNode[]>>,
+  takeSnapshot: () => void,
+  type: DesignerNodeType,
+): void {
+  takeSnapshot();
+  setNodes((current) =>
+    appendNode(current, {
+      id: createNodeId(type),
+      type,
+      position: { x: 180, y: 120 },
+      data: defaultNodeData(type),
+    }),
+  );
+}
+
+export function applyImportedGraph(
+  setNodes: (nodes: DesignerRFNode[]) => void,
+  setEdges: (edges: DesignerRFEdge[]) => void,
+  takeSnapshot: () => void,
+  next: { nodes: DesignerRFNode[]; edges: DesignerRFEdge[] },
+): void {
+  takeSnapshot();
+  setNodes(next.nodes);
+  setEdges(next.edges);
+}

--- a/frontend/src/pages/workflow/designer/hooks/useDesignerPersistence.ts
+++ b/frontend/src/pages/workflow/designer/hooks/useDesignerPersistence.ts
@@ -1,0 +1,74 @@
+import { message } from 'antd';
+import {
+  createFlowDefinition,
+  getFlowDefinitionDetail,
+  getFlowVersion,
+  listFlowVersions,
+  publishFlowDefinition,
+  saveFlowDraft,
+} from '@/api/workflow';
+import type { CreateDefinitionPayload, FlowGraphData } from '@/types/workflow';
+import { fromBackendGraph, toPublishGraph } from '../utils/graphMapper';
+import { validateDraftGraph, validatePublishGraph } from '../utils/graphValidate';
+
+export async function loadDefinitionGraph(id: string): Promise<{
+  name: string;
+  key: string;
+  status: number;
+  graph: FlowGraphData;
+}> {
+  const detail = await getFlowDefinitionDetail(id);
+  if (detail.draft_graph && detail.draft_graph.nodes) {
+    return {
+      name: detail.name,
+      key: detail.key,
+      status: detail.status,
+      graph: fromBackendGraph(detail.draft_graph),
+    };
+  }
+  const versions = await listFlowVersions(id);
+  const current = versions.find((item) => item.status === 1) ?? versions[0];
+  if (!current) {
+    return { name: detail.name, key: detail.key, status: detail.status, graph: { nodes: [], edges: [] } };
+  }
+  const version = current.bpmn_data?.nodes
+    ? current
+    : await getFlowVersion(id, current.id);
+  return {
+    name: detail.name,
+    key: detail.key,
+    status: detail.status,
+    graph: fromBackendGraph(version.bpmn_data ?? { nodes: [], edges: [] }),
+  };
+}
+
+export async function persistDraft(
+  definitionId: string | null,
+  graph: FlowGraphData,
+  createPayload?: CreateDefinitionPayload,
+): Promise<string> {
+  const issues = validateDraftGraph(graph);
+  if (issues.length > 0) {
+    throw new Error(issues[0].message);
+  }
+  let id = definitionId;
+  if (!id) {
+    if (!createPayload) {
+      throw new Error('NEED_CREATE');
+    }
+    const created = await createFlowDefinition(createPayload);
+    id = created.id;
+  }
+  await saveFlowDraft(id, graph);
+  message.success('草稿已保存');
+  return id;
+}
+
+export async function persistPublish(definitionId: string, graph: FlowGraphData): Promise<void> {
+  const issues = validatePublishGraph(graph);
+  if (issues.length > 0) {
+    throw new Error(issues.map((item) => item.message).join('；'));
+  }
+  await publishFlowDefinition(definitionId, toPublishGraph(graph));
+  message.success('流程已发布');
+}

--- a/frontend/src/pages/workflow/designer/hooks/useUndoRedo.ts
+++ b/frontend/src/pages/workflow/designer/hooks/useUndoRedo.ts
@@ -1,0 +1,75 @@
+import { useCallback, useRef, useState } from 'react';
+import type { DesignerRFEdge, DesignerRFNode } from '../utils/flowConvert';
+import { HISTORY_LIMIT } from '../constants';
+
+interface Snapshot {
+  nodes: DesignerRFNode[];
+  edges: DesignerRFEdge[];
+}
+
+function cloneSnapshot(nodes: DesignerRFNode[], edges: DesignerRFEdge[]): Snapshot {
+  return {
+    nodes: nodes.map((node) => ({ ...node, position: { ...node.position }, data: { ...node.data } })),
+    edges: edges.map((edge) => ({ ...edge })),
+  };
+}
+
+export function useUndoRedo(
+  nodes: DesignerRFNode[],
+  edges: DesignerRFEdge[],
+  setNodes: (nodes: DesignerRFNode[]) => void,
+  setEdges: (edges: DesignerRFEdge[]) => void,
+) {
+  const pastRef = useRef<Snapshot[]>([]);
+  const futureRef = useRef<Snapshot[]>([]);
+  const applyingRef = useRef(false);
+  const [revision, setRevision] = useState(0);
+
+  const takeSnapshot = useCallback(() => {
+    if (applyingRef.current) return;
+    pastRef.current.push(cloneSnapshot(nodes, edges));
+    if (pastRef.current.length > HISTORY_LIMIT) {
+      pastRef.current.shift();
+    }
+    futureRef.current = [];
+    setRevision((value) => value + 1);
+  }, [nodes, edges]);
+
+  const undo = useCallback(() => {
+    const previous = pastRef.current.pop();
+    if (!previous) return;
+    futureRef.current.push(cloneSnapshot(nodes, edges));
+    applyingRef.current = true;
+    setNodes(previous.nodes);
+    setEdges(previous.edges);
+    applyingRef.current = false;
+    setRevision((value) => value + 1);
+  }, [nodes, edges, setNodes, setEdges]);
+
+  const redo = useCallback(() => {
+    const next = futureRef.current.pop();
+    if (!next) return;
+    pastRef.current.push(cloneSnapshot(nodes, edges));
+    applyingRef.current = true;
+    setNodes(next.nodes);
+    setEdges(next.edges);
+    applyingRef.current = false;
+    setRevision((value) => value + 1);
+  }, [nodes, edges, setNodes, setEdges]);
+
+  const resetHistory = useCallback(() => {
+    pastRef.current = [];
+    futureRef.current = [];
+    setRevision((value) => value + 1);
+  }, []);
+
+  return {
+    takeSnapshot,
+    undo,
+    redo,
+    resetHistory,
+    canUndo: pastRef.current.length > 0,
+    canRedo: futureRef.current.length > 0,
+    revision,
+  };
+}

--- a/frontend/src/pages/workflow/designer/nodes/FlowNodeCard.tsx
+++ b/frontend/src/pages/workflow/designer/nodes/FlowNodeCard.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { ConditionConfig, DesignerNodeData, DesignerNodeType } from '@/types/workflow';
+import { NODE_META } from '../constants';
+
+const ICONS: Record<DesignerNodeType, string> = {
+  start: '▶',
+  end: '■',
+  approval: '✓',
+  condition: '◇',
+  parallel: '⑂',
+  merge: '⫻',
+  timer: '⏱',
+  notify: '🔔',
+};
+
+const FlowNodeCard: React.FC<NodeProps<DesignerNodeData>> = ({ data, selected, type }) => {
+  const nodeType = (type ?? 'approval') as DesignerNodeType;
+  const meta = NODE_META[nodeType];
+  const isCircle = meta.shape === 'circle';
+  const isDiamond = meta.shape === 'diamond';
+  const size = isCircle ? 72 : undefined;
+
+  const boxStyle: React.CSSProperties = isDiamond
+    ? {
+        width: 88,
+        height: 88,
+        transform: 'rotate(45deg)',
+        background: '#fff',
+        border: `2px solid ${meta.color}`,
+        boxShadow: selected ? `0 0 0 3px ${meta.color}33` : '0 2px 6px rgba(0,0,0,0.08)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }
+    : {
+        minWidth: isCircle ? size : 132,
+        height: isCircle ? size : 56,
+        borderRadius: isCircle ? '50%' : 8,
+        background: '#fff',
+        border: `2px solid ${meta.color}`,
+        boxShadow: selected ? `0 0 0 3px ${meta.color}33` : '0 2px 6px rgba(0,0,0,0.08)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 6,
+        padding: isCircle ? 0 : '0 12px',
+      };
+
+  const innerStyle: React.CSSProperties = isDiamond
+    ? { transform: 'rotate(-45deg)', textAlign: 'center', fontSize: 12, fontWeight: 600 }
+    : { fontSize: 13, fontWeight: 600, color: '#1f1f1f' };
+
+  return (
+    <div style={boxStyle}>
+      {nodeType !== 'start' && (
+        <Handle type="target" position={Position.Top} style={{ background: meta.color }} />
+      )}
+      <div style={innerStyle}>
+        <span style={{ color: meta.color, marginRight: 4 }}>{ICONS[nodeType]}</span>
+        {data.name || meta.label}
+      </div>
+      {nodeType !== 'end' && nodeType !== 'condition' && (
+        <Handle type="source" position={Position.Bottom} style={{ background: meta.color }} />
+      )}
+      {nodeType === 'condition' &&
+        ((data.config as ConditionConfig).branches ?? []).map((branch, index) => (
+          <Handle
+            key={branch.id}
+            id={branch.id}
+            type="source"
+            position={index % 2 === 0 ? Position.Right : Position.Bottom}
+            style={{ background: meta.color, top: index % 2 === 0 ? 24 + index * 8 : undefined }}
+          />
+        ))}
+    </div>
+  );
+};
+
+export default FlowNodeCard;

--- a/frontend/src/pages/workflow/designer/nodes/nodeTypes.ts
+++ b/frontend/src/pages/workflow/designer/nodes/nodeTypes.ts
@@ -1,0 +1,13 @@
+import type { NodeTypes } from 'reactflow';
+import FlowNodeCard from './FlowNodeCard';
+
+export const designerNodeTypes: NodeTypes = {
+  start: FlowNodeCard,
+  end: FlowNodeCard,
+  approval: FlowNodeCard,
+  condition: FlowNodeCard,
+  parallel: FlowNodeCard,
+  merge: FlowNodeCard,
+  timer: FlowNodeCard,
+  notify: FlowNodeCard,
+};

--- a/frontend/src/pages/workflow/designer/panels/ApprovalConfigForm.tsx
+++ b/frontend/src/pages/workflow/designer/panels/ApprovalConfigForm.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { AutoComplete, Form, InputNumber, Select } from 'antd';
 import { getUserList } from '@/api/user';
-import request from '@/api/request';
-import type { PageResponse, Role } from '@/types/api';
+import { getWorkflowRoleList } from '@/api/workflow';
 import type { ApprovalConfig, ApprovalType, AssigneeStrategy } from '@/types/workflow';
 
 interface OptionItem {
@@ -21,12 +20,10 @@ const ApprovalConfigForm: React.FC<ApprovalConfigFormProps> = ({ value, disabled
   const [roleOptions, setRoleOptions] = useState<OptionItem[]>([]);
 
   useEffect(() => {
-    request
-      .get('/system/roles', { params: { page: 1, page_size: 100 } })
-      .then((res) => {
-        const page = res as PageResponse<Role>;
-        setRoleOptions((page.list ?? []).map((item) => ({ label: item.name, value: item.id })));
-      })
+    getWorkflowRoleList()
+      .then((res) =>
+        setRoleOptions((res.list ?? []).map((item) => ({ label: item.name, value: item.id }))),
+      )
       .catch(() => setRoleOptions([]));
   }, []);
 

--- a/frontend/src/pages/workflow/designer/panels/ApprovalConfigForm.tsx
+++ b/frontend/src/pages/workflow/designer/panels/ApprovalConfigForm.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { AutoComplete, Form, InputNumber, Select } from 'antd';
+import { getUserList } from '@/api/user';
+import request from '@/api/request';
+import type { PageResponse, Role } from '@/types/api';
+import type { ApprovalConfig, ApprovalType, AssigneeStrategy } from '@/types/workflow';
+
+interface OptionItem {
+  label: string;
+  value: string;
+}
+
+interface ApprovalConfigFormProps {
+  value: ApprovalConfig;
+  disabled?: boolean;
+  onChange: (next: ApprovalConfig) => void;
+}
+
+const ApprovalConfigForm: React.FC<ApprovalConfigFormProps> = ({ value, disabled, onChange }) => {
+  const [userOptions, setUserOptions] = useState<OptionItem[]>([]);
+  const [roleOptions, setRoleOptions] = useState<OptionItem[]>([]);
+
+  useEffect(() => {
+    request
+      .get('/system/roles', { params: { page: 1, page_size: 100 } })
+      .then((res) => {
+        const page = res as PageResponse<Role>;
+        setRoleOptions((page.list ?? []).map((item) => ({ label: item.name, value: item.id })));
+      })
+      .catch(() => setRoleOptions([]));
+  }, []);
+
+  const searchUsers = (keyword: string) => {
+    getUserList({ page: 1, page_size: 20, keyword })
+      .then((res) =>
+        setUserOptions(
+          res.list.map((user) => ({
+            label: `${user.real_name || user.username} (${user.username})`,
+            value: user.id,
+          })),
+        ),
+      )
+      .catch(() => setUserOptions([]));
+  };
+
+  const patch = (partial: Partial<ApprovalConfig>) => onChange({ ...value, ...partial });
+
+  return (
+    <>
+      <Form.Item label="审批人类型">
+        <Select
+          disabled={disabled}
+          value={value.assigneeStrategy}
+          onChange={(assigneeStrategy: AssigneeStrategy) => patch({ assigneeStrategy })}
+          options={[
+            { label: '指定用户', value: 'static' },
+            { label: '指定角色', value: 'role' },
+            { label: '部门负责人', value: 'dept_leader' },
+            { label: '发起人', value: 'initiator' },
+          ]}
+        />
+      </Form.Item>
+      {value.assigneeStrategy === 'static' && (
+        <Form.Item label="审批人">
+          <Select
+            mode="multiple"
+            disabled={disabled}
+            value={value.assignees}
+            options={userOptions}
+            showSearch
+            filterOption={false}
+            onSearch={searchUsers}
+            onDropdownVisibleChange={(open) => open && searchUsers('')}
+            onChange={(assignees: string[]) => patch({ assignees })}
+            placeholder="搜索并选择用户"
+          />
+        </Form.Item>
+      )}
+      {value.assigneeStrategy === 'role' && (
+        <Form.Item label="角色">
+          <AutoComplete
+            disabled={disabled}
+            value={value.roleId}
+            options={roleOptions}
+            onChange={(roleId: string) => patch({ roleId })}
+            placeholder="选择角色"
+          />
+        </Form.Item>
+      )}
+      <Form.Item label="多人策略">
+        <Select
+          disabled={disabled}
+          value={value.approvalType ?? 'single'}
+          onChange={(approvalType: ApprovalType) => patch({ approvalType })}
+          options={[
+            { label: '单人', value: 'single' },
+            { label: '会签（全部）', value: 'all' },
+            { label: '或签（任一）', value: 'any' },
+            { label: '比例通过', value: 'ratio' },
+          ]}
+        />
+      </Form.Item>
+      {value.approvalType === 'ratio' && (
+        <Form.Item label="比例阈值">
+          <InputNumber
+            disabled={disabled}
+            min={1}
+            max={100}
+            value={value.passRatio}
+            onChange={(passRatio) => patch({ passRatio: passRatio ?? 0 })}
+            addonAfter="%"
+          />
+        </Form.Item>
+      )}
+    </>
+  );
+};
+
+export default ApprovalConfigForm;

--- a/frontend/src/pages/workflow/designer/panels/ConditionConfigForm.tsx
+++ b/frontend/src/pages/workflow/designer/panels/ConditionConfigForm.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { AutoComplete, Button, Checkbox, Form, Input, Select, Space } from 'antd';
+import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import type { ConditionBranch, ConditionConfig, ConditionOperator } from '@/types/workflow';
+import { CONDITION_OPERATORS, CONDITION_VARIABLES } from '../constants';
+
+interface ConditionConfigFormProps {
+  value: ConditionConfig;
+  nodeOptions: Array<{ label: string; value: string }>;
+  edgeTargets: Record<string, string>;
+  disabled?: boolean;
+  onChange: (next: ConditionConfig) => void;
+  onRetarget: (branchId: string, targetId: string) => void;
+}
+
+function parseExpression(expression: string): {
+  variable: string;
+  operator: ConditionOperator;
+  value: string;
+} {
+  const matched = expression.match(/^(.+?)\s*(==|!=|>=|<=|>|<)\s*(.+)$/);
+  if (!matched) {
+    return { variable: expression, operator: '==', value: '' };
+  }
+  return {
+    variable: matched[1].trim(),
+    operator: matched[2] as ConditionOperator,
+    value: matched[3].trim(),
+  };
+}
+
+const ConditionConfigForm: React.FC<ConditionConfigFormProps> = ({
+  value,
+  nodeOptions,
+  edgeTargets,
+  disabled,
+  onChange,
+  onRetarget,
+}) => {
+  const updateBranch = (index: number, next: ConditionBranch) => {
+    const branches = value.branches.map((branch, i) => (i === index ? next : branch));
+    onChange({ branches });
+  };
+
+  const addBranch = () => {
+    const id = `branch_${Date.now().toString(36)}`;
+    onChange({
+      branches: [
+        ...value.branches,
+        { id, label: `条件${value.branches.length + 1}`, expression: '', is_default: false },
+      ],
+    });
+  };
+
+  const removeBranch = (index: number) => {
+    onChange({ branches: value.branches.filter((_, i) => i !== index) });
+  };
+
+  return (
+    <>
+      {value.branches.map((branch, index) => {
+        const parsed = parseExpression(branch.expression);
+        return (
+          <div key={branch.id} style={{ marginBottom: 12, padding: 8, background: '#fafafa' }}>
+            <Space style={{ width: '100%', justifyContent: 'space-between' }}>
+              <span>分支 {index + 1}</span>
+              {!disabled && (
+                <MinusCircleOutlined onClick={() => removeBranch(index)} />
+              )}
+            </Space>
+            <Form.Item label="变量">
+              <AutoComplete
+                disabled={disabled}
+                value={parsed.variable}
+                options={CONDITION_VARIABLES.map((item) => ({ value: item }))}
+                onChange={(variable) =>
+                  updateBranch(index, {
+                    ...branch,
+                    expression: `${variable} ${parsed.operator} ${parsed.value}`.trim(),
+                    label: `${variable} ${parsed.operator} ${parsed.value}`.trim(),
+                  })
+                }
+              />
+            </Form.Item>
+            <Form.Item label="运算符">
+              <Select
+                disabled={disabled}
+                value={parsed.operator}
+                options={CONDITION_OPERATORS.map((op) => ({ label: op, value: op }))}
+                onChange={(operator: ConditionOperator) =>
+                  updateBranch(index, {
+                    ...branch,
+                    expression: `${parsed.variable} ${operator} ${parsed.value}`.trim(),
+                    label: `${parsed.variable} ${operator} ${parsed.value}`.trim(),
+                  })
+                }
+              />
+            </Form.Item>
+            <Form.Item label="值">
+              <Input
+                disabled={disabled}
+                value={parsed.value}
+                onChange={(event) =>
+                  updateBranch(index, {
+                    ...branch,
+                    expression: `${parsed.variable} ${parsed.operator} ${event.target.value}`.trim(),
+                    label: `${parsed.variable} ${parsed.operator} ${event.target.value}`.trim(),
+                  })
+                }
+              />
+            </Form.Item>
+            <Form.Item label="目标节点">
+              <Select
+                disabled={disabled}
+                allowClear
+                value={edgeTargets[branch.id]}
+                options={nodeOptions}
+                onChange={(targetId: string) => onRetarget(branch.id, targetId)}
+              />
+            </Form.Item>
+            <Checkbox
+              disabled={disabled}
+              checked={branch.is_default}
+              onChange={(event) =>
+                updateBranch(index, { ...branch, is_default: event.target.checked })
+              }
+            >
+              默认分支
+            </Checkbox>
+          </div>
+        );
+      })}
+      {!disabled && (
+        <Button type="dashed" block icon={<PlusOutlined />} onClick={addBranch}>
+          添加条件
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default ConditionConfigForm;

--- a/frontend/src/pages/workflow/designer/panels/ExtraConfigForms.tsx
+++ b/frontend/src/pages/workflow/designer/panels/ExtraConfigForms.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Checkbox, Form, Input, InputNumber, Select } from 'antd';
+import type { NotifyChannel, NotifyConfig, ParallelConfig, TimerConfig, TimerUnit } from '@/types/workflow';
+import { NOTIFY_TEMPLATES } from '../constants';
+
+interface ParallelFormProps {
+  value: ParallelConfig;
+  disabled?: boolean;
+  onChange: (next: ParallelConfig) => void;
+}
+
+export const ParallelConfigForm: React.FC<ParallelFormProps> = ({ value, disabled, onChange }) => (
+  <>
+    <Form.Item label="分支数量">
+      <InputNumber
+        disabled={disabled}
+        min={2}
+        max={8}
+        value={value.branchCount}
+        onChange={(branchCount) => {
+          const count = branchCount ?? 2;
+          const labels = [...(value.branchLabels ?? [])];
+          while (labels.length < count) labels.push(`分支${labels.length + 1}`);
+          onChange({ ...value, branchCount: count, branchLabels: labels.slice(0, count) });
+        }}
+      />
+    </Form.Item>
+    {(value.branchLabels ?? []).map((label, index) => (
+      <Form.Item key={`branch-label-${index}`} label={`分支${index + 1}说明`}>
+        <Input
+          disabled={disabled}
+          value={label}
+          onChange={(event) => {
+            const branchLabels = [...value.branchLabels];
+            branchLabels[index] = event.target.value;
+            onChange({ ...value, branchLabels });
+          }}
+        />
+      </Form.Item>
+    ))}
+  </>
+);
+
+interface TimerFormProps {
+  value: TimerConfig;
+  disabled?: boolean;
+  onChange: (next: TimerConfig) => void;
+}
+
+export const TimerConfigForm: React.FC<TimerFormProps> = ({ value, disabled, onChange }) => (
+  <>
+    <Form.Item label="持续时长">
+      <InputNumber
+        disabled={disabled}
+        min={1}
+        value={value.duration}
+        onChange={(duration) => onChange({ ...value, duration: duration ?? 1 })}
+      />
+    </Form.Item>
+    <Form.Item label="单位">
+      <Select
+        disabled={disabled}
+        value={value.unit}
+        onChange={(unit: TimerUnit) => onChange({ ...value, unit })}
+        options={[
+          { label: '分钟', value: 'minutes' },
+          { label: '小时', value: 'hours' },
+          { label: '天', value: 'days' },
+        ]}
+      />
+    </Form.Item>
+  </>
+);
+
+interface NotifyFormProps {
+  value: NotifyConfig;
+  disabled?: boolean;
+  onChange: (next: NotifyConfig) => void;
+}
+
+export const NotifyConfigForm: React.FC<NotifyFormProps> = ({ value, disabled, onChange }) => (
+  <>
+    <Form.Item label="通知渠道">
+      <Checkbox.Group
+        disabled={disabled}
+        value={value.channels}
+        onChange={(channels) => onChange({ ...value, channels: channels as NotifyChannel[] })}
+        options={[
+          { label: '站内信', value: 'in_app' },
+          { label: '邮件', value: 'email' },
+        ]}
+      />
+    </Form.Item>
+    <Form.Item label="通知模板">
+      <Select
+        disabled={disabled}
+        value={value.notificationType}
+        onChange={(notificationType: string) => onChange({ ...value, notificationType })}
+        options={NOTIFY_TEMPLATES}
+      />
+    </Form.Item>
+  </>
+);

--- a/frontend/src/pages/workflow/designer/panels/PropertyPanel.tsx
+++ b/frontend/src/pages/workflow/designer/panels/PropertyPanel.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Empty, Form, Input } from 'antd';
+import type {
+  ApprovalConfig,
+  ConditionConfig,
+  DesignerNodeData,
+  NotifyConfig,
+  ParallelConfig,
+  TimerConfig,
+} from '@/types/workflow';
+import type { DesignerRFNode } from '../utils/flowConvert';
+import ApprovalConfigForm from './ApprovalConfigForm';
+import ConditionConfigForm from './ConditionConfigForm';
+import { NotifyConfigForm, ParallelConfigForm, TimerConfigForm } from './ExtraConfigForms';
+
+interface PropertyPanelProps {
+  node: DesignerRFNode | null;
+  nodeOptions: Array<{ label: string; value: string }>;
+  edgeTargets: Record<string, string>;
+  disabled?: boolean;
+  onChangeData: (nodeId: string, data: DesignerNodeData) => void;
+  onRetarget: (branchId: string, targetId: string) => void;
+}
+
+const PropertyPanel: React.FC<PropertyPanelProps> = ({
+  node,
+  nodeOptions,
+  edgeTargets,
+  disabled,
+  onChangeData,
+  onRetarget,
+}) => {
+  if (!node) {
+    return (
+      <div className="designer-side-panel">
+        <h4>属性面板</h4>
+        <Empty description="选中节点后配置属性" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+      </div>
+    );
+  }
+
+  const patchData = (partial: Partial<DesignerNodeData>) => {
+    const next = { ...node.data, ...partial };
+    next.label = next.name;
+    onChangeData(node.id, next);
+  };
+
+  return (
+    <div className="designer-side-panel">
+      <h4>属性面板</h4>
+      <Form layout="vertical" size="small">
+        <Form.Item label="节点名称">
+          <Input
+            disabled={disabled}
+            value={node.data.name}
+            onChange={(event) => patchData({ name: event.target.value })}
+          />
+        </Form.Item>
+        <Form.Item label="节点说明">
+          <Input.TextArea
+            disabled={disabled}
+            rows={2}
+            value={node.data.description}
+            onChange={(event) => patchData({ description: event.target.value })}
+          />
+        </Form.Item>
+        {node.type === 'approval' && (
+          <ApprovalConfigForm
+            value={node.data.config as ApprovalConfig}
+            disabled={disabled}
+            onChange={(config) => patchData({ config })}
+          />
+        )}
+        {node.type === 'condition' && (
+          <ConditionConfigForm
+            value={node.data.config as ConditionConfig}
+            nodeOptions={nodeOptions}
+            edgeTargets={edgeTargets}
+            disabled={disabled}
+            onChange={(config) => patchData({ config })}
+            onRetarget={onRetarget}
+          />
+        )}
+        {node.type === 'parallel' && (
+          <ParallelConfigForm
+            value={node.data.config as ParallelConfig}
+            disabled={disabled}
+            onChange={(config) => patchData({ config })}
+          />
+        )}
+        {node.type === 'timer' && (
+          <TimerConfigForm
+            value={node.data.config as TimerConfig}
+            disabled={disabled}
+            onChange={(config) => patchData({ config })}
+          />
+        )}
+        {node.type === 'notify' && (
+          <NotifyConfigForm
+            value={node.data.config as NotifyConfig}
+            disabled={disabled}
+            onChange={(config) => patchData({ config })}
+          />
+        )}
+      </Form>
+    </div>
+  );
+};
+
+export default PropertyPanel;

--- a/frontend/src/pages/workflow/designer/utils/flowConvert.ts
+++ b/frontend/src/pages/workflow/designer/utils/flowConvert.ts
@@ -1,0 +1,87 @@
+import type { Edge, Node } from 'reactflow';
+import type { DesignerNodeData, DesignerNodeType, FlowGraphData } from '@/types/workflow';
+import { NODE_META } from '../constants';
+
+export type DesignerRFNode = Node<DesignerNodeData, DesignerNodeType>;
+export type DesignerRFEdge = Edge<{ condition?: string }>;
+
+export function defaultNodeData(type: DesignerNodeType): DesignerNodeData {
+  const name = NODE_META[type].label;
+  if (type === 'approval') {
+    return {
+      name,
+      label: name,
+      config: { assigneeStrategy: 'static', assignees: [], approvalType: 'single' },
+    };
+  }
+  if (type === 'condition') {
+    return {
+      name,
+      label: name,
+      config: {
+        branches: [
+          { id: 'branch_1', label: '条件1', expression: '', is_default: false },
+          { id: 'branch_2', label: '默认', expression: '', is_default: true },
+        ],
+      },
+    };
+  }
+  if (type === 'parallel') {
+    return { name, label: name, config: { branchCount: 2, branchLabels: ['分支1', '分支2'] } };
+  }
+  if (type === 'merge') {
+    return { name, label: name, config: { kind: 'join', branchCount: 2, branchLabels: [] } };
+  }
+  if (type === 'timer') {
+    return { name, label: name, config: { duration: 1, unit: 'hours' } };
+  }
+  if (type === 'notify') {
+    return { name, label: name, config: { notificationType: 'default', channels: ['in_app'] } };
+  }
+  return { name, label: name, config: {} };
+}
+
+export function toFlowGraph(nodes: DesignerRFNode[], edges: DesignerRFEdge[]): FlowGraphData {
+  return {
+    nodes: nodes.map((node) => ({
+      id: node.id,
+      type: (node.type ?? 'approval') as DesignerNodeType,
+      position: { x: node.position.x, y: node.position.y },
+      data: node.data,
+    })),
+    edges: edges.map((edge) => ({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      sourceHandle: edge.sourceHandle ?? undefined,
+      label: typeof edge.label === 'string' ? edge.label : undefined,
+      data: edge.data,
+    })),
+  };
+}
+
+export function fromFlowGraph(graph: FlowGraphData): {
+  nodes: DesignerRFNode[];
+  edges: DesignerRFEdge[];
+} {
+  return {
+    nodes: graph.nodes.map((node) => ({
+      id: node.id,
+      type: node.type,
+      position: node.position,
+      data: node.data,
+    })),
+    edges: graph.edges.map((edge) => ({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      sourceHandle: edge.sourceHandle,
+      label: edge.label,
+      data: edge.data,
+    })),
+  };
+}
+
+export function createNodeId(type: DesignerNodeType): string {
+  return `${type}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+}

--- a/frontend/src/pages/workflow/designer/utils/flowConvert.ts
+++ b/frontend/src/pages/workflow/designer/utils/flowConvert.ts
@@ -85,3 +85,18 @@ export function fromFlowGraph(graph: FlowGraphData): {
 export function createNodeId(type: DesignerNodeType): string {
   return `${type}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
 }
+
+export function appendNode(
+  current: DesignerRFNode[],
+  node: DesignerRFNode,
+): DesignerRFNode[] {
+  let { x, y } = node.position;
+  const overlaps = current.some(
+    (item) => Math.abs(item.position.x - x) < 16 && Math.abs(item.position.y - y) < 16,
+  );
+  if (overlaps) {
+    x += 48 * current.length;
+    y += 36 * current.length;
+  }
+  return [...current, { ...node, position: { x, y } }];
+}

--- a/frontend/src/pages/workflow/designer/utils/graphIO.ts
+++ b/frontend/src/pages/workflow/designer/utils/graphIO.ts
@@ -1,0 +1,28 @@
+import type { FlowGraphData } from '@/types/workflow';
+import { validateDraftGraph } from './graphValidate';
+
+export function parseImportedGraph(raw: string): FlowGraphData {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('导入文件不是有效的 JSON 对象');
+  }
+  const graph = parsed as FlowGraphData;
+  const issues = validateDraftGraph(graph);
+  if (issues.length > 0) {
+    throw new Error(issues[0].message);
+  }
+  if (graph.nodes.some((node) => !node.id || !node.type || !node.position || !node.data)) {
+    throw new Error('导入文件缺少节点必要字段');
+  }
+  return graph;
+}
+
+export function downloadGraphJson(graph: FlowGraphData, filename: string): void {
+  const blob = new Blob([JSON.stringify(graph, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/workflow/designer/utils/graphMapper.ts
+++ b/frontend/src/pages/workflow/designer/utils/graphMapper.ts
@@ -1,0 +1,104 @@
+import type {
+  DesignerNodeType,
+  FlowGraphData,
+  FlowNode,
+  ParallelConfig,
+  PublishGraphData,
+} from '@/types/workflow';
+
+const TO_BACKEND: Record<DesignerNodeType, string> = {
+  start: 'start',
+  end: 'end',
+  approval: 'approval',
+  condition: 'exclusive_gateway',
+  parallel: 'parallel_gateway',
+  merge: 'parallel_gateway',
+  timer: 'timer',
+  notify: 'notification_task',
+};
+
+const FROM_BACKEND: Record<string, DesignerNodeType> = {
+  start: 'start',
+  end: 'end',
+  approval: 'approval',
+  exclusive_gateway: 'condition',
+  notification_task: 'notify',
+  timer: 'timer',
+  notify: 'notify',
+  condition: 'condition',
+  parallel: 'parallel',
+  merge: 'merge',
+};
+
+function isDesignerType(value: string): value is DesignerNodeType {
+  return value in TO_BACKEND;
+}
+
+function mapPublishNode(node: FlowNode): PublishGraphData['nodes'][number] {
+  const config =
+    node.type === 'merge'
+      ? { ...(node.data.config as ParallelConfig), kind: 'join' as const }
+      : node.data.config;
+  return {
+    id: node.id,
+    type: TO_BACKEND[node.type],
+    position: node.position,
+    data: {
+      ...node.data,
+      label: node.data.name,
+      config,
+    },
+  };
+}
+
+/** 发布前：短名 → 后端引擎类型 */
+export function toPublishGraph(graph: FlowGraphData): PublishGraphData {
+  return {
+    nodes: graph.nodes.map(mapPublishNode),
+    edges: graph.edges,
+  };
+}
+
+function mapLoadedNode(node: FlowNode | PublishGraphData['nodes'][number]): FlowNode {
+  let type: DesignerNodeType = isDesignerType(node.type) ? node.type : 'approval';
+  if (node.type === 'exclusive_gateway') {
+    type = 'condition';
+  } else if (node.type === 'notification_task') {
+    type = 'notify';
+  } else if (node.type === 'parallel_gateway') {
+    const kind = (node.data.config as ParallelConfig | undefined)?.kind;
+    type = kind === 'join' ? 'merge' : 'parallel';
+  } else if (FROM_BACKEND[node.type]) {
+    type = FROM_BACKEND[node.type];
+  }
+  const name = node.data.name || node.data.label || NODE_FALLBACK[type];
+  return {
+    ...node,
+    type,
+    data: {
+      ...node.data,
+      name,
+      label: name,
+      config: node.data.config ?? {},
+    },
+  };
+}
+
+const NODE_FALLBACK: Record<DesignerNodeType, string> = {
+  start: '开始',
+  end: '结束',
+  approval: '审批',
+  condition: '条件',
+  parallel: '并行',
+  merge: '合并',
+  timer: '定时器',
+  notify: '通知',
+};
+
+/** 加载已发布版本：后端类型 → 短名 */
+export function fromBackendGraph(graph: FlowGraphData | PublishGraphData): FlowGraphData {
+  return {
+    nodes: graph.nodes.map(mapLoadedNode),
+    edges: graph.edges,
+  };
+}

--- a/frontend/src/pages/workflow/designer/utils/graphValidate.ts
+++ b/frontend/src/pages/workflow/designer/utils/graphValidate.ts
@@ -1,0 +1,123 @@
+import type {
+  ApprovalConfig,
+  ConditionConfig,
+  FlowGraphData,
+  ValidationIssue,
+} from '@/types/workflow';
+
+function outgoing(graph: FlowGraphData, nodeId: string) {
+  return graph.edges.filter((e) => e.source === nodeId);
+}
+
+function reachableFromStart(graph: FlowGraphData, startId: string): Set<string> {
+  const seen = new Set<string>();
+  const queue = [startId];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || seen.has(current)) continue;
+    seen.add(current);
+    outgoing(graph, current).forEach((edge) => queue.push(edge.target));
+  }
+  return seen;
+}
+
+function validateApproval(graph: FlowGraphData, issues: ValidationIssue[]): void {
+  graph.nodes
+    .filter((node) => node.type === 'approval')
+    .forEach((node) => {
+      const config = node.data.config as ApprovalConfig;
+      const strategy = config?.assigneeStrategy;
+      if (!strategy) {
+        issues.push({ level: 'error', message: `审批节点「${node.data.name}」未配置审批人类型` });
+        return;
+      }
+      if (strategy === 'static' && (!config.assignees || config.assignees.length === 0)) {
+        issues.push({ level: 'error', message: `审批节点「${node.data.name}」未选择审批人` });
+      }
+      if (strategy === 'role' && !config.roleId) {
+        issues.push({ level: 'error', message: `审批节点「${node.data.name}」未选择角色` });
+      }
+    });
+}
+
+function validateConditions(graph: FlowGraphData, issues: ValidationIssue[]): void {
+  graph.nodes
+    .filter((node) => node.type === 'condition')
+    .forEach((node) => {
+      const config = node.data.config as ConditionConfig;
+      const edges = outgoing(graph, node.id);
+      if (edges.length < 2) {
+        issues.push({ level: 'error', message: `条件节点「${node.data.name}」至少需要两条出线` });
+      }
+      edges.forEach((edge) => {
+        const branch = config?.branches?.find((item) => item.id === edge.sourceHandle);
+        const expression = branch?.expression || edge.data?.condition || '';
+        if (!expression && !branch?.is_default) {
+          issues.push({
+            level: 'error',
+            message: `条件节点「${node.data.name}」的连线缺少条件表达式`,
+          });
+        }
+      });
+    });
+}
+
+/** 草稿：只检查 JSON 结构 */
+export function validateDraftGraph(graph: FlowGraphData): ValidationIssue[] {
+  if (!graph || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+    return [{ level: 'error', message: '流程图数据格式无效' }];
+  }
+  return [];
+}
+
+/** 发布：完整合法性校验（含 timer 拦截） */
+export function validatePublishGraph(graph: FlowGraphData): ValidationIssue[] {
+  const issues = validateDraftGraph(graph);
+  if (issues.length > 0) return issues;
+
+  const starts = graph.nodes.filter((n) => n.type === 'start');
+  const ends = graph.nodes.filter((n) => n.type === 'end');
+  if (starts.length !== 1) {
+    issues.push({ level: 'error', message: '必须有且仅有一个开始节点' });
+  }
+  if (ends.length < 1) {
+    issues.push({ level: 'error', message: '至少需要一个结束节点' });
+  }
+
+  const timers = graph.nodes.filter((n) => n.type === 'timer');
+  if (timers.length > 0) {
+    issues.push({
+      level: 'error',
+      message: '定时器节点一期后端未实现，请删除后再发布',
+    });
+  }
+
+  if (starts.length === 1) {
+    const reachable = reachableFromStart(graph, starts[0].id);
+    graph.nodes.forEach((node) => {
+      if (!reachable.has(node.id)) {
+        issues.push({ level: 'error', message: `节点「${node.data.name}」从开始节点不可达` });
+      }
+    });
+  }
+
+  validateApproval(graph, issues);
+  validateConditions(graph, issues);
+
+  const parallels = graph.nodes.filter((n) => n.type === 'parallel');
+  const merges = graph.nodes.filter((n) => n.type === 'merge');
+  if (parallels.length > 0 && merges.length === 0) {
+    issues.push({ level: 'error', message: '并行分支必须有对应的合并节点' });
+  }
+  if (starts.length === 1 && parallels.length > 0) {
+    parallels.forEach((node) => {
+      const reachable = reachableFromStart(graph, node.id);
+      const hasMerge = graph.nodes.some((item) => item.type === 'merge' && reachable.has(item.id));
+      if (!hasMerge) {
+        issues.push({ level: 'error', message: `并行节点「${node.data.name}」缺少对应的合并节点` });
+      }
+    });
+  }
+
+  return issues;
+}

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -16,6 +16,7 @@ const UserList = lazy(() => import('@/pages/user/UserList'));
 const NotificationList = lazy(() => import('@/pages/notification/NotificationList'));
 const TemplateList = lazy(() => import('@/pages/notification/TemplateList'));
 const AuditList = lazy(() => import('@/pages/system/audit/AuditList'));
+const WorkflowDesigner = lazy(() => import('@/pages/workflow/designer/DesignerPage'));
 const Forbidden = lazy(() => import('@/pages/error/Forbidden'));
 
 // 懒加载 fallback
@@ -181,8 +182,13 @@ const routes: AppRouteObject[] = [
         children: [
           {
             path: 'designer',
-            element: <div style={{ padding: 24 }}>流程设计器（开发中）</div>,
+            element: lazyWrap(WorkflowDesigner),
             meta: { title: '流程设计' },
+          },
+          {
+            path: 'designer/:id',
+            element: lazyWrap(WorkflowDesigner),
+            meta: { title: '流程设计', hidden: true },
           },
           {
             path: 'instances',

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -3,6 +3,7 @@ import authReducer from './slices/authSlice';
 import userReducer from './slices/userSlice';
 import appReducer from './slices/appSlice';
 import notificationReducer from './slices/notificationSlice';
+import workflowReducer from './slices/workflowSlice';
 
 export const store = configureStore({
   reducer: {
@@ -10,6 +11,7 @@ export const store = configureStore({
     user: userReducer,
     app: appReducer,
     notification: notificationReducer,
+    workflow: workflowReducer,
   },
   devTools: process.env.NODE_ENV !== 'production',
 });

--- a/frontend/src/store/slices/workflowSlice.ts
+++ b/frontend/src/store/slices/workflowSlice.ts
@@ -1,0 +1,72 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '@/store';
+
+interface WorkflowDesignerState {
+  selectedNodeId: string | null;
+  previewMode: boolean;
+  definitionId: string | null;
+  definitionName: string;
+  definitionKey: string;
+  definitionStatus: number;
+  dirty: boolean;
+}
+
+const initialState: WorkflowDesignerState = {
+  selectedNodeId: null,
+  previewMode: false,
+  definitionId: null,
+  definitionName: '',
+  definitionKey: '',
+  definitionStatus: 0,
+  dirty: false,
+};
+
+const workflowSlice = createSlice({
+  name: 'workflow',
+  initialState,
+  reducers: {
+    setSelectedNodeId(state, action: PayloadAction<string | null>) {
+      state.selectedNodeId = action.payload;
+    },
+    setPreviewMode(state, action: PayloadAction<boolean>) {
+      state.previewMode = action.payload;
+    },
+    setDefinitionMeta(
+      state,
+      action: PayloadAction<{
+        id: string | null;
+        name: string;
+        key: string;
+        status: number;
+      }>,
+    ) {
+      state.definitionId = action.payload.id;
+      state.definitionName = action.payload.name;
+      state.definitionKey = action.payload.key;
+      state.definitionStatus = action.payload.status;
+    },
+    setDirty(state, action: PayloadAction<boolean>) {
+      state.dirty = action.payload;
+    },
+    resetDesigner() {
+      return initialState;
+    },
+  },
+});
+
+export const {
+  setSelectedNodeId,
+  setPreviewMode,
+  setDefinitionMeta,
+  setDirty,
+  resetDesigner,
+} = workflowSlice.actions;
+
+export const selectSelectedNodeId = (state: RootState) => state.workflow.selectedNodeId;
+export const selectPreviewMode = (state: RootState) => state.workflow.previewMode;
+export const selectDefinitionId = (state: RootState) => state.workflow.definitionId;
+export const selectDefinitionName = (state: RootState) => state.workflow.definitionName;
+export const selectDefinitionKey = (state: RootState) => state.workflow.definitionKey;
+export const selectDesignerDirty = (state: RootState) => state.workflow.dirty;
+
+export default workflowSlice.reducer;

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,0 +1,140 @@
+/** 设计器 8 种节点（短名） */
+export type DesignerNodeType =
+  | 'start'
+  | 'end'
+  | 'approval'
+  | 'condition'
+  | 'parallel'
+  | 'merge'
+  | 'timer'
+  | 'notify';
+
+export type AssigneeStrategy = 'static' | 'role' | 'dept_leader' | 'initiator';
+export type ApprovalType = 'single' | 'all' | 'any' | 'ratio';
+export type TimerUnit = 'minutes' | 'hours' | 'days';
+export type NotifyChannel = 'in_app' | 'email';
+export type ConditionOperator = '==' | '!=' | '>' | '<' | '>=' | '<=';
+
+export interface ApprovalConfig {
+  assigneeStrategy: AssigneeStrategy;
+  assignees?: string[];
+  roleId?: string;
+  approvalType?: ApprovalType;
+  passRatio?: number;
+}
+
+export interface ConditionBranch {
+  id: string;
+  label: string;
+  expression: string;
+  is_default: boolean;
+}
+
+export interface ConditionConfig {
+  branches: ConditionBranch[];
+}
+
+export interface ParallelConfig {
+  branchCount: number;
+  branchLabels: string[];
+  kind?: 'fork' | 'join';
+}
+
+export interface TimerConfig {
+  duration: number;
+  unit: TimerUnit;
+}
+
+export interface NotifyConfig {
+  notificationType: string;
+  channels: NotifyChannel[];
+}
+
+export type NodeConfig =
+  | ApprovalConfig
+  | ConditionConfig
+  | ParallelConfig
+  | TimerConfig
+  | NotifyConfig
+  | Record<string, never>;
+
+export interface DesignerNodeData {
+  name: string;
+  label: string;
+  description?: string;
+  config: NodeConfig;
+}
+
+export interface FlowGraphPosition {
+  x: number;
+  y: number;
+}
+
+export interface FlowNode {
+  id: string;
+  type: DesignerNodeType;
+  position: FlowGraphPosition;
+  data: DesignerNodeData;
+}
+
+export interface FlowEdge {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle?: string;
+  label?: string;
+  data?: { condition?: string };
+}
+
+export interface FlowGraphData {
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+}
+
+/** 发布给后端的图（节点 type 可能已映射） */
+export interface PublishGraphData {
+  nodes: Array<{
+    id: string;
+    type: string;
+    position: FlowGraphPosition;
+    data: DesignerNodeData;
+  }>;
+  edges: FlowEdge[];
+}
+
+export interface FlowDefinitionDTO {
+  id: string;
+  key: string;
+  name: string;
+  description: string;
+  category: string;
+  status: 0 | 1 | 2;
+  draft_graph?: FlowGraphData | null;
+  created_by?: string | null;
+  updated_by?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface FlowVersionDTO {
+  id: string;
+  definition_id: string;
+  version: number;
+  bpmn_data: FlowGraphData;
+  status: number;
+  published_by?: string | null;
+  published_at?: string | null;
+  created_at: string;
+}
+
+export interface CreateDefinitionPayload {
+  key: string;
+  name: string;
+  description?: string;
+  category?: string;
+}
+
+export interface ValidationIssue {
+  level: 'error' | 'warning';
+  message: string;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 Issue #3 前端流程设计器，并补齐服务端草稿图存储（对齐结论 B1）。

设计器支持 8 种节点（start/end/approval/condition/parallel/merge/timer/notify），左侧拖拽或点击添加、画布连线、右侧属性面板、工具栏（保存草稿/发布/只读预览/导入导出/撤销重做）。发布时将短名映射为后端引擎类型；`timer` 可配置但发布会被拦截。

## 关联 Issue

Closes #3

## 测试方式

1. 运行迁移 `000007_workflow_draft_graph`
2. 登录后打开「流程管理 → 流程设计」
3. 点击或拖入开始/审批/结束并连线，配置审批人后保存草稿、发布
4. 带 timer 节点时发布应失败；导入/导出 JSON、撤销/重做、预览只读

后端单测：`go test ./internal/workflow/...` 已通过。  
前端：`npm run lint` 无新增 error，`npx tsc --noEmit` 通过。  
CI：`22ad337` 上 4 项检查全绿（中间一次 Docker 失败是 Docker Hub 拉 `node:20-alpine` 断连，已重跑通过）。

浏览器：本环境无 PostgreSQL/后端，无法走登录后的保存/发布。已验证设计器壳层（三栏布局、节点面板、属性面板、预览按钮、发布弹窗）。自动化拖拽不稳定，因此增加了**点击节点面板即可落点**。

## 截图 / GIF

| 页面/功能 | 截图 |
|----------|------|
| 设计器布局 | [流程设计器三栏布局](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesigner_layout.webp) |
| 预览模式 | [只读预览](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesigner_preview_mode.webp) |
| 首次保存创建定义 | [创建流程定义弹窗](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesigner_create_modal.webp) |

## 注意事项

- 认领评论中的分支名是 `feature/3-workflow-designer`，本 PR 使用云端规范分支 `cursor/3-workflow-designer-2c5c`
- `PUT /api/v1/workflow/definitions/:id/draft` 保存 `draft_graph`，已发布定义也可存下一版工作稿
- 发布 `graph_data` 边字段现包含 `sourceHandle`/`label`，条件分支才能被引擎识别
- 撤销/重做为自建历史栈（React Flow 11 无 `useHistory`）
- 条件变量为预置 + 可自定义；审批人走真实用户/角色 API

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测（后端单测 + 前端类型检查；浏览器为无后端的壳层验证）
- [ ] 已添加/更新必要的文档
- [x] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

