### PR TITLE
feat(interview): 面试场次、评分与结果同步 (#7)

### DIFF
--- a/TEAM_DEV_GUIDE.md
+++ b/TEAM_DEV_GUIDE.md
@@ -72,7 +72,7 @@ StarByte/
 │   │   ├── auth/                     # 认证（空目录，待开发）
 │   │   ├── file/                     # 文件管理（空目录，待开发）
 │   │   ├── internship/               # 实习管理（空目录，待开发）
-│   │   ├── interview/                # 面试管理（空目录，待开发）
+│   │   ├── interview/                # 面试管理（#7）
 │   │   ├── meeting/                  # 会议管理（空目录，待开发）
 │   │   ├── member/                   # 入会申请 + 人员档案（#6）
 │   │   ├── notification/             # 通知系统（空目录，待开发）
@@ -242,7 +242,7 @@ response.ErrorWithCode(c, 2002, "用户名或密码错误") // 自定义错误�
 | 4000-4999 | 流程引擎 | 4001 流程定义不存在, 4002 流程已结束 |
 | 5000-5999 | 审计日志 | 5001 审计日志不存在, 5002 导出格式不支持 |
 | 6000-6999 | 会员模块 | 6001 申请不存在, 6003 重复申请, 6004 档案不存在 |
-| 7000-7999 | 面试模块 | 7001 面试场次不存在, 7002 时间冲突 |
+| 7000-7999 | 面试模块 | 7001 场次不存在, 7002 记录不存在, 7003 时间冲突 |
 | 8000-8999 | 会议模块 | 8001 会议不存在, 8002 投票已结束 |
 | 9000-9999 | 任务模块 | 9001 任务不存在, 9002 无权操作 |
 | 10000-10999 | 实习模块 | 10001 实习不存在, 10002 无权操作 |
@@ -926,8 +926,8 @@ AI 系统提示词（见 8.2 节）已包含强制变更检查步骤。当开发
 
 | Issue | 标题 | 模块 | 依赖 | 备注 |
 |-------|------|------|------|------|
-| [#6](https://github.com/Yogdunana/StarByte/issues/6) | 入会申请 + 人员档案 | fullstack | #1, #2, #4 | 进行中（`000020` 补列；勿另起表） |
-| [#7](https://github.com/Yogdunana/StarByte/issues/7) | 面试管理 | fullstack | #1, #2, #6 | |
+| [#6](https://github.com/Yogdunana/StarByte/issues/6) | 入会申请 + 人员档案 | fullstack | #1, #2, #4 | 完成（`000020` 补列；勿另起表） |
+| [#7](https://github.com/Yogdunana/StarByte/issues/7) | 面试管理 | fullstack | #1, #2, #6 | 进行中（`000021` 补列；勿另起表） |
 | [#8](https://github.com/Yogdunana/StarByte/issues/8) | 会议管理 + 投票系统（等权 + 加权） | fullstack | #1, #4 | 含加权；#51 已并入 |
 | [#9](https://github.com/Yogdunana/StarByte/issues/9) | 任务流转 | fullstack | #1, #4 | |
 | [#10](https://github.com/Yogdunana/StarByte/issues/10) | IT 实习管理 | fullstack | #1, #4 | |

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -18,6 +18,9 @@ import (
 	fileHandler "github.com/Yogdunana/StarByte/backend/internal/file/handler"
 	fileRepo "github.com/Yogdunana/StarByte/backend/internal/file/repo"
 	fileService "github.com/Yogdunana/StarByte/backend/internal/file/service"
+	interviewHandler "github.com/Yogdunana/StarByte/backend/internal/interview/handler"
+	interviewRepo "github.com/Yogdunana/StarByte/backend/internal/interview/repo"
+	interviewService "github.com/Yogdunana/StarByte/backend/internal/interview/service"
 	memberHandler "github.com/Yogdunana/StarByte/backend/internal/member/handler"
 	memberRepo "github.com/Yogdunana/StarByte/backend/internal/member/repo"
 	memberService "github.com/Yogdunana/StarByte/backend/internal/member/service"
@@ -204,6 +207,14 @@ func main() {
 	memberSvc := memberService.NewMemberService(memberAppRepo, memberProfRepo, interviewStarter)
 	memberH := memberHandler.NewMemberHandler(memberSvc)
 
+	// 面试管理
+	ivSessionRepo := interviewRepo.NewSessionRepo(database.DB())
+	ivRecordRepo := interviewRepo.NewInterviewRepo(database.DB())
+	ivEvalRepo := interviewRepo.NewEvaluationRepo(database.DB())
+	ivNotifier := interviewService.NewNotifier(notifSvc)
+	ivSvc := interviewService.NewInterviewService(ivSessionRepo, ivRecordRepo, ivEvalRepo, ivNotifier, memberSvc)
+	ivH := interviewHandler.NewInterviewHandler(ivSvc)
+
 	// 审计日志模块
 	auditR := auditRepo.NewAuditRepo(database.DB())
 	auditSvc := auditService.NewAuditService(auditR, &cfg.MinIO)
@@ -265,6 +276,9 @@ func main() {
 
 		// 入会申请 + 人员档案（/member）
 		memberHandler.RegisterRoutes(protected, memberH, cacheService, database.DB(), deptRepo)
+
+		// 面试管理（/interviews）
+		interviewHandler.RegisterRoutes(protected, ivH, cacheService, database.DB(), deptRepo)
 
 		// 审计日志模块路由（/system/audit-logs，audit:read / audit:export / audit:archive）
 		auditHandler.RegisterRoutes(protected, auditH, cacheService)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/minio/minio-go/v7 v7.0.79
 	github.com/redis/go-redis/v9 v9.5.1
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/stretchr/testify v1.9.0
 	github.com/xuri/excelize/v2 v2.8.1
 	go.uber.org/zap v1.27.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -103,6 +103,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/backend/internal/interview/dto/evaluation.go
+++ b/backend/internal/interview/dto/evaluation.go
@@ -1,0 +1,106 @@
+package dto
+
+import "time"
+
+type EvaluationItem struct {
+	Dimension string  `json:"dimension" binding:"required,max=50"`
+	Score     float64 `json:"score"`
+	Comment   string  `json:"comment"`
+}
+
+type SubmitEvaluationsRequest struct {
+	Evaluations []EvaluationItem `json:"evaluations" binding:"required,min=1,dive"`
+}
+
+type UpdateEvaluationRequest struct {
+	Score   *float64 `json:"score"`
+	Comment *string  `json:"comment"`
+}
+
+type SubmitResultRequest struct {
+	Result  int16  `json:"result" binding:"required,oneof=1 2 3"`
+	Comment string `json:"comment"`
+}
+
+type DimensionScore struct {
+	Dimension string  `json:"dimension"`
+	Score     float64 `json:"score"`
+	Comment   string  `json:"comment,omitempty"`
+}
+
+type EvaluatorScores struct {
+	Evaluator  Person           `json:"evaluator"`
+	Scores     []DimensionScore `json:"scores"`
+	TotalScore float64          `json:"total_score"`
+}
+
+type EvaluationSummary struct {
+	InterviewID   string            `json:"interview_id"`
+	Applicant     Person            `json:"applicant"`
+	Evaluations   []EvaluatorScores `json:"evaluations"`
+	AverageScore  float64           `json:"average_score"`
+	WeightedScore float64           `json:"weighted_score"`
+}
+
+type EvaluationResponse struct {
+	ID          string    `json:"id"`
+	InterviewID string    `json:"interview_id"`
+	Evaluator   Person    `json:"evaluator"`
+	Dimension   string    `json:"dimension"`
+	Score       float64   `json:"score"`
+	Comment     string    `json:"comment"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type CreateDimensionRequest struct {
+	Name      string  `json:"name" binding:"required,max=50"`
+	Weight    float64 `json:"weight" binding:"required,gt=0"`
+	MaxScore  float64 `json:"max_score" binding:"required,gt=0"`
+	SortOrder int     `json:"sort_order"`
+}
+
+type UpdateDimensionRequest struct {
+	Name      *string  `json:"name"`
+	Weight    *float64 `json:"weight"`
+	MaxScore  *float64 `json:"max_score"`
+	SortOrder *int     `json:"sort_order"`
+}
+
+type DimensionResponse struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Weight    float64   `json:"weight"`
+	MaxScore  float64   `json:"max_score"`
+	SortOrder int       `json:"sort_order"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type StatsQuery struct {
+	StartDate    string `form:"start_date"`
+	EndDate      string `form:"end_date"`
+	DepartmentID string `form:"department_id"`
+	Round        *int16 `form:"round"`
+}
+
+type ScoreBucketVO struct {
+	Range string `json:"range"`
+	Count int64  `json:"count"`
+}
+
+type DeptStatVO struct {
+	Department string `json:"department"`
+	Count      int64  `json:"count"`
+	PassCount  int64  `json:"pass_count"`
+}
+
+type StatsResponse struct {
+	Total        int64           `json:"total"`
+	PassCount    int64           `json:"pass_count"`
+	FailCount    int64           `json:"fail_count"`
+	PendingCount int64           `json:"pending_count"`
+	PassRate     float64         `json:"pass_rate"`
+	ScoreBuckets []ScoreBucketVO `json:"score_buckets"`
+	ByDepartment []DeptStatVO    `json:"by_department"`
+}

--- a/backend/internal/interview/dto/interview.go
+++ b/backend/internal/interview/dto/interview.go
@@ -1,0 +1,58 @@
+package dto
+
+import "time"
+
+type CreateInterviewRequest struct {
+	SessionID     string     `json:"session_id" binding:"required,uuid"`
+	ApplicantID   string     `json:"applicant_id" binding:"omitempty,uuid"`
+	ApplicationID string     `json:"application_id" binding:"omitempty,uuid"`
+	ScheduledTime *time.Time `json:"scheduled_time"`
+	Location      string     `json:"location" binding:"max=200"`
+	Duration      int        `json:"duration"`
+	Notes         string     `json:"notes"`
+}
+
+type ListInterviewRequest struct {
+	Page      int    `form:"page"`
+	PageSize  int    `form:"page_size"`
+	SessionID string `form:"session_id"`
+	Status    *int16 `form:"status"`
+	Result    *int16 `form:"result"`
+	Keyword   string `form:"keyword"`
+	MyRole    string `form:"role"`
+}
+
+type AssignEvaluatorsRequest struct {
+	EvaluatorIDs []string `json:"evaluator_ids" binding:"required,min=1"`
+}
+
+type CheckinRequest struct {
+	Token string `json:"token"`
+}
+
+type Person struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type InterviewResponse struct {
+	ID              string     `json:"id"`
+	SessionID       string     `json:"session_id,omitempty"`
+	SessionTitle    string     `json:"session_title,omitempty"`
+	Applicant       Person     `json:"applicant"`
+	StudentNo       string     `json:"student_no,omitempty"`
+	ApplicationID   string     `json:"application_id,omitempty"`
+	Status          int16      `json:"status"`
+	ScheduledTime   *time.Time `json:"scheduled_time,omitempty"`
+	ActualStartTime *time.Time `json:"actual_start_time,omitempty"`
+	ActualEndTime   *time.Time `json:"actual_end_time,omitempty"`
+	Result          int16      `json:"result"`
+	ResultComment   string     `json:"result_comment,omitempty"`
+	Location        string     `json:"location,omitempty"`
+	Duration        int        `json:"duration,omitempty"`
+	Score           *float64   `json:"score,omitempty"`
+	Evaluators      []Person   `json:"evaluators"`
+	DepartmentName  string     `json:"department_name,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+}

--- a/backend/internal/interview/dto/session.go
+++ b/backend/internal/interview/dto/session.go
@@ -1,0 +1,61 @@
+package dto
+
+import "time"
+
+type CreateSessionRequest struct {
+	Title         string    `json:"title" binding:"required,max=200"`
+	Round         int       `json:"round" binding:"required,min=1,max=20"`
+	DepartmentID  string    `json:"department_id" binding:"omitempty,uuid"`
+	StartTime     time.Time `json:"start_time" binding:"required"`
+	EndTime       time.Time `json:"end_time" binding:"required"`
+	Location      string    `json:"location" binding:"max=200"`
+	OnlineLink    string    `json:"online_link" binding:"max=500"`
+	MaxCandidates int       `json:"max_candidates" binding:"required,min=1,max=500"`
+	Description   string    `json:"description"`
+}
+
+type UpdateSessionRequest struct {
+	Title         *string    `json:"title"`
+	Round         *int       `json:"round"`
+	DepartmentID  *string    `json:"department_id"`
+	StartTime     *time.Time `json:"start_time"`
+	EndTime       *time.Time `json:"end_time"`
+	Location      *string    `json:"location"`
+	OnlineLink    *string    `json:"online_link"`
+	MaxCandidates *int       `json:"max_candidates"`
+	Description   *string    `json:"description"`
+}
+
+type ListSessionRequest struct {
+	Page         int    `form:"page"`
+	PageSize     int    `form:"page_size"`
+	Status       *int16 `form:"status"`
+	DepartmentID string `form:"department_id"`
+	Round        *int16 `form:"round"`
+	Keyword      string `form:"keyword"`
+}
+
+type SessionResponse struct {
+	ID             string    `json:"id"`
+	Title          string    `json:"title"`
+	Round          int16     `json:"round"`
+	DepartmentID   string    `json:"department_id,omitempty"`
+	DepartmentName string    `json:"department_name,omitempty"`
+	StartTime      time.Time `json:"start_time"`
+	EndTime        time.Time `json:"end_time"`
+	Location       string    `json:"location"`
+	OnlineLink     string    `json:"online_link,omitempty"`
+	Status         int16     `json:"status"`
+	MaxCandidates  int       `json:"max_candidates"`
+	Description    string    `json:"description"`
+	CandidateCount int64     `json:"candidate_count"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type QRCodeResponse struct {
+	SessionID   string `json:"session_id"`
+	Token       string `json:"token"`
+	CheckinPath string `json:"checkin_path"`
+	PNGBase64   string `json:"png_base64"`
+}

--- a/backend/internal/interview/handler/evaluation_handler.go
+++ b/backend/internal/interview/handler/evaluation_handler.go
@@ -1,0 +1,220 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// SubmitEvaluations 提交评分
+// @Summary 提交评分
+// @Tags 面试
+// @Accept json
+// @Produce json
+// @Param id path string true "面试ID"
+// @Param request body dto.SubmitEvaluationsRequest true "评分"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id}/evaluations [post]
+func (h *InterviewHandler) SubmitEvaluations(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.SubmitEvaluationsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.SubmitEvaluations(c.Request.Context(), userID, id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// GetEvaluations 查看评分汇总
+// @Summary 查看评分
+// @Tags 面试
+// @Param id path string true "面试ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id}/evaluations [get]
+func (h *InterviewHandler) GetEvaluations(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.GetEvaluations(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateEvaluation 更新评分
+// @Summary 更新评分
+// @Tags 面试
+// @Param id path string true "面试ID"
+// @Param eid path string true "评分ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id}/evaluations/{eid} [put]
+func (h *InterviewHandler) UpdateEvaluation(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	eid, err := parseNamedID(c, "eid")
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.UpdateEvaluationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.UpdateEvaluation(c.Request.Context(), userID, id, eid, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// SubmitResult 提交面试结果
+// @Summary 提交面试结果
+// @Tags 面试
+// @Param id path string true "面试ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id}/result [post]
+func (h *InterviewHandler) SubmitResult(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.SubmitResultRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.SubmitResult(c.Request.Context(), userID, id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// ListDimensions 维度列表
+// @Summary 评分维度列表
+// @Tags 面试
+// @Success 200 {object} response.Response
+// @Router /interviews/dimensions [get]
+func (h *InterviewHandler) ListDimensions(c *gin.Context) {
+	out, err := h.svc.ListDimensions(c.Request.Context())
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// CreateDimension 创建维度
+// @Summary 创建评分维度
+// @Tags 面试
+// @Success 200 {object} response.Response
+// @Router /interviews/dimensions [post]
+func (h *InterviewHandler) CreateDimension(c *gin.Context) {
+	var req dto.CreateDimensionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.CreateDimension(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateDimension 更新维度
+// @Summary 更新评分维度
+// @Tags 面试
+// @Success 200 {object} response.Response
+// @Router /interviews/dimensions/{id} [put]
+func (h *InterviewHandler) UpdateDimension(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.UpdateDimensionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.UpdateDimension(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// DeleteDimension 删除维度
+// @Summary 删除评分维度
+// @Tags 面试
+// @Success 200 {object} response.Response
+// @Router /interviews/dimensions/{id} [delete]
+func (h *InterviewHandler) DeleteDimension(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if err := h.svc.DeleteDimension(c.Request.Context(), id); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+// Stats 面试统计
+// @Summary 面试统计
+// @Tags 面试
+// @Success 200 {object} response.Response
+// @Router /interviews/stats [get]
+func (h *InterviewHandler) Stats(c *gin.Context) {
+	var q dto.StatsQuery
+	if err := c.ShouldBindQuery(&q); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Stats(c.Request.Context(), &q)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}

--- a/backend/internal/interview/handler/handler_test.go
+++ b/backend/internal/interview/handler/handler_test.go
@@ -1,0 +1,235 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSvc struct{ mock.Mock }
+
+func (m *mockSvc) CreateSession(ctx context.Context, operator uuid.UUID, req *dto.CreateSessionRequest) (*dto.SessionResponse, error) {
+	args := m.Called(ctx, operator, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.SessionResponse), args.Error(1)
+}
+func (m *mockSvc) ListSessions(ctx context.Context, viewer uuid.UUID, req *dto.ListSessionRequest, scope *rbacModel.DataScopeCondition) ([]*dto.SessionResponse, int64, error) {
+	args := m.Called(ctx, viewer, req, scope)
+	return args.Get(0).([]*dto.SessionResponse), args.Get(1).(int64), args.Error(2)
+}
+func (m *mockSvc) GetSession(ctx context.Context, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.SessionResponse, error) {
+	args := m.Called(ctx, id, scope)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.SessionResponse), args.Error(1)
+}
+func (m *mockSvc) UpdateSession(ctx context.Context, id uuid.UUID, req *dto.UpdateSessionRequest) (*dto.SessionResponse, error) {
+	args := m.Called(ctx, id, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.SessionResponse), args.Error(1)
+}
+func (m *mockSvc) DeleteSession(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+func (m *mockSvc) StartSession(ctx context.Context, id uuid.UUID) (*dto.SessionResponse, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.SessionResponse), args.Error(1)
+}
+func (m *mockSvc) EndSession(ctx context.Context, id uuid.UUID) (*dto.SessionResponse, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.SessionResponse), args.Error(1)
+}
+func (m *mockSvc) SessionQRCode(ctx context.Context, id uuid.UUID) (*dto.QRCodeResponse, []byte, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, nil, args.Error(2)
+	}
+	return args.Get(0).(*dto.QRCodeResponse), args.Get(1).([]byte), args.Error(2)
+}
+func (m *mockSvc) CreateInterview(ctx context.Context, operator uuid.UUID, req *dto.CreateInterviewRequest) (*dto.InterviewResponse, error) {
+	args := m.Called(ctx, operator, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.InterviewResponse), args.Error(1)
+}
+func (m *mockSvc) ListInterviews(ctx context.Context, viewer uuid.UUID, req *dto.ListInterviewRequest, scope *rbacModel.DataScopeCondition) ([]*dto.InterviewResponse, int64, error) {
+	args := m.Called(ctx, viewer, req, scope)
+	return args.Get(0).([]*dto.InterviewResponse), args.Get(1).(int64), args.Error(2)
+}
+func (m *mockSvc) GetInterview(ctx context.Context, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.InterviewResponse, error) {
+	args := m.Called(ctx, id, scope)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.InterviewResponse), args.Error(1)
+}
+func (m *mockSvc) AssignEvaluators(ctx context.Context, id uuid.UUID, req *dto.AssignEvaluatorsRequest) (*dto.InterviewResponse, error) {
+	args := m.Called(ctx, id, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.InterviewResponse), args.Error(1)
+}
+func (m *mockSvc) Checkin(ctx context.Context, userID, id uuid.UUID, token string) (*dto.InterviewResponse, error) {
+	args := m.Called(ctx, userID, id, token)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.InterviewResponse), args.Error(1)
+}
+func (m *mockSvc) StartInterview(ctx context.Context, operator, id uuid.UUID) (*dto.InterviewResponse, error) {
+	args := m.Called(ctx, operator, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.InterviewResponse), args.Error(1)
+}
+func (m *mockSvc) EndInterview(ctx context.Context, operator, id uuid.UUID) (*dto.InterviewResponse, error) {
+	args := m.Called(ctx, operator, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.InterviewResponse), args.Error(1)
+}
+func (m *mockSvc) MyInterviews(ctx context.Context, userID uuid.UUID, status *int16) ([]*dto.InterviewResponse, error) {
+	args := m.Called(ctx, userID, status)
+	return args.Get(0).([]*dto.InterviewResponse), args.Error(1)
+}
+func (m *mockSvc) SubmitEvaluations(ctx context.Context, evaluator, id uuid.UUID, req *dto.SubmitEvaluationsRequest) (*dto.EvaluationSummary, error) {
+	args := m.Called(ctx, evaluator, id, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.EvaluationSummary), args.Error(1)
+}
+func (m *mockSvc) GetEvaluations(ctx context.Context, id uuid.UUID) (*dto.EvaluationSummary, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.EvaluationSummary), args.Error(1)
+}
+func (m *mockSvc) UpdateEvaluation(ctx context.Context, evaluator, interviewID, eid uuid.UUID, req *dto.UpdateEvaluationRequest) (*dto.EvaluationResponse, error) {
+	args := m.Called(ctx, evaluator, interviewID, eid, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.EvaluationResponse), args.Error(1)
+}
+func (m *mockSvc) SubmitResult(ctx context.Context, operator, id uuid.UUID, req *dto.SubmitResultRequest) (*dto.InterviewResponse, error) {
+	args := m.Called(ctx, operator, id, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.InterviewResponse), args.Error(1)
+}
+func (m *mockSvc) ListDimensions(ctx context.Context) ([]dto.DimensionResponse, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]dto.DimensionResponse), args.Error(1)
+}
+func (m *mockSvc) CreateDimension(ctx context.Context, req *dto.CreateDimensionRequest) (*dto.DimensionResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.DimensionResponse), args.Error(1)
+}
+func (m *mockSvc) UpdateDimension(ctx context.Context, id uuid.UUID, req *dto.UpdateDimensionRequest) (*dto.DimensionResponse, error) {
+	args := m.Called(ctx, id, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.DimensionResponse), args.Error(1)
+}
+func (m *mockSvc) DeleteDimension(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+func (m *mockSvc) Stats(ctx context.Context, q *dto.StatsQuery) (*dto.StatsResponse, error) {
+	args := m.Called(ctx, q)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*dto.StatsResponse), args.Error(1)
+}
+
+func withUser(uid uuid.UUID) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("user_id", uid.String())
+		c.Next()
+	}
+}
+
+func TestCreateSession_Handler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &mockSvc{}
+	h := NewInterviewHandler(svc)
+	uid := uuid.New()
+	r := gin.New()
+	r.POST("/interviews/sessions", withUser(uid), h.CreateSession)
+	svc.On("CreateSession", mock.Anything, uid, mock.AnythingOfType("*dto.CreateSessionRequest")).
+		Return(&dto.SessionResponse{Title: "一面", Status: 0}, nil)
+	now := time.Now()
+	body, _ := json.Marshal(dto.CreateSessionRequest{
+		Title: "一面", Round: 1, MaxCandidates: 10, StartTime: now, EndTime: now.Add(time.Hour),
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/interviews/sessions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGetInterview_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &mockSvc{}
+	h := NewInterviewHandler(svc)
+	id := uuid.New()
+	r := gin.New()
+	r.GET("/interviews/:id", withUser(uuid.New()), h.GetInterview)
+	svc.On("GetInterview", mock.Anything, id, mock.Anything).
+		Return(nil, response.NewError(response.CodeInterviewRecordGone, "面试记录不存在"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/interviews/"+id.String(), nil))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var env response.Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, response.CodeInterviewRecordGone, env.Code)
+}
+
+func TestMyInterviews_OK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &mockSvc{}
+	h := NewInterviewHandler(svc)
+	uid := uuid.New()
+	r := gin.New()
+	r.GET("/interviews/my", withUser(uid), h.MyInterviews)
+	svc.On("MyInterviews", mock.Anything, uid, mock.Anything).Return([]*dto.InterviewResponse{}, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/interviews/my", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+}

--- a/backend/internal/interview/handler/helper.go
+++ b/backend/internal/interview/handler/helper.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func getUserID(c *gin.Context) (uuid.UUID, error) {
+	userIDStr := auth.GetUserID(c)
+	if userIDStr == "" {
+		return uuid.Nil, response.NewUnauthorizedError("用户未认证")
+	}
+	id, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的用户ID")
+	}
+	return id, nil
+}
+
+func parseID(c *gin.Context) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的ID")
+	}
+	return id, nil
+}
+
+func parseNamedID(c *gin.Context, name string) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Param(name))
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的ID")
+	}
+	return id, nil
+}
+
+func dataScope(c *gin.Context) *rbacModel.DataScopeCondition {
+	return middleware.GetDataScopeFromContext(c)
+}
+
+func defaultPage(page, pageSize int) (int, int) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	return page, pageSize
+}

--- a/backend/internal/interview/handler/interview_handler.go
+++ b/backend/internal/interview/handler/interview_handler.go
@@ -1,0 +1,211 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// CreateInterview 创建面试记录
+// @Summary 创建面试记录
+// @Tags 面试
+// @Accept json
+// @Produce json
+// @Param request body dto.CreateInterviewRequest true "面试"
+// @Success 200 {object} response.Response
+// @Router /interviews [post]
+func (h *InterviewHandler) CreateInterview(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CreateInterviewRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.CreateInterview(c.Request.Context(), userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// ListInterviews 面试列表
+// @Summary 面试列表
+// @Tags 面试
+// @Produce json
+// @Success 200 {object} response.Response
+// @Router /interviews [get]
+func (h *InterviewHandler) ListInterviews(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.ListInterviewRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	list, total, err := h.svc.ListInterviews(c.Request.Context(), userID, &req, dataScope(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	page, size := defaultPage(req.Page, req.PageSize)
+	response.Page(c, list, total, page, size)
+}
+
+// GetInterview 面试详情
+// @Summary 面试详情
+// @Tags 面试
+// @Param id path string true "面试ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id} [get]
+func (h *InterviewHandler) GetInterview(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.GetInterview(c.Request.Context(), id, dataScope(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// AssignEvaluators 分配面试官
+// @Summary 分配面试官
+// @Tags 面试
+// @Param id path string true "面试ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id}/assign [post]
+func (h *InterviewHandler) AssignEvaluators(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.AssignEvaluatorsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.AssignEvaluators(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// Checkin 签到
+// @Summary 面试签到
+// @Tags 面试
+// @Param id path string true "面试ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id}/checkin [post]
+func (h *InterviewHandler) Checkin(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CheckinRequest
+	_ = c.ShouldBindJSON(&req)
+	out, err := h.svc.Checkin(c.Request.Context(), userID, id, req.Token)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// StartInterview 开始面试
+// @Summary 开始面试
+// @Tags 面试
+// @Param id path string true "面试ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id}/start [post]
+func (h *InterviewHandler) StartInterview(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.StartInterview(c.Request.Context(), userID, id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// EndInterview 结束面试
+// @Summary 结束面试
+// @Tags 面试
+// @Param id path string true "面试ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/{id}/end [post]
+func (h *InterviewHandler) EndInterview(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.EndInterview(c.Request.Context(), userID, id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// MyInterviews 我的面试
+// @Summary 我的面试
+// @Tags 面试
+// @Produce json
+// @Success 200 {object} response.Response
+// @Router /interviews/my [get]
+func (h *InterviewHandler) MyInterviews(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var status *int16
+	var req struct {
+		Status *int16 `form:"status"`
+	}
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	status = req.Status
+	list, err := h.svc.MyInterviews(c.Request.Context(), userID, status)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, list)
+}

--- a/backend/internal/interview/handler/routes.go
+++ b/backend/internal/interview/handler/routes.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/interview/service"
+	rbacRepo "github.com/Yogdunana/StarByte/backend/internal/rbac/repo"
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type InterviewHandler struct {
+	svc service.InterviewService
+}
+
+func NewInterviewHandler(svc service.InterviewService) *InterviewHandler {
+	return &InterviewHandler{svc: svc}
+}
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
+}
+
+func withReadScope(
+	group *gin.RouterGroup,
+	cacheService rbacService.PermissionCacheService,
+	db *gorm.DB,
+	deptRepo rbacRepo.DepartmentRepo,
+) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission("interview:read"))
+	g.Use(middleware.RequireDataScope("interview"))
+	g.Use(middleware.PermissionRequired(cacheService))
+	g.Use(middleware.DataScopeMiddleware(db, deptRepo, cacheService))
+	return g
+}
+
+// RegisterRoutes 注册 /api/v1/interviews。静态路径必须在 /:id 之前。
+func RegisterRoutes(
+	r *gin.RouterGroup,
+	h *InterviewHandler,
+	cacheService rbacService.PermissionCacheService,
+	db *gorm.DB,
+	deptRepo rbacRepo.DepartmentRepo,
+) {
+	g := r.Group("/interviews")
+
+	g.GET("/my", h.MyInterviews)
+	g.POST("/:id/checkin", h.Checkin)
+
+	read := withReadScope(g, cacheService, db, deptRepo)
+	read.GET("/sessions", h.ListSessions)
+	read.GET("/sessions/:id", h.GetSession)
+	read.GET("/dimensions", h.ListDimensions)
+	read.GET("/stats", h.Stats)
+	read.GET("", h.ListInterviews)
+	read.GET("/:id", h.GetInterview)
+	read.GET("/:id/evaluations", h.GetEvaluations)
+
+	manage := withPermission(g, "interview:manage", cacheService)
+	manage.POST("/sessions", h.CreateSession)
+	manage.PUT("/sessions/:id", h.UpdateSession)
+	manage.DELETE("/sessions/:id", h.DeleteSession)
+	manage.POST("/sessions/:id/start", h.StartSession)
+	manage.POST("/sessions/:id/end", h.EndSession)
+	manage.GET("/sessions/:id/qrcode", h.SessionQRCode)
+	manage.POST("/dimensions", h.CreateDimension)
+	manage.PUT("/dimensions/:id", h.UpdateDimension)
+	manage.DELETE("/dimensions/:id", h.DeleteDimension)
+	manage.POST("", h.CreateInterview)
+	manage.POST("/:id/assign", h.AssignEvaluators)
+	manage.POST("/:id/result", h.SubmitResult)
+
+	evaluate := withPermission(g, "interview:evaluate", cacheService)
+	evaluate.POST("/:id/start", h.StartInterview)
+	evaluate.POST("/:id/end", h.EndInterview)
+	evaluate.POST("/:id/evaluations", h.SubmitEvaluations)
+	evaluate.PUT("/:id/evaluations/:eid", h.UpdateEvaluation)
+}

--- a/backend/internal/interview/handler/session_handler.go
+++ b/backend/internal/interview/handler/session_handler.go
@@ -1,0 +1,193 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// CreateSession 创建面试场次
+// @Summary 创建面试场次
+// @Tags 面试
+// @Accept json
+// @Produce json
+// @Param request body dto.CreateSessionRequest true "场次"
+// @Success 200 {object} response.Response
+// @Router /interviews/sessions [post]
+func (h *InterviewHandler) CreateSession(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CreateSessionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.CreateSession(c.Request.Context(), userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// ListSessions 场次列表
+// @Summary 场次列表
+// @Tags 面试
+// @Produce json
+// @Success 200 {object} response.Response
+// @Router /interviews/sessions [get]
+func (h *InterviewHandler) ListSessions(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.ListSessionRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	list, total, err := h.svc.ListSessions(c.Request.Context(), userID, &req, dataScope(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	page, size := defaultPage(req.Page, req.PageSize)
+	response.Page(c, list, total, page, size)
+}
+
+// GetSession 场次详情
+// @Summary 场次详情
+// @Tags 面试
+// @Produce json
+// @Param id path string true "场次ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/sessions/{id} [get]
+func (h *InterviewHandler) GetSession(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.GetSession(c.Request.Context(), id, dataScope(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateSession 更新场次
+// @Summary 更新场次
+// @Tags 面试
+// @Accept json
+// @Produce json
+// @Param id path string true "场次ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/sessions/{id} [put]
+func (h *InterviewHandler) UpdateSession(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.UpdateSessionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.UpdateSession(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// DeleteSession 删除场次
+// @Summary 删除场次
+// @Tags 面试
+// @Param id path string true "场次ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/sessions/{id} [delete]
+func (h *InterviewHandler) DeleteSession(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if err := h.svc.DeleteSession(c.Request.Context(), id); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+// StartSession 开始场次
+// @Summary 开始场次
+// @Tags 面试
+// @Param id path string true "场次ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/sessions/{id}/start [post]
+func (h *InterviewHandler) StartSession(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.StartSession(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// EndSession 结束场次
+// @Summary 结束场次
+// @Tags 面试
+// @Param id path string true "场次ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/sessions/{id}/end [post]
+func (h *InterviewHandler) EndSession(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.EndSession(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// SessionQRCode 签到二维码
+// @Summary 获取签到二维码
+// @Tags 面试
+// @Param id path string true "场次ID"
+// @Success 200 {object} response.Response
+// @Router /interviews/sessions/{id}/qrcode [get]
+func (h *InterviewHandler) SessionQRCode(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	meta, png, err := h.svc.SessionQRCode(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if c.Query("format") == "png" {
+		c.Header("Content-Type", "image/png")
+		c.Writer.WriteHeader(200)
+		_, _ = c.Writer.Write(png)
+		return
+	}
+	response.OK(c, meta)
+}

--- a/backend/internal/interview/model/const.go
+++ b/backend/internal/interview/model/const.go
@@ -1,0 +1,22 @@
+package model
+
+const (
+	SessionPending   int16 = 0
+	SessionOngoing   int16 = 1
+	SessionEnded     int16 = 2
+	SessionCancelled int16 = 3
+
+	InterviewPending   int16 = 0
+	InterviewCheckedIn int16 = 1
+	InterviewOngoing   int16 = 2
+	InterviewDone      int16 = 3
+	InterviewAbsent    int16 = 4
+	InterviewCancelled int16 = 5
+
+	ResultNone    int16 = 0
+	ResultPass    int16 = 1
+	ResultFail    int16 = 2
+	ResultPending int16 = 3
+
+	DefaultDuration = 30
+)

--- a/backend/internal/interview/model/evaluation.go
+++ b/backend/internal/interview/model/evaluation.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Evaluation 按维度评分。interviewer_id 沿用 000011。
+type Evaluation struct {
+	ID             uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	InterviewID    uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:uq_interview_eval_dim" json:"interview_id"`
+	InterviewerID  uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:uq_interview_eval_dim" json:"evaluator_id"`
+	Dimension      string    `gorm:"type:varchar(50);not null;uniqueIndex:uq_interview_eval_dim" json:"dimension"`
+	Score          float64   `gorm:"type:decimal(5,2);not null" json:"score"`
+	Comment        string    `gorm:"type:text" json:"comment"`
+	Recommendation int16     `gorm:"type:smallint;not null;default:3" json:"recommendation"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+func (Evaluation) TableName() string { return "interview_evaluations" }
+
+// EvaluationNamed 评分带面试官姓名。
+type EvaluationNamed struct {
+	Evaluation
+	EvaluatorName string `gorm:"column:evaluator_name"`
+}
+
+// Dimension 评分维度配置。
+type Dimension struct {
+	ID        uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	Name      string    `gorm:"type:varchar(50);not null;uniqueIndex" json:"name"`
+	Weight    float64   `gorm:"type:numeric(5,2);not null;default:1" json:"weight"`
+	MaxScore  float64   `gorm:"type:numeric(5,2);not null;default:100" json:"max_score"`
+	SortOrder int       `gorm:"not null;default:0" json:"sort_order"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (Dimension) TableName() string { return "interview_dimensions" }
+
+// StatsRow 统计聚合。
+type StatsRow struct {
+	Total        int64
+	PassCount    int64
+	FailCount    int64
+	PendingCount int64
+}
+
+// ScoreBucket 评分区间。
+type ScoreBucket struct {
+	Range string
+	Count int64
+}
+
+// DeptStat 部门统计。
+type DeptStat struct {
+	Department string
+	Count      int64
+	PassCount  int64
+}

--- a/backend/internal/interview/model/interview.go
+++ b/backend/internal/interview/model/interview.go
@@ -1,0 +1,59 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Interview 面试记录。scheduled_at / type / score / result 沿用 000011。
+type Interview struct {
+	ID              uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	SessionID       *uuid.UUID `gorm:"type:uuid" json:"session_id"`
+	ApplicationID   *uuid.UUID `gorm:"type:uuid" json:"application_id"`
+	ApplicantID     uuid.UUID  `gorm:"type:uuid;not null" json:"applicant_id"`
+	Round           int16      `gorm:"type:smallint;not null;default:1" json:"round"`
+	Type            int16      `gorm:"type:smallint;not null;default:1" json:"type"`
+	Status          int16      `gorm:"type:smallint;not null;default:0" json:"status"`
+	ScheduledAt     *time.Time `gorm:"column:scheduled_at" json:"scheduled_time"`
+	Location        string     `gorm:"type:varchar(200)" json:"location"`
+	Duration        int        `json:"duration"`
+	ActualStartTime *time.Time `json:"actual_start_time"`
+	ActualEndTime   *time.Time `json:"actual_end_time"`
+	Score           *float64   `json:"score"`
+	Result          string     `gorm:"type:varchar(50)" json:"result_label"`
+	ResultCode      int16      `gorm:"column:result_code;type:smallint;not null;default:0" json:"result"`
+	ResultComment   string     `gorm:"type:text;not null;default:''" json:"result_comment"`
+	Notes           string     `gorm:"type:text" json:"notes"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+}
+
+func (Interview) TableName() string { return "interviews" }
+
+// Interviewer 面试官关联。列名 interviewer_id 沿用 000011。
+type Interviewer struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	InterviewID   uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:uq_interview_interviewer" json:"interview_id"`
+	InterviewerID uuid.UUID `gorm:"type:uuid;not null;uniqueIndex:uq_interview_interviewer" json:"evaluator_id"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+func (Interviewer) TableName() string { return "interview_interviewers" }
+
+// InterviewWithNames 面试联表。
+type InterviewWithNames struct {
+	Interview
+	ApplicantName  string     `gorm:"column:applicant_name"`
+	StudentNo      string     `gorm:"column:student_no"`
+	SessionTitle   string     `gorm:"column:session_title"`
+	DepartmentID   *uuid.UUID `gorm:"column:department_id"`
+	DepartmentName string     `gorm:"column:department_name"`
+}
+
+// InterviewerNamed 面试官带姓名。
+type InterviewerNamed struct {
+	InterviewID   uuid.UUID
+	InterviewerID uuid.UUID
+	Name          string
+}

--- a/backend/internal/interview/model/session.go
+++ b/backend/internal/interview/model/session.go
@@ -1,0 +1,52 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Session 面试场次。
+type Session struct {
+	ID            uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	Title         string     `gorm:"type:varchar(200);not null" json:"title"`
+	Round         int16      `gorm:"type:smallint;not null;default:1" json:"round"`
+	DepartmentID  *uuid.UUID `gorm:"type:uuid" json:"department_id"`
+	StartTime     time.Time  `json:"start_time"`
+	EndTime       time.Time  `json:"end_time"`
+	Location      string     `gorm:"type:varchar(200);not null;default:''" json:"location"`
+	OnlineLink    string     `gorm:"type:varchar(500);not null;default:''" json:"online_link"`
+	Status        int16      `gorm:"type:smallint;not null;default:0" json:"status"`
+	MaxCandidates int        `gorm:"not null;default:20" json:"max_candidates"`
+	Description   string     `gorm:"type:text;not null;default:''" json:"description"`
+	CreatedBy     *uuid.UUID `gorm:"type:uuid" json:"created_by"`
+	QRToken       string     `gorm:"column:qr_token;type:varchar(64);not null;default:''" json:"-"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+func (Session) TableName() string { return "interview_sessions" }
+
+// SessionWithNames 场次联表。
+type SessionWithNames struct {
+	Session
+	DepartmentName string `gorm:"column:department_name"`
+	CandidateCount int64  `gorm:"column:candidate_count"`
+}
+
+// NamedUser 用户摘要。
+type NamedUser struct {
+	ID       uuid.UUID
+	RealName string
+	Username string
+}
+
+// ApplicationBrief 入会申请摘要，用于导入面试者。
+type ApplicationBrief struct {
+	ID           uuid.UUID
+	UserID       uuid.UUID
+	RealName     string
+	StudentNo    string
+	DepartmentID *uuid.UUID
+	Status       int16
+}

--- a/backend/internal/interview/repo/evaluation_repo.go
+++ b/backend/internal/interview/repo/evaluation_repo.go
@@ -1,0 +1,196 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type EvaluationRepo interface {
+	CreateBatch(ctx context.Context, rows []model.Evaluation) error
+	Update(ctx context.Context, ev *model.Evaluation) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Evaluation, error)
+	ListByInterview(ctx context.Context, interviewID uuid.UUID) ([]model.EvaluationNamed, error)
+	HasEvaluatorScores(ctx context.Context, interviewID, evaluatorID uuid.UUID) (bool, error)
+	ListDimensions(ctx context.Context) ([]model.Dimension, error)
+	GetDimensionByName(ctx context.Context, name string) (*model.Dimension, error)
+	GetDimensionByID(ctx context.Context, id uuid.UUID) (*model.Dimension, error)
+	CreateDimension(ctx context.Context, d *model.Dimension) error
+	UpdateDimension(ctx context.Context, d *model.Dimension) error
+	DeleteDimension(ctx context.Context, id uuid.UUID) error
+	Stats(ctx context.Context, q *dto.StatsQuery) (model.StatsRow, []model.ScoreBucket, []model.DeptStat, error)
+}
+
+type evaluationRepo struct{ db *gorm.DB }
+
+func NewEvaluationRepo(db *gorm.DB) EvaluationRepo {
+	return &evaluationRepo{db: db}
+}
+
+func (r *evaluationRepo) CreateBatch(ctx context.Context, rows []model.Evaluation) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).Create(&rows).Error
+}
+
+func (r *evaluationRepo) Update(ctx context.Context, ev *model.Evaluation) error {
+	return r.db.WithContext(ctx).Save(ev).Error
+}
+
+func (r *evaluationRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Evaluation, error) {
+	var ev model.Evaluation
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&ev).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
+func (r *evaluationRepo) ListByInterview(ctx context.Context, interviewID uuid.UUID) ([]model.EvaluationNamed, error) {
+	var rows []model.EvaluationNamed
+	err := r.db.WithContext(ctx).Table("interview_evaluations AS e").
+		Select("e.*, COALESCE(u.real_name, u.username, '') AS evaluator_name").
+		Joins("LEFT JOIN users u ON u.id = e.interviewer_id").
+		Where("e.interview_id = ?", interviewID).
+		Order("e.created_at ASC").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *evaluationRepo) HasEvaluatorScores(ctx context.Context, interviewID, evaluatorID uuid.UUID) (bool, error) {
+	var n int64
+	err := r.db.WithContext(ctx).Model(&model.Evaluation{}).
+		Where("interview_id = ? AND interviewer_id = ?", interviewID, evaluatorID).
+		Count(&n).Error
+	return n > 0, err
+}
+
+func (r *evaluationRepo) ListDimensions(ctx context.Context) ([]model.Dimension, error) {
+	var rows []model.Dimension
+	err := r.db.WithContext(ctx).Order("sort_order ASC, created_at ASC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *evaluationRepo) GetDimensionByName(ctx context.Context, name string) (*model.Dimension, error) {
+	var d model.Dimension
+	err := r.db.WithContext(ctx).Where("name = ?", name).First(&d).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+func (r *evaluationRepo) GetDimensionByID(ctx context.Context, id uuid.UUID) (*model.Dimension, error) {
+	var d model.Dimension
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&d).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+func (r *evaluationRepo) CreateDimension(ctx context.Context, d *model.Dimension) error {
+	return r.db.WithContext(ctx).Create(d).Error
+}
+
+func (r *evaluationRepo) UpdateDimension(ctx context.Context, d *model.Dimension) error {
+	return r.db.WithContext(ctx).Save(d).Error
+}
+
+func (r *evaluationRepo) DeleteDimension(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.Dimension{}, "id = ?", id).Error
+}
+
+func (r *evaluationRepo) Stats(ctx context.Context, q *dto.StatsQuery) (model.StatsRow, []model.ScoreBucket, []model.DeptStat, error) {
+	base := r.statsBase(ctx, q)
+	var row model.StatsRow
+	err := base.Select(`COUNT(*) AS total,
+		COUNT(*) FILTER (WHERE i.result_code = 1) AS pass_count,
+		COUNT(*) FILTER (WHERE i.result_code = 2) AS fail_count,
+		COUNT(*) FILTER (WHERE i.result_code IN (0, 3)) AS pending_count`).
+		Scan(&row).Error
+	if err != nil {
+		return row, nil, nil, err
+	}
+	buckets, err := r.scoreBuckets(ctx, q)
+	if err != nil {
+		return row, nil, nil, err
+	}
+	depts, err := r.deptStats(ctx, q)
+	return row, buckets, depts, err
+}
+
+func (r *evaluationRepo) statsBase(ctx context.Context, q *dto.StatsQuery) *gorm.DB {
+	db := r.db.WithContext(ctx).Table("interviews AS i").
+		Joins("LEFT JOIN interview_sessions s ON s.id = i.session_id").
+		Where("i.status <> ?", model.InterviewCancelled)
+	if q.DepartmentID != "" {
+		db = db.Where("s.department_id = ?", q.DepartmentID)
+	}
+	if q.Round != nil {
+		db = db.Where("s.round = ?", *q.Round)
+	}
+	if q.StartDate != "" {
+		if t, err := time.Parse("2006-01-02", q.StartDate); err == nil {
+			db = db.Where("i.created_at >= ?", t)
+		}
+	}
+	if q.EndDate != "" {
+		if t, err := time.Parse("2006-01-02", q.EndDate); err == nil {
+			db = db.Where("i.created_at < ?", t.Add(24*time.Hour))
+		}
+	}
+	return db
+}
+
+func (r *evaluationRepo) scoreBuckets(ctx context.Context, q *dto.StatsQuery) ([]model.ScoreBucket, error) {
+	type row struct {
+		Bucket string
+		Count  int64
+	}
+	var rows []row
+	err := r.statsBase(ctx, q).
+		Select(`CASE
+			WHEN i.score IS NULL THEN '未评分'
+			WHEN i.score < 60 THEN '0-59'
+			WHEN i.score < 70 THEN '60-69'
+			WHEN i.score < 80 THEN '70-79'
+			WHEN i.score < 90 THEN '80-89'
+			ELSE '90-100' END AS bucket, COUNT(*) AS count`).
+		Group("bucket").Scan(&rows).Error
+	out := []model.ScoreBucket{
+		{Range: "0-59"}, {Range: "60-69"}, {Range: "70-79"}, {Range: "80-89"}, {Range: "90-100"}, {Range: "未评分"},
+	}
+	idx := map[string]int{"0-59": 0, "60-69": 1, "70-79": 2, "80-89": 3, "90-100": 4, "未评分": 5}
+	for _, item := range rows {
+		if i, ok := idx[item.Bucket]; ok {
+			out[i].Count = item.Count
+		}
+	}
+	return out, err
+}
+
+func (r *evaluationRepo) deptStats(ctx context.Context, q *dto.StatsQuery) ([]model.DeptStat, error) {
+	var rows []model.DeptStat
+	err := r.statsBase(ctx, q).
+		Select("COALESCE(d.name, '未分配') AS department, COUNT(*) AS count, COUNT(*) FILTER (WHERE i.result_code = 1) AS pass_count").
+		Joins("LEFT JOIN departments d ON d.id = s.department_id").
+		Group("d.name").
+		Order("count DESC").
+		Scan(&rows).Error
+	return rows, err
+}

--- a/backend/internal/interview/repo/helpers.go
+++ b/backend/internal/interview/repo/helpers.go
@@ -1,0 +1,26 @@
+package repo
+
+import (
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"gorm.io/gorm"
+)
+
+func normalizePage(page, pageSize int) (int, int) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+	return page, pageSize
+}
+
+func applyScope(q *gorm.DB, scope *rbacModel.DataScopeCondition) *gorm.DB {
+	if scope == nil || scope.IsEmpty() {
+		return q
+	}
+	return q.Where(scope.Query, scope.Args...)
+}

--- a/backend/internal/interview/repo/interview_repo.go
+++ b/backend/internal/interview/repo/interview_repo.go
@@ -1,0 +1,211 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type InterviewRepo interface {
+	Create(ctx context.Context, iv *model.Interview) error
+	Update(ctx context.Context, iv *model.Interview) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Interview, error)
+	GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.InterviewWithNames, error)
+	List(ctx context.Context, req *dto.ListInterviewRequest, scope *rbacModel.DataScopeCondition) ([]model.InterviewWithNames, int64, error)
+	ListMine(ctx context.Context, userID uuid.UUID, status *int16) ([]model.InterviewWithNames, error)
+	FindBySessionApplicant(ctx context.Context, sessionID, applicantID uuid.UUID) (*model.Interview, error)
+	ReplaceInterviewers(ctx context.Context, interviewID uuid.UUID, rows []model.Interviewer) error
+	ListInterviewers(ctx context.Context, interviewIDs []uuid.UUID) ([]model.InterviewerNamed, error)
+	HasInterviewerConflict(ctx context.Context, interviewerID uuid.UUID, start, end time.Time, exclude uuid.UUID) (bool, error)
+	MarkAbsentBySession(ctx context.Context, sessionID uuid.UUID) error
+	GetUser(ctx context.Context, id uuid.UUID) (*model.NamedUser, error)
+	GetApplication(ctx context.Context, id uuid.UUID) (*model.ApplicationBrief, error)
+}
+
+type interviewRepo struct{ db *gorm.DB }
+
+func NewInterviewRepo(db *gorm.DB) InterviewRepo {
+	return &interviewRepo{db: db}
+}
+
+func (r *interviewRepo) Create(ctx context.Context, iv *model.Interview) error {
+	return r.db.WithContext(ctx).Create(iv).Error
+}
+
+func (r *interviewRepo) Update(ctx context.Context, iv *model.Interview) error {
+	return r.db.WithContext(ctx).Save(iv).Error
+}
+
+func (r *interviewRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Interview, error) {
+	var iv model.Interview
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&iv).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &iv, nil
+}
+
+func (r *interviewRepo) namedQuery(ctx context.Context) *gorm.DB {
+	return r.db.WithContext(ctx).Table("interviews AS i").
+		Select(`i.*, COALESCE(a.real_name, u.real_name, '') AS applicant_name,
+			COALESCE(a.student_no, '') AS student_no,
+			COALESCE(s.title, '') AS session_title,
+			s.department_id,
+			COALESCE(d.name, '') AS department_name`).
+		Joins("LEFT JOIN interview_sessions s ON s.id = i.session_id").
+		Joins("LEFT JOIN users u ON u.id = i.applicant_id").
+		Joins("LEFT JOIN member_applications a ON a.id = i.application_id").
+		Joins("LEFT JOIN departments d ON d.id = s.department_id")
+}
+
+func (r *interviewRepo) GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.InterviewWithNames, error) {
+	var row model.InterviewWithNames
+	err := r.namedQuery(ctx).Where("i.id = ?", id).First(&row).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *interviewRepo) List(ctx context.Context, req *dto.ListInterviewRequest, scope *rbacModel.DataScopeCondition) ([]model.InterviewWithNames, int64, error) {
+	q := r.namedQuery(ctx)
+	q = applyScope(q, scope)
+	q = filterInterviews(q, req)
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	page, size := normalizePage(req.Page, req.PageSize)
+	var rows []model.InterviewWithNames
+	err := q.Order("i.created_at DESC").Offset((page - 1) * size).Limit(size).Find(&rows).Error
+	return rows, total, err
+}
+
+func filterInterviews(q *gorm.DB, req *dto.ListInterviewRequest) *gorm.DB {
+	if req.SessionID != "" {
+		q = q.Where("i.session_id = ?", req.SessionID)
+	}
+	if req.Status != nil {
+		q = q.Where("i.status = ?", *req.Status)
+	}
+	if req.Result != nil {
+		q = q.Where("i.result_code = ?", *req.Result)
+	}
+	if req.Keyword != "" {
+		like := "%" + req.Keyword + "%"
+		q = q.Where("a.real_name ILIKE ? OR a.student_no ILIKE ? OR u.real_name ILIKE ?", like, like, like)
+	}
+	return q
+}
+
+func (r *interviewRepo) ListMine(ctx context.Context, userID uuid.UUID, status *int16) ([]model.InterviewWithNames, error) {
+	q := r.namedQuery(ctx).Where(
+		"i.applicant_id = ? OR i.id IN (SELECT interview_id FROM interview_interviewers WHERE interviewer_id = ?)",
+		userID, userID,
+	)
+	if status != nil {
+		q = q.Where("i.status = ?", *status)
+	}
+	var rows []model.InterviewWithNames
+	err := q.Order("i.scheduled_at DESC NULLS LAST, i.created_at DESC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *interviewRepo) FindBySessionApplicant(ctx context.Context, sessionID, applicantID uuid.UUID) (*model.Interview, error) {
+	var iv model.Interview
+	err := r.db.WithContext(ctx).
+		Where("session_id = ? AND applicant_id = ? AND status <> ?", sessionID, applicantID, model.InterviewCancelled).
+		First(&iv).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &iv, nil
+}
+
+func (r *interviewRepo) ReplaceInterviewers(ctx context.Context, interviewID uuid.UUID, rows []model.Interviewer) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("interview_id = ?", interviewID).Delete(&model.Interviewer{}).Error; err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		return tx.Create(&rows).Error
+	})
+}
+
+func (r *interviewRepo) ListInterviewers(ctx context.Context, interviewIDs []uuid.UUID) ([]model.InterviewerNamed, error) {
+	if len(interviewIDs) == 0 {
+		return nil, nil
+	}
+	var rows []model.InterviewerNamed
+	err := r.db.WithContext(ctx).Table("interview_interviewers AS ii").
+		Select("ii.interview_id, ii.interviewer_id, COALESCE(u.real_name, u.username, '') AS name").
+		Joins("LEFT JOIN users u ON u.id = ii.interviewer_id").
+		Where("ii.interview_id IN ?", interviewIDs).
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *interviewRepo) HasInterviewerConflict(ctx context.Context, interviewerID uuid.UUID, start, end time.Time, exclude uuid.UUID) (bool, error) {
+	var n int64
+	q := r.db.WithContext(ctx).Table("interview_interviewers AS ii").
+		Joins("JOIN interviews i ON i.id = ii.interview_id").
+		Where("ii.interviewer_id = ? AND i.status NOT IN ? AND i.scheduled_at IS NOT NULL",
+			interviewerID, []int16{model.InterviewCancelled, model.InterviewAbsent}).
+		Where("i.scheduled_at < ? AND (i.scheduled_at + (COALESCE(NULLIF(i.duration, 0), ?) || ' minutes')::interval) > ?",
+			end, model.DefaultDuration, start)
+	if exclude != uuid.Nil {
+		q = q.Where("i.id <> ?", exclude)
+	}
+	err := q.Count(&n).Error
+	return n > 0, err
+}
+
+func (r *interviewRepo) MarkAbsentBySession(ctx context.Context, sessionID uuid.UUID) error {
+	return r.db.WithContext(ctx).Model(&model.Interview{}).
+		Where("session_id = ? AND status IN ?", sessionID, []int16{model.InterviewPending, model.InterviewCheckedIn}).
+		Updates(map[string]interface{}{"status": model.InterviewAbsent}).Error
+}
+
+func (r *interviewRepo) GetUser(ctx context.Context, id uuid.UUID) (*model.NamedUser, error) {
+	var u model.NamedUser
+	err := r.db.WithContext(ctx).Table("users").
+		Select("id, COALESCE(real_name, '') AS real_name, username").
+		Where("id = ?", id).First(&u).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (r *interviewRepo) GetApplication(ctx context.Context, id uuid.UUID) (*model.ApplicationBrief, error) {
+	var a model.ApplicationBrief
+	err := r.db.WithContext(ctx).Table("member_applications").
+		Select("id, user_id, real_name, student_no, department_id, status").
+		Where("id = ?", id).First(&a).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}

--- a/backend/internal/interview/repo/session_repo.go
+++ b/backend/internal/interview/repo/session_repo.go
@@ -1,0 +1,105 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type SessionRepo interface {
+	Create(ctx context.Context, s *model.Session) error
+	Update(ctx context.Context, s *model.Session) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Session, error)
+	GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.SessionWithNames, error)
+	List(ctx context.Context, req *dto.ListSessionRequest, scope *rbacModel.DataScopeCondition) ([]model.SessionWithNames, int64, error)
+	CountCandidates(ctx context.Context, sessionID uuid.UUID) (int64, error)
+}
+
+type sessionRepo struct{ db *gorm.DB }
+
+func NewSessionRepo(db *gorm.DB) SessionRepo {
+	return &sessionRepo{db: db}
+}
+
+func (r *sessionRepo) Create(ctx context.Context, s *model.Session) error {
+	return r.db.WithContext(ctx).Create(s).Error
+}
+
+func (r *sessionRepo) Update(ctx context.Context, s *model.Session) error {
+	return r.db.WithContext(ctx).Save(s).Error
+}
+
+func (r *sessionRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.Session{}, "id = ?", id).Error
+}
+
+func (r *sessionRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Session, error) {
+	var s model.Session
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&s).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *sessionRepo) namedQuery(ctx context.Context) *gorm.DB {
+	return r.db.WithContext(ctx).Table("interview_sessions AS s").
+		Select(`s.*, COALESCE(d.name, '') AS department_name,
+			(SELECT COUNT(*) FROM interviews i WHERE i.session_id = s.id AND i.status <> ?) AS candidate_count`,
+			model.InterviewCancelled).
+		Joins("LEFT JOIN departments d ON d.id = s.department_id")
+}
+
+func (r *sessionRepo) GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.SessionWithNames, error) {
+	var row model.SessionWithNames
+	err := r.namedQuery(ctx).Where("s.id = ?", id).First(&row).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *sessionRepo) List(ctx context.Context, req *dto.ListSessionRequest, scope *rbacModel.DataScopeCondition) ([]model.SessionWithNames, int64, error) {
+	q := r.namedQuery(ctx)
+	q = applyScope(q, scope)
+	if req.Status != nil {
+		q = q.Where("s.status = ?", *req.Status)
+	}
+	if req.Round != nil {
+		q = q.Where("s.round = ?", *req.Round)
+	}
+	if req.DepartmentID != "" {
+		q = q.Where("s.department_id = ?", req.DepartmentID)
+	}
+	if req.Keyword != "" {
+		like := "%" + req.Keyword + "%"
+		q = q.Where("s.title ILIKE ? OR s.location ILIKE ?", like, like)
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	page, size := normalizePage(req.Page, req.PageSize)
+	var rows []model.SessionWithNames
+	err := q.Order("s.start_time DESC").Offset((page - 1) * size).Limit(size).Find(&rows).Error
+	return rows, total, err
+}
+
+func (r *sessionRepo) CountCandidates(ctx context.Context, sessionID uuid.UUID) (int64, error) {
+	var n int64
+	err := r.db.WithContext(ctx).Model(&model.Interview{}).
+		Where("session_id = ? AND status <> ?", sessionID, model.InterviewCancelled).
+		Count(&n).Error
+	return n, err
+}

--- a/backend/internal/interview/service/dimension.go
+++ b/backend/internal/interview/service/dimension.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *interviewService) ListDimensions(ctx context.Context) ([]dto.DimensionResponse, error) {
+	rows, err := s.evals.ListDimensions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list dimensions: %w", err)
+	}
+	out := make([]dto.DimensionResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, *mapDimension(&rows[i]))
+	}
+	return out, nil
+}
+
+func (s *interviewService) CreateDimension(ctx context.Context, req *dto.CreateDimensionRequest) (*dto.DimensionResponse, error) {
+	exist, err := s.evals.GetDimensionByName(ctx, req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("get dimension: %w", err)
+	}
+	if exist != nil {
+		return nil, response.NewError(response.CodeConflict, "维度名称已存在")
+	}
+	now := time.Now()
+	d := &model.Dimension{
+		ID: uuid.New(), Name: req.Name, Weight: req.Weight,
+		MaxScore: req.MaxScore, SortOrder: req.SortOrder,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := s.evals.CreateDimension(ctx, d); err != nil {
+		return nil, fmt.Errorf("create dimension: %w", err)
+	}
+	return mapDimension(d), nil
+}
+
+func (s *interviewService) UpdateDimension(ctx context.Context, id uuid.UUID, req *dto.UpdateDimensionRequest) (*dto.DimensionResponse, error) {
+	d, err := s.evals.GetDimensionByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get dimension: %w", err)
+	}
+	if d == nil {
+		return nil, response.NewError(response.CodeInterviewDimGone, "维度不存在")
+	}
+	if req.Name != nil {
+		d.Name = *req.Name
+	}
+	if req.Weight != nil {
+		d.Weight = *req.Weight
+	}
+	if req.MaxScore != nil {
+		d.MaxScore = *req.MaxScore
+	}
+	if req.SortOrder != nil {
+		d.SortOrder = *req.SortOrder
+	}
+	d.UpdatedAt = time.Now()
+	if err := s.evals.UpdateDimension(ctx, d); err != nil {
+		return nil, fmt.Errorf("update dimension: %w", err)
+	}
+	return mapDimension(d), nil
+}
+
+func (s *interviewService) DeleteDimension(ctx context.Context, id uuid.UUID) error {
+	d, err := s.evals.GetDimensionByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get dimension: %w", err)
+	}
+	if d == nil {
+		return response.NewError(response.CodeInterviewDimGone, "维度不存在")
+	}
+	return s.evals.DeleteDimension(ctx, id)
+}
+
+func (s *interviewService) Stats(ctx context.Context, q *dto.StatsQuery) (*dto.StatsResponse, error) {
+	if q == nil {
+		q = &dto.StatsQuery{}
+	}
+	row, buckets, depts, err := s.evals.Stats(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("stats: %w", err)
+	}
+	var rate float64
+	if row.Total > 0 {
+		rate = float64(int(float64(row.PassCount)/float64(row.Total)*1000+0.5)) / 10
+	}
+	out := &dto.StatsResponse{
+		Total: row.Total, PassCount: row.PassCount, FailCount: row.FailCount,
+		PendingCount: row.PendingCount, PassRate: rate,
+		ScoreBuckets: make([]dto.ScoreBucketVO, 0, len(buckets)),
+		ByDepartment: make([]dto.DeptStatVO, 0, len(depts)),
+	}
+	for _, b := range buckets {
+		out.ScoreBuckets = append(out.ScoreBuckets, dto.ScoreBucketVO{Range: b.Range, Count: b.Count})
+	}
+	for _, d := range depts {
+		out.ByDepartment = append(out.ByDepartment, dto.DeptStatVO{
+			Department: d.Department, Count: d.Count, PassCount: d.PassCount,
+		})
+	}
+	return out, nil
+}

--- a/backend/internal/interview/service/evaluation.go
+++ b/backend/internal/interview/service/evaluation.go
@@ -1,0 +1,195 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *interviewService) SubmitEvaluations(ctx context.Context, evaluator, id uuid.UUID, req *dto.SubmitEvaluationsRequest) (*dto.EvaluationSummary, error) {
+	iv, err := s.mustInterview(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canScore(iv.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "当前状态不允许评分")
+	}
+	if err := s.ensureAssigned(ctx, id, evaluator); err != nil {
+		return nil, err
+	}
+	dup, err := s.evals.HasEvaluatorScores(ctx, id, evaluator)
+	if err != nil {
+		return nil, fmt.Errorf("check dup eval: %w", err)
+	}
+	if dup {
+		return nil, response.NewError(response.CodeInterviewDupEval, "重复评分")
+	}
+	dims, err := s.evals.ListDimensions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list dimensions: %w", err)
+	}
+	rows, err := buildEvalRows(id, evaluator, req.Evaluations, dims)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.evals.CreateBatch(ctx, rows); err != nil {
+		return nil, fmt.Errorf("create evaluations: %w", err)
+	}
+	if err := s.persistWeightedScore(ctx, iv); err != nil {
+		return nil, err
+	}
+	return s.GetEvaluations(ctx, id)
+}
+
+func (s *interviewService) GetEvaluations(ctx context.Context, id uuid.UUID) (*dto.EvaluationSummary, error) {
+	row, err := s.records.GetByIDWithNames(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get interview: %w", err)
+	}
+	if row == nil {
+		return nil, response.NewError(response.CodeInterviewRecordGone, "面试记录不存在")
+	}
+	evals, err := s.evals.ListByInterview(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("list evaluations: %w", err)
+	}
+	dims, err := s.evals.ListDimensions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list dimensions: %w", err)
+	}
+	return summarizeEvaluations(id, dto.Person{ID: row.ApplicantID.String(), Name: row.ApplicantName}, evals, dims), nil
+}
+
+func (s *interviewService) UpdateEvaluation(ctx context.Context, evaluator, interviewID, eid uuid.UUID, req *dto.UpdateEvaluationRequest) (*dto.EvaluationResponse, error) {
+	ev, err := s.evals.GetByID(ctx, eid)
+	if err != nil {
+		return nil, fmt.Errorf("get evaluation: %w", err)
+	}
+	if ev == nil || ev.InterviewID != interviewID {
+		return nil, response.NewError(response.CodeNotFound, "评分不存在")
+	}
+	if ev.InterviewerID != evaluator {
+		return nil, response.NewError(response.CodeForbidden, "只能修改自己的评分")
+	}
+	iv, err := s.mustInterview(ctx, interviewID)
+	if err != nil {
+		return nil, err
+	}
+	if !canScore(iv.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "当前状态不允许改分")
+	}
+	if req.Score != nil {
+		dim, err := s.evals.GetDimensionByName(ctx, ev.Dimension)
+		if err != nil {
+			return nil, fmt.Errorf("get dimension: %w", err)
+		}
+		if dim != nil && (*req.Score < 0 || *req.Score > dim.MaxScore) {
+			return nil, response.NewError(response.CodeInterviewScoreRange, "评分超出范围")
+		}
+		ev.Score = *req.Score
+	}
+	if req.Comment != nil {
+		ev.Comment = *req.Comment
+	}
+	ev.UpdatedAt = time.Now()
+	if err := s.evals.Update(ctx, ev); err != nil {
+		return nil, fmt.Errorf("update evaluation: %w", err)
+	}
+	_ = s.persistWeightedScore(ctx, iv)
+	return &dto.EvaluationResponse{
+		ID: ev.ID.String(), InterviewID: ev.InterviewID.String(),
+		Evaluator: dto.Person{ID: ev.InterviewerID.String()},
+		Dimension: ev.Dimension, Score: ev.Score, Comment: ev.Comment,
+		CreatedAt: ev.CreatedAt, UpdatedAt: ev.UpdatedAt,
+	}, nil
+}
+
+func (s *interviewService) SubmitResult(ctx context.Context, operator, id uuid.UUID, req *dto.SubmitResultRequest) (*dto.InterviewResponse, error) {
+	iv, err := s.mustInterview(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canSubmitResult(iv.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "当前状态不允许提交结果")
+	}
+	if err := s.refreshScore(ctx, iv); err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	iv.ResultCode = req.Result
+	iv.ResultComment = req.Comment
+	iv.Result = resultLabel(req.Result)
+	if iv.Status == model.InterviewOngoing {
+		iv.Status = model.InterviewDone
+		iv.ActualEndTime = &now
+	}
+	iv.UpdatedAt = now
+	if err := s.records.Update(ctx, iv); err != nil {
+		return nil, fmt.Errorf("submit result: %w", err)
+	}
+	s.notifyResult(ctx, iv)
+	if iv.ApplicationID != nil && s.syncer != nil && req.Result != model.ResultPending {
+		if err := s.syncer.SyncFromInterview(ctx, operator, *iv.ApplicationID, req.Result, req.Comment); err != nil {
+			return nil, err
+		}
+	}
+	return s.GetInterview(ctx, id, nil)
+}
+
+func (s *interviewService) ensureAssigned(ctx context.Context, interviewID, evaluator uuid.UUID) error {
+	rows, err := s.records.ListInterviewers(ctx, []uuid.UUID{interviewID})
+	if err != nil {
+		return fmt.Errorf("list interviewers: %w", err)
+	}
+	if len(rows) == 0 {
+		return response.NewError(response.CodeInterviewNoEvaluator, "面试官未分配")
+	}
+	for _, r := range rows {
+		if r.InterviewerID == evaluator {
+			return nil
+		}
+	}
+	return response.NewError(response.CodeForbidden, "你不是本场面试官")
+}
+
+func buildEvalRows(interviewID, evaluator uuid.UUID, items []dto.EvaluationItem, dims []model.Dimension) ([]model.Evaluation, error) {
+	byName := map[string]model.Dimension{}
+	for _, d := range dims {
+		byName[d.Name] = d
+	}
+	now := time.Now()
+	seen := map[string]struct{}{}
+	rows := make([]model.Evaluation, 0, len(items))
+	for _, item := range items {
+		if _, dup := seen[item.Dimension]; dup {
+			return nil, response.NewError(response.CodeInterviewDupEval, "重复评分")
+		}
+		seen[item.Dimension] = struct{}{}
+		dim, ok := byName[item.Dimension]
+		if !ok {
+			return nil, response.NewError(response.CodeInterviewDimGone, "维度不存在")
+		}
+		if item.Score < 0 || item.Score > dim.MaxScore {
+			return nil, response.NewError(response.CodeInterviewScoreRange, "评分超出范围")
+		}
+		rows = append(rows, model.Evaluation{
+			ID: uuid.New(), InterviewID: interviewID, InterviewerID: evaluator,
+			Dimension: item.Dimension, Score: item.Score, Comment: item.Comment,
+			Recommendation: 3, CreatedAt: now, UpdatedAt: now,
+		})
+	}
+	return rows, nil
+}
+
+func (s *interviewService) persistWeightedScore(ctx context.Context, iv *model.Interview) error {
+	if err := s.refreshScore(ctx, iv); err != nil {
+		return err
+	}
+	iv.UpdatedAt = time.Now()
+	return s.records.Update(ctx, iv)
+}

--- a/backend/internal/interview/service/evaluation_test.go
+++ b/backend/internal/interview/service/evaluation_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func defaultDims() []model.Dimension {
+	return []model.Dimension{
+		{Name: "技术能力", Weight: 0.4, MaxScore: 100},
+		{Name: "沟通能力", Weight: 0.3, MaxScore: 100},
+	}
+}
+
+func TestSubmitEvaluations_Duplicate(t *testing.T) {
+	records := &mockInterviewRepo{}
+	evals := &mockEvalRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, evals, nil, nil)
+	id := uuid.New()
+	evalID := uuid.New()
+	records.On("GetByID", mock.Anything, id).Return(&model.Interview{ID: id, Status: model.InterviewOngoing}, nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{{InterviewID: id, InterviewerID: evalID}}, nil)
+	evals.On("HasEvaluatorScores", mock.Anything, id, evalID).Return(true, nil)
+	_, err := svc.SubmitEvaluations(context.Background(), evalID, id, &dto.SubmitEvaluationsRequest{
+		Evaluations: []dto.EvaluationItem{{Dimension: "技术能力", Score: 80}},
+	})
+	requireAppError(t, err, response.CodeInterviewDupEval)
+}
+
+func TestSubmitEvaluations_ScoreRange(t *testing.T) {
+	records := &mockInterviewRepo{}
+	evals := &mockEvalRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, evals, nil, nil)
+	id := uuid.New()
+	evalID := uuid.New()
+	records.On("GetByID", mock.Anything, id).Return(&model.Interview{ID: id, Status: model.InterviewOngoing}, nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{{InterviewID: id, InterviewerID: evalID}}, nil)
+	evals.On("HasEvaluatorScores", mock.Anything, id, evalID).Return(false, nil)
+	evals.On("ListDimensions", mock.Anything).Return(defaultDims(), nil)
+	_, err := svc.SubmitEvaluations(context.Background(), evalID, id, &dto.SubmitEvaluationsRequest{
+		Evaluations: []dto.EvaluationItem{{Dimension: "技术能力", Score: 120}},
+	})
+	requireAppError(t, err, response.CodeInterviewScoreRange)
+}
+
+func TestSubmitEvaluations_DimGone(t *testing.T) {
+	records := &mockInterviewRepo{}
+	evals := &mockEvalRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, evals, nil, nil)
+	id := uuid.New()
+	evalID := uuid.New()
+	records.On("GetByID", mock.Anything, id).Return(&model.Interview{ID: id, Status: model.InterviewOngoing}, nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{{InterviewID: id, InterviewerID: evalID}}, nil)
+	evals.On("HasEvaluatorScores", mock.Anything, id, evalID).Return(false, nil)
+	evals.On("ListDimensions", mock.Anything).Return(defaultDims(), nil)
+	_, err := svc.SubmitEvaluations(context.Background(), evalID, id, &dto.SubmitEvaluationsRequest{
+		Evaluations: []dto.EvaluationItem{{Dimension: "不存在", Score: 80}},
+	})
+	requireAppError(t, err, response.CodeInterviewDimGone)
+}
+
+func TestSubmitEvaluations_NoEvaluator(t *testing.T) {
+	records := &mockInterviewRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	records.On("GetByID", mock.Anything, id).Return(&model.Interview{ID: id, Status: model.InterviewOngoing}, nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{}, nil)
+	_, err := svc.SubmitEvaluations(context.Background(), uuid.New(), id, &dto.SubmitEvaluationsRequest{
+		Evaluations: []dto.EvaluationItem{{Dimension: "技术能力", Score: 80}},
+	})
+	requireAppError(t, err, response.CodeInterviewNoEvaluator)
+}
+
+func TestSubmitEvaluations_OK(t *testing.T) {
+	records := &mockInterviewRepo{}
+	evals := &mockEvalRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, evals, nil, nil)
+	id := uuid.New()
+	evalID := uuid.New()
+	iv := &model.Interview{ID: id, Status: model.InterviewOngoing, ApplicantID: uuid.New()}
+	records.On("GetByID", mock.Anything, id).Return(iv, nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{{InterviewID: id, InterviewerID: evalID, Name: "官"}}, nil)
+	evals.On("HasEvaluatorScores", mock.Anything, id, evalID).Return(false, nil)
+	evals.On("ListDimensions", mock.Anything).Return(defaultDims(), nil)
+	evals.On("CreateBatch", mock.Anything, mock.Anything).Return(nil)
+	evals.On("ListByInterview", mock.Anything, id).Return([]model.EvaluationNamed{
+		{Evaluation: model.Evaluation{InterviewerID: evalID, Dimension: "技术能力", Score: 80}, EvaluatorName: "官"},
+	}, nil)
+	records.On("GetByIDWithNames", mock.Anything, id).Return(namedInterview(iv, "张三"), nil)
+	records.On("Update", mock.Anything, mock.AnythingOfType("*model.Interview")).Return(nil)
+	out, err := svc.SubmitEvaluations(context.Background(), evalID, id, &dto.SubmitEvaluationsRequest{
+		Evaluations: []dto.EvaluationItem{{Dimension: "技术能力", Score: 80, Comment: "扎实"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 80.0, out.AverageScore)
+}

--- a/backend/internal/interview/service/interview.go
+++ b/backend/internal/interview/service/interview.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *interviewService) CreateInterview(ctx context.Context, operator uuid.UUID, req *dto.CreateInterviewRequest) (*dto.InterviewResponse, error) {
+	sessionID, err := uuid.Parse(req.SessionID)
+	if err != nil {
+		return nil, response.NewError(response.CodeBadRequest, "无效的场次ID")
+	}
+	sess, err := s.mustSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if !canAddCandidate(sess.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "当前场次不可添加面试者")
+	}
+	n, err := s.sessions.CountCandidates(ctx, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("count candidates: %w", err)
+	}
+	if int(n) >= sess.MaxCandidates {
+		return nil, response.NewError(response.CodeInterviewSessionFull, "超过最大候选人数")
+	}
+	applicantID, appID, err := s.resolveApplicant(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	exist, err := s.records.FindBySessionApplicant(ctx, sessionID, applicantID)
+	if err != nil {
+		return nil, fmt.Errorf("find interview: %w", err)
+	}
+	if exist != nil {
+		return nil, response.NewError(response.CodeConflict, "该面试者已在本场次中")
+	}
+	now := time.Now()
+	iv := &model.Interview{
+		ID:            uuid.New(),
+		SessionID:     &sessionID,
+		ApplicationID: appID,
+		ApplicantID:   applicantID,
+		Round:         sess.Round,
+		Type:          1,
+		Status:        model.InterviewPending,
+		ScheduledAt:   req.ScheduledTime,
+		Location:      firstNonEmpty(req.Location, sess.Location),
+		Duration:      req.Duration,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := s.records.Create(ctx, iv); err != nil {
+		return nil, fmt.Errorf("create interview: %w", err)
+	}
+	s.notifyInvite(ctx, applicantID, sess, iv)
+	_ = operator
+	return s.GetInterview(ctx, iv.ID, nil)
+}
+
+func (s *interviewService) resolveApplicant(ctx context.Context, req *dto.CreateInterviewRequest) (uuid.UUID, *uuid.UUID, error) {
+	if req.ApplicationID != "" {
+		appID, err := uuid.Parse(req.ApplicationID)
+		if err != nil {
+			return uuid.Nil, nil, response.NewError(response.CodeBadRequest, "无效的申请ID")
+		}
+		app, err := s.records.GetApplication(ctx, appID)
+		if err != nil {
+			return uuid.Nil, nil, fmt.Errorf("get application: %w", err)
+		}
+		if app == nil {
+			return uuid.Nil, nil, response.NewError(response.CodeMemberAppNotFound, "申请不存在")
+		}
+		return app.UserID, &appID, nil
+	}
+	if req.ApplicantID == "" {
+		return uuid.Nil, nil, response.NewError(response.CodeBadRequest, "请指定面试者或入会申请")
+	}
+	uid, err := uuid.Parse(req.ApplicantID)
+	if err != nil {
+		return uuid.Nil, nil, response.NewError(response.CodeBadRequest, "无效的面试者ID")
+	}
+	u, err := s.records.GetUser(ctx, uid)
+	if err != nil {
+		return uuid.Nil, nil, fmt.Errorf("get user: %w", err)
+	}
+	if u == nil {
+		return uuid.Nil, nil, response.NewError(response.CodeUserNotFound, "用户不存在")
+	}
+	return uid, nil, nil
+}
+
+func (s *interviewService) ListInterviews(ctx context.Context, viewer uuid.UUID, req *dto.ListInterviewRequest, scope *rbacModel.DataScopeCondition) ([]*dto.InterviewResponse, int64, error) {
+	rows, total, err := s.records.List(ctx, req, rewriteInterviewScope(scope, viewer))
+	if err != nil {
+		return nil, 0, fmt.Errorf("list interviews: %w", err)
+	}
+	out, err := s.attachEvaluators(ctx, rows)
+	return out, total, err
+}
+
+func (s *interviewService) GetInterview(ctx context.Context, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.InterviewResponse, error) {
+	row, err := s.records.GetByIDWithNames(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get interview: %w", err)
+	}
+	if row == nil {
+		return nil, response.NewError(response.CodeInterviewRecordGone, "面试记录不存在")
+	}
+	_ = scope
+	evals, err := s.records.ListInterviewers(ctx, []uuid.UUID{row.ID})
+	if err != nil {
+		return nil, fmt.Errorf("list interviewers: %w", err)
+	}
+	return mapInterview(row, groupEvaluators(evals)[row.ID]), nil
+}
+
+func (s *interviewService) MyInterviews(ctx context.Context, userID uuid.UUID, status *int16) ([]*dto.InterviewResponse, error) {
+	rows, err := s.records.ListMine(ctx, userID, status)
+	if err != nil {
+		return nil, fmt.Errorf("list my interviews: %w", err)
+	}
+	return s.attachEvaluators(ctx, rows)
+}
+
+func (s *interviewService) attachEvaluators(ctx context.Context, rows []model.InterviewWithNames) ([]*dto.InterviewResponse, error) {
+	ids := make([]uuid.UUID, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+	named, err := s.records.ListInterviewers(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("list interviewers: %w", err)
+	}
+	grouped := groupEvaluators(named)
+	out := make([]*dto.InterviewResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, mapInterview(&rows[i], grouped[rows[i].ID]))
+	}
+	return out, nil
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/backend/internal/interview/service/interview_test.go
+++ b/backend/internal/interview/service/interview_test.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateInterview_SessionFull(t *testing.T) {
+	sessions := &mockSessionRepo{}
+	svc := NewInterviewService(sessions, &mockInterviewRepo{}, &mockEvalRepo{}, nil, nil)
+	sid := uuid.New()
+	sessions.On("GetByID", mock.Anything, sid).Return(&model.Session{ID: sid, Status: model.SessionPending, MaxCandidates: 1}, nil)
+	sessions.On("CountCandidates", mock.Anything, sid).Return(int64(1), nil)
+	_, err := svc.CreateInterview(context.Background(), uuid.New(), &dto.CreateInterviewRequest{
+		SessionID: sid.String(), ApplicantID: uuid.New().String(),
+	})
+	requireAppError(t, err, response.CodeInterviewSessionFull)
+}
+
+func TestCreateInterview_FromApplication(t *testing.T) {
+	sessions := &mockSessionRepo{}
+	records := &mockInterviewRepo{}
+	notify := &mockNotify{}
+	svc := NewInterviewService(sessions, records, &mockEvalRepo{}, notify, nil)
+	sid := uuid.New()
+	appID := uuid.New()
+	uid := uuid.New()
+	sess := &model.Session{ID: sid, Status: model.SessionPending, MaxCandidates: 20, Round: 1, Location: "A", Title: "一面"}
+	sessions.On("GetByID", mock.Anything, sid).Return(sess, nil)
+	sessions.On("CountCandidates", mock.Anything, sid).Return(int64(0), nil)
+	records.On("GetApplication", mock.Anything, appID).Return(&model.ApplicationBrief{ID: appID, UserID: uid, RealName: "张三"}, nil)
+	records.On("FindBySessionApplicant", mock.Anything, sid, uid).Return(nil, nil)
+	records.On("Create", mock.Anything, mock.AnythingOfType("*model.Interview")).Return(nil)
+	records.On("GetUser", mock.Anything, uid).Return(&model.NamedUser{ID: uid, RealName: "张三"}, nil)
+	notify.On("Send", mock.Anything, []uuid.UUID{uid}, tplInvite, mock.Anything).Return(nil)
+	iv := &model.Interview{ID: uuid.New(), SessionID: &sid, ApplicantID: uid, Status: model.InterviewPending}
+	records.On("GetByIDWithNames", mock.Anything, mock.AnythingOfType("uuid.UUID")).Return(namedInterview(iv, "张三"), nil)
+	records.On("ListInterviewers", mock.Anything, mock.Anything).Return([]model.InterviewerNamed{}, nil)
+	out, err := svc.CreateInterview(context.Background(), uuid.New(), &dto.CreateInterviewRequest{
+		SessionID: sid.String(), ApplicationID: appID.String(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "张三", out.Applicant.Name)
+}
+
+func TestCheckin_WrongUser(t *testing.T) {
+	records := &mockInterviewRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	records.On("GetByID", mock.Anything, id).Return(&model.Interview{ID: id, ApplicantID: uuid.New(), Status: model.InterviewPending}, nil)
+	_, err := svc.Checkin(context.Background(), uuid.New(), id, "")
+	requireAppError(t, err, response.CodeForbidden)
+}
+
+func TestCheckin_OK(t *testing.T) {
+	records := &mockInterviewRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	uid := uuid.New()
+	iv := &model.Interview{ID: id, ApplicantID: uid, Status: model.InterviewPending}
+	records.On("GetByID", mock.Anything, id).Return(iv, nil)
+	records.On("Update", mock.Anything, mock.AnythingOfType("*model.Interview")).Return(nil)
+	records.On("GetByIDWithNames", mock.Anything, id).Return(namedInterview(iv, "张三"), nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{}, nil)
+	out, err := svc.Checkin(context.Background(), uid, id, "")
+	require.NoError(t, err)
+	require.Equal(t, model.InterviewCheckedIn, iv.Status)
+	require.Equal(t, "张三", out.Applicant.Name)
+}
+
+func TestAssign_TimeConflict(t *testing.T) {
+	records := &mockInterviewRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	evalID := uuid.New()
+	now := time.Now()
+	iv := &model.Interview{ID: id, Status: model.InterviewPending, ScheduledAt: &now, Duration: 30}
+	records.On("GetByID", mock.Anything, id).Return(iv, nil)
+	records.On("HasInterviewerConflict", mock.Anything, evalID, mock.Anything, mock.Anything, id).Return(true, nil)
+	_, err := svc.AssignEvaluators(context.Background(), id, &dto.AssignEvaluatorsRequest{EvaluatorIDs: []string{evalID.String()}})
+	requireAppError(t, err, response.CodeInterviewConflict)
+}
+
+func TestAssign_SendsNotification(t *testing.T) {
+	records := &mockInterviewRepo{}
+	notify := &mockNotify{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, &mockEvalRepo{}, notify, nil)
+	id := uuid.New()
+	evalID := uuid.New()
+	iv := &model.Interview{ID: id, Status: model.InterviewPending, ApplicantID: uuid.New()}
+	records.On("GetByID", mock.Anything, id).Return(iv, nil)
+	records.On("ReplaceInterviewers", mock.Anything, id, mock.Anything).Return(nil)
+	records.On("GetUser", mock.Anything, iv.ApplicantID).Return(&model.NamedUser{RealName: "张三"}, nil)
+	notify.On("Send", mock.Anything, []uuid.UUID{evalID}, tplAssigned, mock.Anything).Return(nil)
+	records.On("GetByIDWithNames", mock.Anything, id).Return(namedInterview(iv, "张三"), nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{{InterviewID: id, InterviewerID: evalID, Name: "官"}}, nil)
+	out, err := svc.AssignEvaluators(context.Background(), id, &dto.AssignEvaluatorsRequest{EvaluatorIDs: []string{evalID.String()}})
+	require.NoError(t, err)
+	require.Len(t, out.Evaluators, 1)
+}
+
+func TestSubmitResult_SyncsApplication(t *testing.T) {
+	records := &mockInterviewRepo{}
+	evals := &mockEvalRepo{}
+	notify := &mockNotify{}
+	syncer := &mockSyncer{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, evals, notify, syncer)
+	id := uuid.New()
+	appID := uuid.New()
+	op := uuid.New()
+	iv := &model.Interview{ID: id, Status: model.InterviewDone, ApplicantID: uuid.New(), ApplicationID: &appID, ResultCode: 1}
+	records.On("GetByID", mock.Anything, id).Return(iv, nil)
+	records.On("GetByIDWithNames", mock.Anything, id).Return(namedInterview(iv, "张三"), nil)
+	evals.On("ListByInterview", mock.Anything, id).Return([]model.EvaluationNamed{}, nil)
+	evals.On("ListDimensions", mock.Anything).Return([]model.Dimension{}, nil)
+	records.On("Update", mock.Anything, mock.AnythingOfType("*model.Interview")).Return(nil)
+	records.On("GetUser", mock.Anything, iv.ApplicantID).Return(&model.NamedUser{RealName: "张三"}, nil)
+	notify.On("Send", mock.Anything, mock.Anything, tplResult, mock.Anything).Return(nil)
+	syncer.On("SyncFromInterview", mock.Anything, op, appID, int16(1), "过").Return(nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{}, nil)
+	out, err := svc.SubmitResult(context.Background(), op, id, &dto.SubmitResultRequest{Result: 1, Comment: "过"})
+	require.NoError(t, err)
+	require.Equal(t, int16(1), out.Result)
+}
+
+func TestStartInterview_NoEvaluator(t *testing.T) {
+	records := &mockInterviewRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	records.On("GetByID", mock.Anything, id).Return(&model.Interview{ID: id, Status: model.InterviewCheckedIn}, nil)
+	records.On("ListInterviewers", mock.Anything, []uuid.UUID{id}).Return([]model.InterviewerNamed{}, nil)
+	_, err := svc.StartInterview(context.Background(), uuid.New(), id)
+	requireAppError(t, err, response.CodeInterviewNoEvaluator)
+}
+
+func TestGetInterview_NotFound(t *testing.T) {
+	records := &mockInterviewRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, records, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	records.On("GetByIDWithNames", mock.Anything, id).Return(nil, nil)
+	_, err := svc.GetInterview(context.Background(), id, nil)
+	requireAppError(t, err, response.CodeInterviewRecordGone)
+}
+
+func TestStats_PassRate(t *testing.T) {
+	evals := &mockEvalRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, &mockInterviewRepo{}, evals, nil, nil)
+	evals.On("Stats", mock.Anything, mock.Anything).Return(
+		model.StatsRow{Total: 4, PassCount: 2, FailCount: 1, PendingCount: 1},
+		[]model.ScoreBucket{{Range: "80-89", Count: 2}},
+		[]model.DeptStat{{Department: "技术部", Count: 4, PassCount: 2}},
+		nil,
+	)
+	out, err := svc.Stats(context.Background(), &dto.StatsQuery{})
+	require.NoError(t, err)
+	require.Equal(t, 50.0, out.PassRate)
+}
+
+func TestDeleteDimension_NotFound(t *testing.T) {
+	evals := &mockEvalRepo{}
+	svc := NewInterviewService(&mockSessionRepo{}, &mockInterviewRepo{}, evals, nil, nil)
+	id := uuid.New()
+	evals.On("GetDimensionByID", mock.Anything, id).Return(nil, nil)
+	err := svc.DeleteDimension(context.Background(), id)
+	requireAppError(t, err, response.CodeInterviewDimGone)
+}

--- a/backend/internal/interview/service/lifecycle.go
+++ b/backend/internal/interview/service/lifecycle.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *interviewService) AssignEvaluators(ctx context.Context, id uuid.UUID, req *dto.AssignEvaluatorsRequest) (*dto.InterviewResponse, error) {
+	iv, err := s.mustInterview(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if iv.Status == model.InterviewCancelled || iv.Status == model.InterviewDone {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "当前面试不可分配面试官")
+	}
+	ids, err := parseEvaluatorIDs(req.EvaluatorIDs)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.ensureNoConflicts(ctx, iv, ids); err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	rows := make([]model.Interviewer, 0, len(ids))
+	for _, uid := range ids {
+		rows = append(rows, model.Interviewer{
+			ID:            uuid.New(),
+			InterviewID:   id,
+			InterviewerID: uid,
+			CreatedAt:     now,
+		})
+	}
+	if err := s.records.ReplaceInterviewers(ctx, id, rows); err != nil {
+		return nil, fmt.Errorf("assign evaluators: %w", err)
+	}
+	s.notifyAssigned(ctx, ids, iv)
+	return s.GetInterview(ctx, id, nil)
+}
+
+func (s *interviewService) Checkin(ctx context.Context, userID, id uuid.UUID, token string) (*dto.InterviewResponse, error) {
+	iv, err := s.mustInterview(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if iv.ApplicantID != userID {
+		return nil, response.NewError(response.CodeForbidden, "仅本人可签到")
+	}
+	if !canCheckin(iv.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "当前状态不允许签到")
+	}
+	if token != "" && iv.SessionID != nil {
+		sess, err := s.mustSession(ctx, *iv.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		if sess.QRToken != token {
+			return nil, response.NewError(response.CodeBadRequest, "签到码无效")
+		}
+	}
+	iv.Status = model.InterviewCheckedIn
+	iv.UpdatedAt = time.Now()
+	if err := s.records.Update(ctx, iv); err != nil {
+		return nil, fmt.Errorf("checkin: %w", err)
+	}
+	return s.GetInterview(ctx, id, nil)
+}
+
+func (s *interviewService) StartInterview(ctx context.Context, operator, id uuid.UUID) (*dto.InterviewResponse, error) {
+	iv, err := s.mustInterview(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canStartInterview(iv.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "当前状态不允许开始面试")
+	}
+	evals, err := s.records.ListInterviewers(ctx, []uuid.UUID{id})
+	if err != nil {
+		return nil, fmt.Errorf("list interviewers: %w", err)
+	}
+	if len(evals) == 0 {
+		return nil, response.NewError(response.CodeInterviewNoEvaluator, "面试官未分配")
+	}
+	_ = operator
+	now := time.Now()
+	iv.Status = model.InterviewOngoing
+	iv.ActualStartTime = &now
+	iv.UpdatedAt = now
+	if err := s.records.Update(ctx, iv); err != nil {
+		return nil, fmt.Errorf("start interview: %w", err)
+	}
+	return s.GetInterview(ctx, id, nil)
+}
+
+func (s *interviewService) EndInterview(ctx context.Context, operator, id uuid.UUID) (*dto.InterviewResponse, error) {
+	iv, err := s.mustInterview(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canEndInterview(iv.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "当前状态不允许结束面试")
+	}
+	now := time.Now()
+	iv.Status = model.InterviewDone
+	iv.ActualEndTime = &now
+	iv.UpdatedAt = now
+	if err := s.refreshScore(ctx, iv); err != nil {
+		return nil, err
+	}
+	if err := s.records.Update(ctx, iv); err != nil {
+		return nil, fmt.Errorf("end interview: %w", err)
+	}
+	_ = operator
+	return s.GetInterview(ctx, id, nil)
+}
+
+func (s *interviewService) mustInterview(ctx context.Context, id uuid.UUID) (*model.Interview, error) {
+	iv, err := s.records.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get interview: %w", err)
+	}
+	if iv == nil {
+		return nil, response.NewError(response.CodeInterviewRecordGone, "面试记录不存在")
+	}
+	return iv, nil
+}
+
+func (s *interviewService) ensureNoConflicts(ctx context.Context, iv *model.Interview, evaluators []uuid.UUID) error {
+	if iv.ScheduledAt == nil {
+		return nil
+	}
+	dur := iv.Duration
+	if dur <= 0 {
+		dur = model.DefaultDuration
+	}
+	start := *iv.ScheduledAt
+	end := start.Add(time.Duration(dur) * time.Minute)
+	for _, uid := range evaluators {
+		hit, err := s.records.HasInterviewerConflict(ctx, uid, start, end, iv.ID)
+		if err != nil {
+			return fmt.Errorf("check conflict: %w", err)
+		}
+		if hit {
+			return response.NewError(response.CodeInterviewConflict, "面试时间冲突")
+		}
+	}
+	return nil
+}
+
+func parseEvaluatorIDs(raw []string) ([]uuid.UUID, error) {
+	seen := map[uuid.UUID]struct{}{}
+	out := make([]uuid.UUID, 0, len(raw))
+	for _, item := range raw {
+		id, err := uuid.Parse(item)
+		if err != nil {
+			return nil, response.NewError(response.CodeBadRequest, "无效的面试官ID")
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		u := id
+		out = append(out, u)
+	}
+	if len(out) == 0 {
+		return nil, response.NewError(response.CodeBadRequest, "请至少选择一位面试官")
+	}
+	return out, nil
+}
+
+func (s *interviewService) refreshScore(ctx context.Context, iv *model.Interview) error {
+	summary, err := s.GetEvaluations(ctx, iv.ID)
+	if err != nil {
+		return err
+	}
+	if len(summary.Evaluations) == 0 {
+		return nil
+	}
+	score := summary.WeightedScore
+	iv.Score = &score
+	return nil
+}

--- a/backend/internal/interview/service/mapper.go
+++ b/backend/internal/interview/service/mapper.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/google/uuid"
+)
+
+func mapSession(row *model.SessionWithNames) *dto.SessionResponse {
+	out := &dto.SessionResponse{
+		ID:             row.ID.String(),
+		Title:          row.Title,
+		Round:          row.Round,
+		DepartmentName: row.DepartmentName,
+		StartTime:      row.StartTime,
+		EndTime:        row.EndTime,
+		Location:       row.Location,
+		OnlineLink:     row.OnlineLink,
+		Status:         row.Status,
+		MaxCandidates:  row.MaxCandidates,
+		Description:    row.Description,
+		CandidateCount: row.CandidateCount,
+		CreatedAt:      row.CreatedAt,
+		UpdatedAt:      row.UpdatedAt,
+	}
+	if row.DepartmentID != nil {
+		out.DepartmentID = row.DepartmentID.String()
+	}
+	return out
+}
+
+func mapInterview(row *model.InterviewWithNames, evaluators []dto.Person) *dto.InterviewResponse {
+	if evaluators == nil {
+		evaluators = []dto.Person{}
+	}
+	out := &dto.InterviewResponse{
+		SessionTitle:    row.SessionTitle,
+		Applicant:       dto.Person{ID: row.ApplicantID.String(), Name: row.ApplicantName},
+		StudentNo:       row.StudentNo,
+		Status:          row.Status,
+		ScheduledTime:   row.ScheduledAt,
+		ActualStartTime: row.ActualStartTime,
+		ActualEndTime:   row.ActualEndTime,
+		Result:          row.ResultCode,
+		ResultComment:   row.ResultComment,
+		Location:        row.Location,
+		Duration:        row.Duration,
+		Score:           row.Score,
+		Evaluators:      evaluators,
+		DepartmentName:  row.DepartmentName,
+		CreatedAt:       row.CreatedAt,
+		UpdatedAt:       row.UpdatedAt,
+	}
+	out.ID = row.ID.String()
+	if row.SessionID != nil {
+		out.SessionID = row.SessionID.String()
+	}
+	if row.ApplicationID != nil {
+		out.ApplicationID = row.ApplicationID.String()
+	}
+	return out
+}
+
+func groupEvaluators(rows []model.InterviewerNamed) map[uuid.UUID][]dto.Person {
+	out := map[uuid.UUID][]dto.Person{}
+	for _, r := range rows {
+		out[r.InterviewID] = append(out[r.InterviewID], dto.Person{
+			ID:   r.InterviewerID.String(),
+			Name: r.Name,
+		})
+	}
+	return out
+}
+
+func mapDimension(d *model.Dimension) *dto.DimensionResponse {
+	return &dto.DimensionResponse{
+		ID:        d.ID.String(),
+		Name:      d.Name,
+		Weight:    d.Weight,
+		MaxScore:  d.MaxScore,
+		SortOrder: d.SortOrder,
+		CreatedAt: d.CreatedAt,
+		UpdatedAt: d.UpdatedAt,
+	}
+}
+
+func parseOptionalUUID(raw string) *uuid.UUID {
+	if raw == "" {
+		return nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return nil
+	}
+	return &id
+}
+
+func displayName(u *model.NamedUser) string {
+	if u == nil {
+		return ""
+	}
+	if u.RealName != "" {
+		return u.RealName
+	}
+	return u.Username
+}

--- a/backend/internal/interview/service/mock_test.go
+++ b/backend/internal/interview/service/mock_test.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockSessionRepo struct{ mock.Mock }
+
+func (m *mockSessionRepo) Create(ctx context.Context, s *model.Session) error {
+	return m.Called(ctx, s).Error(0)
+}
+func (m *mockSessionRepo) Update(ctx context.Context, s *model.Session) error {
+	return m.Called(ctx, s).Error(0)
+}
+func (m *mockSessionRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+func (m *mockSessionRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Session, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Session), args.Error(1)
+}
+func (m *mockSessionRepo) GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.SessionWithNames, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.SessionWithNames), args.Error(1)
+}
+func (m *mockSessionRepo) List(ctx context.Context, req *dto.ListSessionRequest, scope *rbacModel.DataScopeCondition) ([]model.SessionWithNames, int64, error) {
+	args := m.Called(ctx, req, scope)
+	return args.Get(0).([]model.SessionWithNames), args.Get(1).(int64), args.Error(2)
+}
+func (m *mockSessionRepo) CountCandidates(ctx context.Context, sessionID uuid.UUID) (int64, error) {
+	args := m.Called(ctx, sessionID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+type mockInterviewRepo struct{ mock.Mock }
+
+func (m *mockInterviewRepo) Create(ctx context.Context, iv *model.Interview) error {
+	return m.Called(ctx, iv).Error(0)
+}
+func (m *mockInterviewRepo) Update(ctx context.Context, iv *model.Interview) error {
+	return m.Called(ctx, iv).Error(0)
+}
+func (m *mockInterviewRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Interview, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Interview), args.Error(1)
+}
+func (m *mockInterviewRepo) GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.InterviewWithNames, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.InterviewWithNames), args.Error(1)
+}
+func (m *mockInterviewRepo) List(ctx context.Context, req *dto.ListInterviewRequest, scope *rbacModel.DataScopeCondition) ([]model.InterviewWithNames, int64, error) {
+	args := m.Called(ctx, req, scope)
+	return args.Get(0).([]model.InterviewWithNames), args.Get(1).(int64), args.Error(2)
+}
+func (m *mockInterviewRepo) ListMine(ctx context.Context, userID uuid.UUID, status *int16) ([]model.InterviewWithNames, error) {
+	args := m.Called(ctx, userID, status)
+	return args.Get(0).([]model.InterviewWithNames), args.Error(1)
+}
+func (m *mockInterviewRepo) FindBySessionApplicant(ctx context.Context, sessionID, applicantID uuid.UUID) (*model.Interview, error) {
+	args := m.Called(ctx, sessionID, applicantID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Interview), args.Error(1)
+}
+func (m *mockInterviewRepo) ReplaceInterviewers(ctx context.Context, interviewID uuid.UUID, rows []model.Interviewer) error {
+	return m.Called(ctx, interviewID, rows).Error(0)
+}
+func (m *mockInterviewRepo) ListInterviewers(ctx context.Context, interviewIDs []uuid.UUID) ([]model.InterviewerNamed, error) {
+	args := m.Called(ctx, interviewIDs)
+	return args.Get(0).([]model.InterviewerNamed), args.Error(1)
+}
+func (m *mockInterviewRepo) HasInterviewerConflict(ctx context.Context, interviewerID uuid.UUID, start, end time.Time, exclude uuid.UUID) (bool, error) {
+	args := m.Called(ctx, interviewerID, start, end, exclude)
+	return args.Bool(0), args.Error(1)
+}
+func (m *mockInterviewRepo) MarkAbsentBySession(ctx context.Context, sessionID uuid.UUID) error {
+	return m.Called(ctx, sessionID).Error(0)
+}
+func (m *mockInterviewRepo) GetUser(ctx context.Context, id uuid.UUID) (*model.NamedUser, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.NamedUser), args.Error(1)
+}
+func (m *mockInterviewRepo) GetApplication(ctx context.Context, id uuid.UUID) (*model.ApplicationBrief, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.ApplicationBrief), args.Error(1)
+}
+
+type mockEvalRepo struct{ mock.Mock }
+
+func (m *mockEvalRepo) CreateBatch(ctx context.Context, rows []model.Evaluation) error {
+	return m.Called(ctx, rows).Error(0)
+}
+func (m *mockEvalRepo) Update(ctx context.Context, ev *model.Evaluation) error {
+	return m.Called(ctx, ev).Error(0)
+}
+func (m *mockEvalRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Evaluation, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Evaluation), args.Error(1)
+}
+func (m *mockEvalRepo) ListByInterview(ctx context.Context, interviewID uuid.UUID) ([]model.EvaluationNamed, error) {
+	args := m.Called(ctx, interviewID)
+	return args.Get(0).([]model.EvaluationNamed), args.Error(1)
+}
+func (m *mockEvalRepo) HasEvaluatorScores(ctx context.Context, interviewID, evaluatorID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, interviewID, evaluatorID)
+	return args.Bool(0), args.Error(1)
+}
+func (m *mockEvalRepo) ListDimensions(ctx context.Context) ([]model.Dimension, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]model.Dimension), args.Error(1)
+}
+func (m *mockEvalRepo) GetDimensionByName(ctx context.Context, name string) (*model.Dimension, error) {
+	args := m.Called(ctx, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Dimension), args.Error(1)
+}
+func (m *mockEvalRepo) GetDimensionByID(ctx context.Context, id uuid.UUID) (*model.Dimension, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Dimension), args.Error(1)
+}
+func (m *mockEvalRepo) CreateDimension(ctx context.Context, d *model.Dimension) error {
+	return m.Called(ctx, d).Error(0)
+}
+func (m *mockEvalRepo) UpdateDimension(ctx context.Context, d *model.Dimension) error {
+	return m.Called(ctx, d).Error(0)
+}
+func (m *mockEvalRepo) DeleteDimension(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+func (m *mockEvalRepo) Stats(ctx context.Context, q *dto.StatsQuery) (model.StatsRow, []model.ScoreBucket, []model.DeptStat, error) {
+	args := m.Called(ctx, q)
+	return args.Get(0).(model.StatsRow), args.Get(1).([]model.ScoreBucket), args.Get(2).([]model.DeptStat), args.Error(3)
+}
+
+type mockNotify struct{ mock.Mock }
+
+func (m *mockNotify) Send(ctx context.Context, userIDs []uuid.UUID, template string, vars map[string]interface{}) error {
+	return m.Called(ctx, userIDs, template, vars).Error(0)
+}
+
+type mockSyncer struct{ mock.Mock }
+
+func (m *mockSyncer) SyncFromInterview(ctx context.Context, operator, applicationID uuid.UUID, result int16, comment string) error {
+	return m.Called(ctx, operator, applicationID, result, comment).Error(0)
+}
+
+func requireAppError(t mock.TestingT, err error, code int) {
+	if err == nil {
+		t.Errorf("expected error")
+		return
+	}
+	app, ok := err.(*response.AppError)
+	if !ok {
+		t.Errorf("expected AppError, got %T %v", err, err)
+		return
+	}
+	if app.Code != code {
+		t.Errorf("code %d != %d", app.Code, code)
+	}
+}
+
+func namedSession(s *model.Session) *model.SessionWithNames {
+	return &model.SessionWithNames{Session: *s}
+}
+
+func namedInterview(iv *model.Interview, name string) *model.InterviewWithNames {
+	return &model.InterviewWithNames{Interview: *iv, ApplicantName: name}
+}

--- a/backend/internal/interview/service/notify.go
+++ b/backend/internal/interview/service/notify.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	notifdto "github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	notifsvc "github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+const (
+	tplInvite   = "interview_invite"
+	tplAssigned = "interview_assigned"
+	tplResult   = "interview_result"
+)
+
+type notificationAdapter struct {
+	inner notifsvc.NotificationService
+}
+
+func NewNotifier(inner notifsvc.NotificationService) Notifier {
+	if inner == nil {
+		return nil
+	}
+	return &notificationAdapter{inner: inner}
+}
+
+func (a *notificationAdapter) Send(ctx context.Context, userIDs []uuid.UUID, template string, vars map[string]interface{}) error {
+	if len(userIDs) == 0 {
+		return nil
+	}
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      userIDs,
+		TemplateCode: template,
+		Variables:    vars,
+		Channels:     []string{"in_app", "websocket"},
+	})
+}
+
+func (s *interviewService) notifyInvite(ctx context.Context, applicant uuid.UUID, sess *model.Session, iv *model.Interview) {
+	if s.notify == nil {
+		return
+	}
+	u, _ := s.records.GetUser(ctx, applicant)
+	vars := map[string]interface{}{
+		"real_name":    displayName(u),
+		"round":        fmt.Sprintf("第%d轮", sess.Round),
+		"scheduled_at": formatTime(iv.ScheduledAt),
+		"location":     firstNonEmpty(iv.Location, sess.Location),
+	}
+	if err := s.notify.Send(ctx, []uuid.UUID{applicant}, tplInvite, vars); err != nil {
+		logger.Warn("send interview invite failed", zap.Error(err))
+	}
+}
+
+func (s *interviewService) notifyAssigned(ctx context.Context, evaluators []uuid.UUID, iv *model.Interview) {
+	if s.notify == nil || len(evaluators) == 0 {
+		return
+	}
+	u, _ := s.records.GetUser(ctx, iv.ApplicantID)
+	vars := map[string]interface{}{
+		"real_name":      "",
+		"applicant_name": displayName(u),
+		"scheduled_at":   formatTime(iv.ScheduledAt),
+		"location":       iv.Location,
+		"round":          fmt.Sprintf("第%d轮", iv.Round),
+	}
+	if err := s.notify.Send(ctx, evaluators, tplAssigned, vars); err != nil {
+		logger.Warn("send interview assigned failed", zap.Error(err))
+	}
+}
+
+func (s *interviewService) notifyResult(ctx context.Context, iv *model.Interview) {
+	if s.notify == nil {
+		return
+	}
+	u, _ := s.records.GetUser(ctx, iv.ApplicantID)
+	vars := map[string]interface{}{
+		"real_name": displayName(u),
+		"result":    resultLabel(iv.ResultCode),
+		"comment":   iv.ResultComment,
+	}
+	if err := s.notify.Send(ctx, []uuid.UUID{iv.ApplicantID}, tplResult, vars); err != nil {
+		logger.Warn("send interview result failed", zap.Error(err))
+	}
+}
+
+func formatTime(t *time.Time) string {
+	if t == nil {
+		return "待定"
+	}
+	return t.Format("2006-01-02 15:04")
+}

--- a/backend/internal/interview/service/scope.go
+++ b/backend/internal/interview/service/scope.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"strings"
+
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/google/uuid"
+)
+
+func rewriteSessionScope(scope *rbacModel.DataScopeCondition, userID uuid.UUID) *rbacModel.DataScopeCondition {
+	if scope == nil || scope.IsEmpty() {
+		return scope
+	}
+	if scope.Query == "1 = 0" {
+		return &rbacModel.DataScopeCondition{
+			Query: "s.created_by = ?",
+			Args:  []interface{}{userID},
+		}
+	}
+	q := strings.ReplaceAll(scope.Query, "department_id", "s.department_id")
+	return &rbacModel.DataScopeCondition{Query: q, Args: scope.Args}
+}
+
+func rewriteInterviewScope(scope *rbacModel.DataScopeCondition, userID uuid.UUID) *rbacModel.DataScopeCondition {
+	if scope == nil || scope.IsEmpty() {
+		return scope
+	}
+	if scope.Query == "1 = 0" {
+		return &rbacModel.DataScopeCondition{
+			Query: "i.applicant_id = ? OR i.id IN (SELECT interview_id FROM interview_interviewers WHERE interviewer_id = ?)",
+			Args:  []interface{}{userID, userID},
+		}
+	}
+	q := strings.ReplaceAll(scope.Query, "department_id", "s.department_id")
+	return &rbacModel.DataScopeCondition{Query: q, Args: scope.Args}
+}
+
+func canAccessInterview(scope *rbacModel.DataScopeCondition, applicantID uuid.UUID, deptID *uuid.UUID, viewer uuid.UUID) bool {
+	rewritten := rewriteInterviewScope(scope, viewer)
+	if rewritten == nil || rewritten.IsEmpty() {
+		return true
+	}
+	if strings.Contains(rewritten.Query, "applicant_id") {
+		return applicantID == viewer
+	}
+	if deptID == nil {
+		return false
+	}
+	for _, arg := range rewritten.Args {
+		switch v := arg.(type) {
+		case uuid.UUID:
+			if v == *deptID {
+				return true
+			}
+		case []uuid.UUID:
+			for _, id := range v {
+				if id == *deptID {
+					return true
+				}
+			}
+		}
+	}
+	return strings.Contains(rewritten.Query, "IN")
+}

--- a/backend/internal/interview/service/scope_test.go
+++ b/backend/internal/interview/service/scope_test.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"testing"
+
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteInterviewScope_Self(t *testing.T) {
+	uid := uuid.New()
+	got := rewriteInterviewScope(&rbacModel.DataScopeCondition{Query: "1 = 0"}, uid)
+	require.Contains(t, got.Query, "applicant_id")
+	require.Equal(t, uid, got.Args[0])
+}
+
+func TestCanAccessInterview_Self(t *testing.T) {
+	uid := uuid.New()
+	scope := &rbacModel.DataScopeCondition{Query: "1 = 0"}
+	require.True(t, canAccessInterview(scope, uid, nil, uid))
+	require.False(t, canAccessInterview(scope, uuid.New(), nil, uid))
+}

--- a/backend/internal/interview/service/score.go
+++ b/backend/internal/interview/service/score.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/google/uuid"
+)
+
+func summarizeEvaluations(
+	interviewID uuid.UUID,
+	applicant dto.Person,
+	rows []model.EvaluationNamed,
+	dims []model.Dimension,
+) *dto.EvaluationSummary {
+	weights := map[string]float64{}
+	for _, d := range dims {
+		weights[d.Name] = d.Weight
+	}
+	byEval := map[uuid.UUID]*dto.EvaluatorScores{}
+	order := []uuid.UUID{}
+	dimScores := map[string][]float64{}
+	for _, row := range rows {
+		item, ok := byEval[row.InterviewerID]
+		if !ok {
+			item = &dto.EvaluatorScores{
+				Evaluator: dto.Person{ID: row.InterviewerID.String(), Name: row.EvaluatorName},
+				Scores:    []dto.DimensionScore{},
+			}
+			byEval[row.InterviewerID] = item
+			order = append(order, row.InterviewerID)
+		}
+		item.Scores = append(item.Scores, dto.DimensionScore{
+			Dimension: row.Dimension,
+			Score:     row.Score,
+			Comment:   row.Comment,
+		})
+		dimScores[row.Dimension] = append(dimScores[row.Dimension], row.Score)
+	}
+	evals := make([]dto.EvaluatorScores, 0, len(order))
+	var evalSum float64
+	for _, id := range order {
+		item := byEval[id]
+		item.TotalScore = evaluatorTotal(item.Scores, weights)
+		evalSum += item.TotalScore
+		evals = append(evals, *item)
+	}
+	var avg float64
+	if len(evals) > 0 {
+		avg = round1(evalSum / float64(len(evals)))
+	}
+	return &dto.EvaluationSummary{
+		InterviewID:   interviewID.String(),
+		Applicant:     applicant,
+		Evaluations:   evals,
+		AverageScore:  avg,
+		WeightedScore: weightedAverage(dimScores, weights),
+	}
+}
+
+func evaluatorTotal(scores []dto.DimensionScore, weights map[string]float64) float64 {
+	var sum, wsum float64
+	var usedWeight bool
+	for _, s := range scores {
+		if w, ok := weights[s.Dimension]; ok && w > 0 {
+			sum += s.Score * w
+			wsum += w
+			usedWeight = true
+			continue
+		}
+		sum += s.Score
+		wsum++
+	}
+	if wsum == 0 {
+		return 0
+	}
+	if usedWeight {
+		return round1(sum / wsum)
+	}
+	return round1(sum / float64(len(scores)))
+}
+
+func weightedAverage(dimScores map[string][]float64, weights map[string]float64) float64 {
+	var sum, wsum float64
+	for name, scores := range dimScores {
+		if len(scores) == 0 {
+			continue
+		}
+		var avg float64
+		for _, s := range scores {
+			avg += s
+		}
+		avg /= float64(len(scores))
+		w := weights[name]
+		if w <= 0 {
+			w = 1
+		}
+		sum += avg * w
+		wsum += w
+	}
+	if wsum == 0 {
+		return 0
+	}
+	return round1(sum / wsum)
+}
+
+func round1(v float64) float64 {
+	return float64(int(v*10+0.5)) / 10
+}

--- a/backend/internal/interview/service/score_test.go
+++ b/backend/internal/interview/service/score_test.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummarizeEvaluations_AverageAndWeighted(t *testing.T) {
+	dims := []model.Dimension{
+		{Name: "技术能力", Weight: 0.4},
+		{Name: "沟通能力", Weight: 0.3},
+		{Name: "逻辑思维", Weight: 0.3},
+	}
+	a := uuid.New()
+	b := uuid.New()
+	rows := []model.EvaluationNamed{
+		{Evaluation: model.Evaluation{InterviewerID: a, Dimension: "技术能力", Score: 85}, EvaluatorName: "A"},
+		{Evaluation: model.Evaluation{InterviewerID: a, Dimension: "沟通能力", Score: 90}, EvaluatorName: "A"},
+		{Evaluation: model.Evaluation{InterviewerID: a, Dimension: "逻辑思维", Score: 80}, EvaluatorName: "A"},
+		{Evaluation: model.Evaluation{InterviewerID: b, Dimension: "技术能力", Score: 75}, EvaluatorName: "B"},
+		{Evaluation: model.Evaluation{InterviewerID: b, Dimension: "沟通能力", Score: 70}, EvaluatorName: "B"},
+		{Evaluation: model.Evaluation{InterviewerID: b, Dimension: "逻辑思维", Score: 80}, EvaluatorName: "B"},
+	}
+	sum := summarizeEvaluations(uuid.New(), dto.Person{Name: "张三"}, rows, dims)
+	require.Len(t, sum.Evaluations, 2)
+	require.InDelta(t, 85, sum.Evaluations[0].TotalScore, 0.2)
+	require.InDelta(t, 75, sum.Evaluations[1].TotalScore, 0.2)
+	require.InDelta(t, 80, sum.AverageScore, 0.2)
+	require.InDelta(t, 80, sum.WeightedScore, 0.2)
+}
+
+func TestRound1(t *testing.T) {
+	require.Equal(t, 86.0, round1(85.95))
+	require.Equal(t, 87.5, round1(87.54))
+}

--- a/backend/internal/interview/service/service.go
+++ b/backend/internal/interview/service/service.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/repo"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/google/uuid"
+)
+
+// Notifier 发送模板通知。
+type Notifier interface {
+	Send(ctx context.Context, userIDs []uuid.UUID, template string, vars map[string]interface{}) error
+}
+
+// ApplicationSyncer 把面试结果写回入会申请。
+type ApplicationSyncer interface {
+	SyncFromInterview(ctx context.Context, operator, applicationID uuid.UUID, result int16, comment string) error
+}
+
+// InterviewService 面试管理。
+type InterviewService interface {
+	CreateSession(ctx context.Context, operator uuid.UUID, req *dto.CreateSessionRequest) (*dto.SessionResponse, error)
+	ListSessions(ctx context.Context, viewer uuid.UUID, req *dto.ListSessionRequest, scope *rbacModel.DataScopeCondition) ([]*dto.SessionResponse, int64, error)
+	GetSession(ctx context.Context, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.SessionResponse, error)
+	UpdateSession(ctx context.Context, id uuid.UUID, req *dto.UpdateSessionRequest) (*dto.SessionResponse, error)
+	DeleteSession(ctx context.Context, id uuid.UUID) error
+	StartSession(ctx context.Context, id uuid.UUID) (*dto.SessionResponse, error)
+	EndSession(ctx context.Context, id uuid.UUID) (*dto.SessionResponse, error)
+	SessionQRCode(ctx context.Context, id uuid.UUID) (*dto.QRCodeResponse, []byte, error)
+
+	CreateInterview(ctx context.Context, operator uuid.UUID, req *dto.CreateInterviewRequest) (*dto.InterviewResponse, error)
+	ListInterviews(ctx context.Context, viewer uuid.UUID, req *dto.ListInterviewRequest, scope *rbacModel.DataScopeCondition) ([]*dto.InterviewResponse, int64, error)
+	GetInterview(ctx context.Context, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.InterviewResponse, error)
+	AssignEvaluators(ctx context.Context, id uuid.UUID, req *dto.AssignEvaluatorsRequest) (*dto.InterviewResponse, error)
+	Checkin(ctx context.Context, userID, id uuid.UUID, token string) (*dto.InterviewResponse, error)
+	StartInterview(ctx context.Context, operator, id uuid.UUID) (*dto.InterviewResponse, error)
+	EndInterview(ctx context.Context, operator, id uuid.UUID) (*dto.InterviewResponse, error)
+	MyInterviews(ctx context.Context, userID uuid.UUID, status *int16) ([]*dto.InterviewResponse, error)
+
+	SubmitEvaluations(ctx context.Context, evaluator, id uuid.UUID, req *dto.SubmitEvaluationsRequest) (*dto.EvaluationSummary, error)
+	GetEvaluations(ctx context.Context, id uuid.UUID) (*dto.EvaluationSummary, error)
+	UpdateEvaluation(ctx context.Context, evaluator, interviewID, eid uuid.UUID, req *dto.UpdateEvaluationRequest) (*dto.EvaluationResponse, error)
+	SubmitResult(ctx context.Context, operator, id uuid.UUID, req *dto.SubmitResultRequest) (*dto.InterviewResponse, error)
+
+	ListDimensions(ctx context.Context) ([]dto.DimensionResponse, error)
+	CreateDimension(ctx context.Context, req *dto.CreateDimensionRequest) (*dto.DimensionResponse, error)
+	UpdateDimension(ctx context.Context, id uuid.UUID, req *dto.UpdateDimensionRequest) (*dto.DimensionResponse, error)
+	DeleteDimension(ctx context.Context, id uuid.UUID) error
+	Stats(ctx context.Context, q *dto.StatsQuery) (*dto.StatsResponse, error)
+}
+
+type interviewService struct {
+	sessions repo.SessionRepo
+	records  repo.InterviewRepo
+	evals    repo.EvaluationRepo
+	notify   Notifier
+	syncer   ApplicationSyncer
+}
+
+func NewInterviewService(
+	sessions repo.SessionRepo,
+	records repo.InterviewRepo,
+	evals repo.EvaluationRepo,
+	notify Notifier,
+	syncer ApplicationSyncer,
+) InterviewService {
+	return &interviewService{
+		sessions: sessions,
+		records:  records,
+		evals:    evals,
+		notify:   notify,
+		syncer:   syncer,
+	}
+}

--- a/backend/internal/interview/service/session.go
+++ b/backend/internal/interview/service/session.go
@@ -1,0 +1,220 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	qrcode "github.com/skip2/go-qrcode"
+)
+
+func (s *interviewService) CreateSession(ctx context.Context, operator uuid.UUID, req *dto.CreateSessionRequest) (*dto.SessionResponse, error) {
+	if !req.EndTime.After(req.StartTime) {
+		return nil, response.NewError(response.CodeBadRequest, "结束时间必须晚于开始时间")
+	}
+	now := time.Now()
+	sess := &model.Session{
+		ID:            uuid.New(),
+		Title:         req.Title,
+		Round:         int16(req.Round),
+		DepartmentID:  parseOptionalUUID(req.DepartmentID),
+		StartTime:     req.StartTime,
+		EndTime:       req.EndTime,
+		Location:      req.Location,
+		OnlineLink:    req.OnlineLink,
+		Status:        model.SessionPending,
+		MaxCandidates: req.MaxCandidates,
+		Description:   req.Description,
+		CreatedBy:     &operator,
+		QRToken:       newQRToken(),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := s.sessions.Create(ctx, sess); err != nil {
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+	return s.GetSession(ctx, sess.ID, nil)
+}
+
+func (s *interviewService) ListSessions(ctx context.Context, viewer uuid.UUID, req *dto.ListSessionRequest, scope *rbacModel.DataScopeCondition) ([]*dto.SessionResponse, int64, error) {
+	rows, total, err := s.sessions.List(ctx, req, rewriteSessionScope(scope, viewer))
+	if err != nil {
+		return nil, 0, fmt.Errorf("list sessions: %w", err)
+	}
+	out := make([]*dto.SessionResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, mapSession(&rows[i]))
+	}
+	return out, total, nil
+}
+
+func (s *interviewService) GetSession(ctx context.Context, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.SessionResponse, error) {
+	row, err := s.sessions.GetByIDWithNames(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get session: %w", err)
+	}
+	if row == nil {
+		return nil, response.NewError(response.CodeInterviewNotFound, "面试场次不存在")
+	}
+	_ = scope
+	return mapSession(row), nil
+}
+
+func (s *interviewService) UpdateSession(ctx context.Context, id uuid.UUID, req *dto.UpdateSessionRequest) (*dto.SessionResponse, error) {
+	sess, err := s.mustSession(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canUpdateSession(sess.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "仅待开始场次可修改")
+	}
+	applySessionPatch(sess, req)
+	if !sess.EndTime.After(sess.StartTime) {
+		return nil, response.NewError(response.CodeBadRequest, "结束时间必须晚于开始时间")
+	}
+	sess.UpdatedAt = time.Now()
+	if err := s.sessions.Update(ctx, sess); err != nil {
+		return nil, fmt.Errorf("update session: %w", err)
+	}
+	return s.GetSession(ctx, id, nil)
+}
+
+func (s *interviewService) DeleteSession(ctx context.Context, id uuid.UUID) error {
+	sess, err := s.mustSession(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !canDeleteSession(sess.Status) {
+		return response.NewError(response.CodeInterviewInvalidState, "进行中或已结束的场次不可删除")
+	}
+	n, err := s.sessions.CountCandidates(ctx, id)
+	if err != nil {
+		return fmt.Errorf("count candidates: %w", err)
+	}
+	if n > 0 {
+		sess.Status = model.SessionCancelled
+		sess.UpdatedAt = time.Now()
+		return s.sessions.Update(ctx, sess)
+	}
+	return s.sessions.Delete(ctx, id)
+}
+
+func (s *interviewService) StartSession(ctx context.Context, id uuid.UUID) (*dto.SessionResponse, error) {
+	sess, err := s.mustSession(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canStartSession(sess.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "场次状态不允许开始")
+	}
+	sess.Status = model.SessionOngoing
+	if sess.QRToken == "" {
+		sess.QRToken = newQRToken()
+	}
+	sess.UpdatedAt = time.Now()
+	if err := s.sessions.Update(ctx, sess); err != nil {
+		return nil, fmt.Errorf("start session: %w", err)
+	}
+	return s.GetSession(ctx, id, nil)
+}
+
+func (s *interviewService) EndSession(ctx context.Context, id uuid.UUID) (*dto.SessionResponse, error) {
+	sess, err := s.mustSession(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canEndSession(sess.Status) {
+		return nil, response.NewError(response.CodeInterviewInvalidState, "场次状态不允许结束")
+	}
+	if err := s.records.MarkAbsentBySession(ctx, id); err != nil {
+		return nil, fmt.Errorf("mark absent: %w", err)
+	}
+	sess.Status = model.SessionEnded
+	sess.UpdatedAt = time.Now()
+	if err := s.sessions.Update(ctx, sess); err != nil {
+		return nil, fmt.Errorf("end session: %w", err)
+	}
+	return s.GetSession(ctx, id, nil)
+}
+
+func (s *interviewService) SessionQRCode(ctx context.Context, id uuid.UUID) (*dto.QRCodeResponse, []byte, error) {
+	sess, err := s.mustSession(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sess.QRToken == "" {
+		sess.QRToken = newQRToken()
+		sess.UpdatedAt = time.Now()
+		if err := s.sessions.Update(ctx, sess); err != nil {
+			return nil, nil, fmt.Errorf("save qr token: %w", err)
+		}
+	}
+	path := "/interview/checkin?session_id=" + id.String() + "&token=" + sess.QRToken
+	png, err := qrcode.Encode(path, qrcode.Medium, 256)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode qr: %w", err)
+	}
+	return &dto.QRCodeResponse{
+		SessionID:   id.String(),
+		Token:       sess.QRToken,
+		CheckinPath: path,
+		PNGBase64:   base64.StdEncoding.EncodeToString(png),
+	}, png, nil
+}
+
+func (s *interviewService) mustSession(ctx context.Context, id uuid.UUID) (*model.Session, error) {
+	sess, err := s.sessions.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get session: %w", err)
+	}
+	if sess == nil {
+		return nil, response.NewError(response.CodeInterviewNotFound, "面试场次不存在")
+	}
+	return sess, nil
+}
+
+func applySessionPatch(sess *model.Session, req *dto.UpdateSessionRequest) {
+	if req.Title != nil {
+		sess.Title = *req.Title
+	}
+	if req.Round != nil {
+		sess.Round = int16(*req.Round)
+	}
+	if req.DepartmentID != nil {
+		sess.DepartmentID = parseOptionalUUID(*req.DepartmentID)
+	}
+	if req.StartTime != nil {
+		sess.StartTime = *req.StartTime
+	}
+	if req.EndTime != nil {
+		sess.EndTime = *req.EndTime
+	}
+	if req.Location != nil {
+		sess.Location = *req.Location
+	}
+	if req.OnlineLink != nil {
+		sess.OnlineLink = *req.OnlineLink
+	}
+	if req.MaxCandidates != nil {
+		sess.MaxCandidates = *req.MaxCandidates
+	}
+	if req.Description != nil {
+		sess.Description = *req.Description
+	}
+}
+
+func newQRToken() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return uuid.NewString()
+	}
+	return hex.EncodeToString(buf)
+}

--- a/backend/internal/interview/service/session_test.go
+++ b/backend/internal/interview/service/session_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSession_InvalidTime(t *testing.T) {
+	svc := NewInterviewService(&mockSessionRepo{}, &mockInterviewRepo{}, &mockEvalRepo{}, nil, nil)
+	now := time.Now()
+	_, err := svc.CreateSession(context.Background(), uuid.New(), &dto.CreateSessionRequest{
+		Title: "一面", Round: 1, StartTime: now, EndTime: now, MaxCandidates: 10,
+	})
+	requireAppError(t, err, response.CodeBadRequest)
+}
+
+func TestCreateSession_OK(t *testing.T) {
+	sessions := &mockSessionRepo{}
+	svc := NewInterviewService(sessions, &mockInterviewRepo{}, &mockEvalRepo{}, nil, nil)
+	now := time.Now()
+	sessions.On("Create", mock.Anything, mock.AnythingOfType("*model.Session")).Return(nil)
+	sessions.On("GetByIDWithNames", mock.Anything, mock.AnythingOfType("uuid.UUID")).Return(&model.SessionWithNames{
+		Session: model.Session{Title: "一面", Status: model.SessionPending, MaxCandidates: 10},
+	}, nil)
+	out, err := svc.CreateSession(context.Background(), uuid.New(), &dto.CreateSessionRequest{
+		Title: "一面", Round: 1, StartTime: now, EndTime: now.Add(time.Hour), MaxCandidates: 10, Location: "A101",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "一面", out.Title)
+}
+
+func TestStartSession_InvalidState(t *testing.T) {
+	sessions := &mockSessionRepo{}
+	svc := NewInterviewService(sessions, &mockInterviewRepo{}, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	sessions.On("GetByID", mock.Anything, id).Return(&model.Session{ID: id, Status: model.SessionEnded}, nil)
+	_, err := svc.StartSession(context.Background(), id)
+	requireAppError(t, err, response.CodeInterviewInvalidState)
+}
+
+func TestGetSession_NotFound(t *testing.T) {
+	sessions := &mockSessionRepo{}
+	svc := NewInterviewService(sessions, &mockInterviewRepo{}, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	sessions.On("GetByIDWithNames", mock.Anything, id).Return(nil, nil)
+	_, err := svc.GetSession(context.Background(), id, nil)
+	requireAppError(t, err, response.CodeInterviewNotFound)
+}
+
+func TestEndSession_MarksAbsent(t *testing.T) {
+	sessions := &mockSessionRepo{}
+	records := &mockInterviewRepo{}
+	svc := NewInterviewService(sessions, records, &mockEvalRepo{}, nil, nil)
+	id := uuid.New()
+	sess := &model.Session{ID: id, Status: model.SessionOngoing, Title: "一面"}
+	sessions.On("GetByID", mock.Anything, id).Return(sess, nil)
+	records.On("MarkAbsentBySession", mock.Anything, id).Return(nil)
+	sessions.On("Update", mock.Anything, mock.AnythingOfType("*model.Session")).Return(nil)
+	sessions.On("GetByIDWithNames", mock.Anything, id).Return(namedSession(&model.Session{ID: id, Status: model.SessionEnded, Title: "一面"}), nil)
+	out, err := svc.EndSession(context.Background(), id)
+	require.NoError(t, err)
+	require.Equal(t, model.SessionEnded, out.Status)
+}

--- a/backend/internal/interview/service/state.go
+++ b/backend/internal/interview/service/state.go
@@ -1,0 +1,56 @@
+package service
+
+import "github.com/Yogdunana/StarByte/backend/internal/interview/model"
+
+func canStartSession(status int16) bool {
+	return status == model.SessionPending
+}
+
+func canEndSession(status int16) bool {
+	return status == model.SessionOngoing
+}
+
+func canUpdateSession(status int16) bool {
+	return status == model.SessionPending
+}
+
+func canDeleteSession(status int16) bool {
+	return status == model.SessionPending || status == model.SessionCancelled
+}
+
+func canAddCandidate(status int16) bool {
+	return status == model.SessionPending || status == model.SessionOngoing
+}
+
+func canCheckin(status int16) bool {
+	return status == model.InterviewPending
+}
+
+func canStartInterview(status int16) bool {
+	return status == model.InterviewPending || status == model.InterviewCheckedIn
+}
+
+func canEndInterview(status int16) bool {
+	return status == model.InterviewOngoing
+}
+
+func canScore(status int16) bool {
+	return status == model.InterviewOngoing || status == model.InterviewDone
+}
+
+func canSubmitResult(status int16) bool {
+	return status == model.InterviewDone || status == model.InterviewOngoing
+}
+
+func resultLabel(code int16) string {
+	switch code {
+	case model.ResultPass:
+		return "通过"
+	case model.ResultFail:
+		return "不通过"
+	case model.ResultPending:
+		return "待定"
+	default:
+		return ""
+	}
+}

--- a/backend/internal/interview/service/state_test.go
+++ b/backend/internal/interview/service/state_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/interview/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionStateMachine(t *testing.T) {
+	require.True(t, canStartSession(model.SessionPending))
+	require.False(t, canStartSession(model.SessionOngoing))
+	require.True(t, canEndSession(model.SessionOngoing))
+	require.False(t, canEndSession(model.SessionPending))
+	require.True(t, canUpdateSession(model.SessionPending))
+	require.False(t, canDeleteSession(model.SessionOngoing))
+	require.True(t, canAddCandidate(model.SessionOngoing))
+}
+
+func TestInterviewStateMachine(t *testing.T) {
+	require.True(t, canCheckin(model.InterviewPending))
+	require.False(t, canCheckin(model.InterviewDone))
+	require.True(t, canStartInterview(model.InterviewCheckedIn))
+	require.True(t, canEndInterview(model.InterviewOngoing))
+	require.True(t, canScore(model.InterviewOngoing))
+	require.True(t, canSubmitResult(model.InterviewDone))
+	require.Equal(t, "通过", resultLabel(model.ResultPass))
+	require.Equal(t, "不通过", resultLabel(model.ResultFail))
+}

--- a/backend/internal/member/handler/application_handler_test.go
+++ b/backend/internal/member/handler/application_handler_test.go
@@ -129,6 +129,9 @@ func (m *mockMemberService) MemberStats(ctx context.Context, q *dto.StatsQuery) 
 	}
 	return args.Get(0).(*dto.StatsResponse), args.Error(1)
 }
+func (m *mockMemberService) SyncFromInterview(ctx context.Context, operator, applicationID uuid.UUID, result int16, comment string) error {
+	return m.Called(ctx, operator, applicationID, result, comment).Error(0)
+}
 
 func withUser(uid uuid.UUID) gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/backend/internal/member/service/member_service.go
+++ b/backend/internal/member/service/member_service.go
@@ -31,6 +31,8 @@ type MemberService interface {
 
 	ApplicationStats(ctx context.Context, q *dto.StatsQuery) (*dto.StatsResponse, error)
 	MemberStats(ctx context.Context, q *dto.StatsQuery) (*dto.StatsResponse, error)
+
+	SyncFromInterview(ctx context.Context, operator, applicationID uuid.UUID, result int16, comment string) error
 }
 
 type memberService struct {

--- a/backend/internal/member/service/review_service.go
+++ b/backend/internal/member/service/review_service.go
@@ -71,6 +71,29 @@ func (s *memberService) transit(ctx context.Context, reviewer, id uuid.UUID, act
 	return s.GetApplication(ctx, reviewer, app.ID, nil)
 }
 
+// SyncFromInterview 面试结果回写入会申请：通过→批准，不通过→拒绝。
+func (s *memberService) SyncFromInterview(ctx context.Context, operator, applicationID uuid.UUID, result int16, comment string) error {
+	app, err := s.apps.GetByID(ctx, applicationID)
+	if err != nil {
+		return fmt.Errorf("get application: %w", err)
+	}
+	if app == nil {
+		return nil
+	}
+	if app.Status != model.AppInterviewing {
+		return nil
+	}
+	switch result {
+	case 1:
+		_, err = s.transit(ctx, operator, applicationID, actionApprove, comment, nil)
+	case 2:
+		_, err = s.transit(ctx, operator, applicationID, actionReject, comment, nil)
+	default:
+		return nil
+	}
+	return err
+}
+
 func (s *memberService) startInterview(ctx context.Context, app *model.MemberApplication, reviewer uuid.UUID) error {
 	if s.starter == nil {
 		return response.NewError(response.CodeMemberAppInvalid, "面试流程引擎未配置")

--- a/backend/internal/member/service/review_service_test.go
+++ b/backend/internal/member/service/review_service_test.go
@@ -113,3 +113,25 @@ func TestReject_Pending(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, model.AppRejected, out.Status)
 }
+
+func TestSyncFromInterview_ApproveWhenInterviewing(t *testing.T) {
+	apps := &mockAppRepo{}
+	profs := &mockProfRepo{}
+	svc := NewMemberService(apps, profs, nil)
+	id := uuid.New()
+	userID := uuid.New()
+	apps.On("GetByID", mock.Anything, id).Return(&model.MemberApplication{
+		ID: id, UserID: userID, Type: model.ApplicantOfficer, Status: model.AppInterviewing,
+		RealName: "王五", StudentNo: "2024003",
+	}, nil)
+	profs.On("GetByUserID", mock.Anything, userID).Return(nil, nil)
+	profs.On("GetByStudentNo", mock.Anything, "2024003", (*uuid.UUID)(nil)).Return(nil, nil)
+	profs.On("Create", mock.Anything, mock.AnythingOfType("*model.MemberProfile")).Return(nil)
+	apps.On("Update", mock.Anything, mock.AnythingOfType("*model.MemberApplication")).Return(nil)
+	apps.On("CreateHistory", mock.Anything, mock.AnythingOfType("*model.ApplicationHistory")).Return(nil)
+	apps.On("GetByIDWithNames", mock.Anything, id).Return(&model.ApplicationWithNames{
+		MemberApplication: model.MemberApplication{ID: id, Status: model.AppApproved},
+	}, nil)
+	err := svc.SyncFromInterview(context.Background(), uuid.New(), id, 1, "面试通过")
+	require.NoError(t, err)
+}

--- a/backend/migrations/000021_interview_management.down.sql
+++ b/backend/migrations/000021_interview_management.down.sql
@@ -1,0 +1,21 @@
+DELETE FROM permissions WHERE code IN ('interview:manage', 'interview:evaluate');
+
+DROP INDEX IF EXISTS uq_interview_eval_dim;
+ALTER TABLE interview_evaluations
+    DROP COLUMN IF EXISTS dimension,
+    DROP COLUMN IF EXISTS updated_at;
+CREATE UNIQUE INDEX IF NOT EXISTS interview_evaluations_interview_id_interviewer_id_key
+    ON interview_evaluations (interview_id, interviewer_id);
+
+DROP INDEX IF EXISTS idx_interviews_applicant_id;
+DROP INDEX IF EXISTS idx_interviews_session_id;
+ALTER TABLE interviews
+    DROP COLUMN IF EXISTS session_id,
+    DROP COLUMN IF EXISTS applicant_id,
+    DROP COLUMN IF EXISTS actual_start_time,
+    DROP COLUMN IF EXISTS actual_end_time,
+    DROP COLUMN IF EXISTS result_code,
+    DROP COLUMN IF EXISTS result_comment;
+
+DROP TABLE IF EXISTS interview_dimensions;
+DROP TABLE IF EXISTS interview_sessions;

--- a/backend/migrations/000021_interview_management.down.sql
+++ b/backend/migrations/000021_interview_management.down.sql
@@ -4,8 +4,9 @@ DROP INDEX IF EXISTS uq_interview_eval_dim;
 ALTER TABLE interview_evaluations
     DROP COLUMN IF EXISTS dimension,
     DROP COLUMN IF EXISTS updated_at;
-CREATE UNIQUE INDEX IF NOT EXISTS interview_evaluations_interview_id_interviewer_id_key
-    ON interview_evaluations (interview_id, interviewer_id);
+ALTER TABLE interview_evaluations
+    ADD CONSTRAINT interview_evaluations_interview_id_interviewer_id_key
+    UNIQUE (interview_id, interviewer_id);
 
 DROP INDEX IF EXISTS idx_interviews_applicant_id;
 DROP INDEX IF EXISTS idx_interviews_session_id;

--- a/backend/migrations/000021_interview_management.up.sql
+++ b/backend/migrations/000021_interview_management.up.sql
@@ -55,6 +55,8 @@ ALTER TABLE interview_evaluations
     ADD COLUMN IF NOT EXISTS dimension VARCHAR(50) NOT NULL DEFAULT '',
     ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
+ALTER TABLE interview_evaluations
+    DROP CONSTRAINT IF EXISTS interview_evaluations_interview_id_interviewer_id_key;
 DROP INDEX IF EXISTS interview_evaluations_interview_id_interviewer_id_key;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_interview_eval_dim
     ON interview_evaluations (interview_id, interviewer_id, dimension);

--- a/backend/migrations/000021_interview_management.up.sql
+++ b/backend/migrations/000021_interview_management.up.sql
@@ -1,0 +1,73 @@
+-- ============================================================
+-- 000021_interview_management.up.sql
+-- Issue #7：场次、维度、补齐 interviews / evaluations 列与权限
+-- 复用 000011 表，不改已有列名（scheduled_at / interviewer_id）
+-- interviews.status 对齐 Issue：0待面试 1已签到 2面试中 3已完成 4缺席 5已取消
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS interview_sessions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    title VARCHAR(200) NOT NULL,
+    round SMALLINT NOT NULL DEFAULT 1,
+    department_id UUID REFERENCES departments(id) ON DELETE RESTRICT,
+    start_time TIMESTAMP NOT NULL,
+    end_time TIMESTAMP NOT NULL,
+    location VARCHAR(200) NOT NULL DEFAULT '',
+    online_link VARCHAR(500) NOT NULL DEFAULT '',
+    status SMALLINT NOT NULL DEFAULT 0, -- 0待开始 1进行中 2已结束 3已取消
+    max_candidates INT NOT NULL DEFAULT 20,
+    description TEXT NOT NULL DEFAULT '',
+    created_by UUID REFERENCES users(id),
+    qr_token VARCHAR(64) NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_interview_sessions_status ON interview_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_interview_sessions_department ON interview_sessions(department_id);
+CREATE INDEX IF NOT EXISTS idx_interview_sessions_round ON interview_sessions(round);
+
+CREATE TABLE IF NOT EXISTS interview_dimensions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(50) NOT NULL,
+    weight NUMERIC(5,2) NOT NULL DEFAULT 1,
+    max_score NUMERIC(5,2) NOT NULL DEFAULT 100,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_interview_dimensions_name ON interview_dimensions(name);
+
+ALTER TABLE interviews
+    ALTER COLUMN application_id DROP NOT NULL,
+    ADD COLUMN IF NOT EXISTS session_id UUID REFERENCES interview_sessions(id) ON DELETE CASCADE,
+    ADD COLUMN IF NOT EXISTS applicant_id UUID REFERENCES users(id) ON DELETE RESTRICT,
+    ADD COLUMN IF NOT EXISTS actual_start_time TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS actual_end_time TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS result_code SMALLINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS result_comment TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_interviews_session_id ON interviews(session_id);
+CREATE INDEX IF NOT EXISTS idx_interviews_applicant_id ON interviews(applicant_id);
+
+ALTER TABLE interview_evaluations
+    ADD COLUMN IF NOT EXISTS dimension VARCHAR(50) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+DROP INDEX IF EXISTS interview_evaluations_interview_id_interviewer_id_key;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_interview_eval_dim
+    ON interview_evaluations (interview_id, interviewer_id, dimension);
+
+INSERT INTO permissions (id, name, code, resource, action, description, type, is_system, status)
+VALUES
+    (uuid_generate_v4(), '面试管理', 'interview:manage', 'interview', 'manage', '场次与结果管理', 2, true, 0),
+    (uuid_generate_v4(), '面试评分', 'interview:evaluate', 'interview', 'evaluate', '面试官评分与开场', 2, true, 0)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO interview_dimensions (id, name, weight, max_score, sort_order)
+VALUES
+    (uuid_generate_v4(), '技术能力', 0.40, 100, 1),
+    (uuid_generate_v4(), '沟通能力', 0.30, 100, 2),
+    (uuid_generate_v4(), '逻辑思维', 0.30, 100, 3)
+ON CONFLICT (name) DO NOTHING;

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -86,8 +86,15 @@ const (
 	CodeMemberFieldRequired = 6008 // 必填字段缺失
 
 	// ===== Interview module (7000-7999) =====
-	CodeInterviewNotFound = 7001 // 面试场次不存在
-	CodeInterviewConflict = 7002 // 面试时间冲突
+	CodeInterviewNotFound     = 7001 // 面试场次不存在
+	CodeInterviewRecordGone   = 7002 // 面试记录不存在
+	CodeInterviewConflict     = 7003 // 面试时间冲突
+	CodeInterviewNoEvaluator  = 7004 // 面试官未分配
+	CodeInterviewDupEval      = 7005 // 重复评分
+	CodeInterviewInvalidState = 7006 // 状态不允许操作
+	CodeInterviewScoreRange   = 7007 // 评分超出范围
+	CodeInterviewDimGone      = 7008 // 维度不存在
+	CodeInterviewSessionFull  = 7009 // 超过最大候选人数
 
 	// ===== Meeting module (8000-8999) =====
 	CodeMeetingNotFound = 8001 // 会议不存在

--- a/backend/scripts/seed_rbac.go
+++ b/backend/scripts/seed_rbac.go
@@ -68,6 +68,10 @@ func allSeedPermissions() []seedPerm {
 		seedPerm{Name: "会员管理", Code: "member:manage", Resource: "member", Action: "manage"},
 	)
 	perms = append(perms, moduleCRUD("interview", "面试")...)
+	perms = append(perms,
+		seedPerm{Name: "面试管理", Code: "interview:manage", Resource: "interview", Action: "manage"},
+		seedPerm{Name: "面试评分", Code: "interview:evaluate", Resource: "interview", Action: "evaluate"},
+	)
 	perms = append(perms, moduleCRUD("meeting", "会议")...)
 	perms = append(perms, moduleCRUD("task", "任务")...)
 	perms = append(perms, moduleCRUD("internship", "实习")...)
@@ -175,6 +179,7 @@ func seedRolePermissions(db *gorm.DB) error {
 			OR (p.resource IN ('member','interview','meeting','task','internship','file','workflow','notification')
 			    AND p.action IN ('create','update'))
 			OR (p.resource = 'member' AND p.action IN ('approve','export','manage'))
+			OR (p.resource = 'interview' AND p.action IN ('manage','evaluate'))
 		)
 		ON CONFLICT (role_id, permission_id) DO NOTHING
 	`).Error; err != nil {
@@ -205,7 +210,7 @@ func seedRolePermissions(db *gorm.DB) error {
 func officerPermCodes() []string {
 	return []string{
 		"user:read", "member:read", "member:create",
-		"interview:read", "meeting:read",
+		"interview:read", "interview:evaluate", "meeting:read",
 		"task:read", "task:create",
 		"file:read", "file:create",
 		"internship:read", "internship:create",

--- a/backend/scripts/seed_templates.go
+++ b/backend/scripts/seed_templates.go
@@ -25,6 +25,18 @@ var seedTemplatesData = []seedTemplate{
 		Schema: `{"real_name":"string","round":"string","scheduled_at":"string","location":"string"}`,
 	},
 	{
+		Code: "interview_assigned", Name: "面试官分配", Category: "interview",
+		Title:  "你被分配为面试官",
+		Body:   "请面试 {{.applicant_name}}，时间 {{.scheduled_at}}，地点 {{.location}}。",
+		Schema: `{"applicant_name":"string","scheduled_at":"string","location":"string","round":"string"}`,
+	},
+	{
+		Code: "interview_result", Name: "面试结果", Category: "interview",
+		Title:  "面试结果：{{.result}}",
+		Body:   "{{.real_name}}，你的面试结果为 {{.result}}。{{.comment}}",
+		Schema: `{"real_name":"string","result":"string","comment":"string"}`,
+	},
+	{
 		Code: "meeting_notice", Name: "会议通知", Category: "meeting",
 		Title:  "会议通知：{{.title}}",
 		Body:   "会议「{{.title}}」将于 {{.start_time}} 在 {{.location}} 召开。",

--- a/frontend/src/api/interview.ts
+++ b/frontend/src/api/interview.ts
@@ -1,49 +1,127 @@
 import request from './request';
 import type {
   Interview,
-  InterviewEvaluation,
+  InterviewSession,
+  InterviewQRCode,
+  EvaluationDimension,
+  EvaluationSummary,
+  InterviewStats,
+  CreateSessionParams,
   CreateInterviewParams,
-  UpdateInterviewParams,
+  ListSessionParams,
   ListInterviewParams,
   PageResponse,
+  InterviewRecordStatus,
 } from '@/types/api';
 
-// 获取面试列表
-export function getInterviewList(
-  params: ListInterviewParams,
-): Promise<PageResponse<Interview>> {
+export function getSessionList(params: ListSessionParams): Promise<PageResponse<InterviewSession>> {
+  return request.get('/interviews/sessions', { params });
+}
+
+export function getSessionDetail(id: string): Promise<InterviewSession> {
+  return request.get(`/interviews/sessions/${id}`);
+}
+
+export function createSession(data: CreateSessionParams): Promise<InterviewSession> {
+  return request.post('/interviews/sessions', data);
+}
+
+export function updateSession(id: string, data: Partial<CreateSessionParams>): Promise<InterviewSession> {
+  return request.put(`/interviews/sessions/${id}`, data);
+}
+
+export function deleteSession(id: string): Promise<void> {
+  return request.delete(`/interviews/sessions/${id}`);
+}
+
+export function startSession(id: string): Promise<InterviewSession> {
+  return request.post(`/interviews/sessions/${id}/start`);
+}
+
+export function endSession(id: string): Promise<InterviewSession> {
+  return request.post(`/interviews/sessions/${id}/end`);
+}
+
+export function getSessionQRCode(id: string): Promise<InterviewQRCode> {
+  return request.get(`/interviews/sessions/${id}/qrcode`);
+}
+
+export function getInterviewList(params: ListInterviewParams): Promise<PageResponse<Interview>> {
   return request.get('/interviews', { params });
 }
 
-// 获取面试详情
 export function getInterviewDetail(id: string): Promise<Interview> {
   return request.get(`/interviews/${id}`);
 }
 
-// 创建面试
 export function createInterview(data: CreateInterviewParams): Promise<Interview> {
   return request.post('/interviews', data);
 }
 
-// 更新面试
-export function updateInterview(id: string, data: UpdateInterviewParams): Promise<Interview> {
-  return request.put(`/interviews/${id}`, data);
+export function assignEvaluators(id: string, evaluator_ids: string[]): Promise<Interview> {
+  return request.post(`/interviews/${id}/assign`, { evaluator_ids });
 }
 
-// 删除面试
-export function deleteInterview(id: string): Promise<void> {
-  return request.delete(`/interviews/${id}`);
+export function checkinInterview(id: string, token?: string): Promise<Interview> {
+  return request.post(`/interviews/${id}/checkin`, { token });
 }
 
-// 获取面试评分列表
-export function getInterviewEvaluations(interviewId: string): Promise<InterviewEvaluation[]> {
-  return request.get(`/interviews/${interviewId}/evaluations`);
+export function startInterview(id: string): Promise<Interview> {
+  return request.post(`/interviews/${id}/start`);
 }
 
-// 提交面试评分
-export function submitInterviewEvaluation(
-  interviewId: string,
-  data: { score: number; comment: string; recommendation: number },
-): Promise<InterviewEvaluation> {
-  return request.post(`/interviews/${interviewId}/evaluations`, data);
+export function endInterview(id: string): Promise<Interview> {
+  return request.post(`/interviews/${id}/end`);
+}
+
+export function submitInterviewResult(id: string, result: 1 | 2 | 3, comment: string): Promise<Interview> {
+  return request.post(`/interviews/${id}/result`, { result, comment });
+}
+
+export function getMyInterviews(status?: InterviewRecordStatus): Promise<Interview[]> {
+  return request.get('/interviews/my', { params: { status } });
+}
+
+export function getDimensions(): Promise<EvaluationDimension[]> {
+  return request.get('/interviews/dimensions');
+}
+
+export function createDimension(data: {
+  name: string;
+  weight: number;
+  max_score: number;
+  sort_order?: number;
+}): Promise<EvaluationDimension> {
+  return request.post('/interviews/dimensions', data);
+}
+
+export function updateDimension(
+  id: string,
+  data: Partial<{ name: string; weight: number; max_score: number; sort_order: number }>,
+): Promise<EvaluationDimension> {
+  return request.put(`/interviews/dimensions/${id}`, data);
+}
+
+export function deleteDimension(id: string): Promise<void> {
+  return request.delete(`/interviews/dimensions/${id}`);
+}
+
+export function getEvaluationSummary(id: string): Promise<EvaluationSummary> {
+  return request.get(`/interviews/${id}/evaluations`);
+}
+
+export function submitEvaluations(
+  id: string,
+  evaluations: Array<{ dimension: string; score: number; comment: string }>,
+): Promise<EvaluationSummary> {
+  return request.post(`/interviews/${id}/evaluations`, { evaluations });
+}
+
+export function getInterviewStats(params?: {
+  start_date?: string;
+  end_date?: string;
+  department_id?: string;
+  round?: number;
+}): Promise<InterviewStats> {
+  return request.get('/interviews/stats', { params });
 }

--- a/frontend/src/pages/interview/CheckinPage.tsx
+++ b/frontend/src/pages/interview/CheckinPage.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { Button, Card, Result, Space, Spin, message } from 'antd';
 import { checkinInterview, getMyInterviews, getSessionQRCode } from '@/api/interview';
+import { selectCurrentUser } from '@/store/slices/userSlice';
 import type { Interview } from '@/types/api';
 
 const CheckinPage: React.FC = () => {
   const [params] = useSearchParams();
   const sessionId = params.get('session_id') || '';
   const token = params.get('token') || '';
+  const currentUser = useSelector(selectCurrentUser);
   const [loading, setLoading] = useState(true);
   const [mine, setMine] = useState<Interview | null>(null);
   const [qr, setQr] = useState<string>();
@@ -19,12 +22,13 @@ const CheckinPage: React.FC = () => {
       sessionId ? getSessionQRCode(sessionId).catch(() => undefined) : Promise.resolve(undefined),
     ])
       .then(([list, code]) => {
-        const hit = list.find((i) => !sessionId || i.session_id === sessionId);
+        const own = list.filter((i) => !currentUser || i.applicant.id === currentUser.id);
+        const hit = own.find((i) => !sessionId || i.session_id === sessionId);
         setMine(hit || null);
         if (code) setQr(code.png_base64);
       })
       .finally(() => setLoading(false));
-  }, [sessionId]);
+  }, [sessionId, currentUser]);
 
   const title = useMemo(() => (mine ? `${mine.applicant.name} · ${mine.session_title || '面试'}` : '面试签到'), [mine]);
 

--- a/frontend/src/pages/interview/CheckinPage.tsx
+++ b/frontend/src/pages/interview/CheckinPage.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Button, Card, Result, Space, Spin, message } from 'antd';
+import { checkinInterview, getMyInterviews, getSessionQRCode } from '@/api/interview';
+import type { Interview } from '@/types/api';
+
+const CheckinPage: React.FC = () => {
+  const [params] = useSearchParams();
+  const sessionId = params.get('session_id') || '';
+  const token = params.get('token') || '';
+  const [loading, setLoading] = useState(true);
+  const [mine, setMine] = useState<Interview | null>(null);
+  const [qr, setQr] = useState<string>();
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      getMyInterviews(),
+      sessionId ? getSessionQRCode(sessionId).catch(() => undefined) : Promise.resolve(undefined),
+    ])
+      .then(([list, code]) => {
+        const hit = list.find((i) => !sessionId || i.session_id === sessionId);
+        setMine(hit || null);
+        if (code) setQr(code.png_base64);
+      })
+      .finally(() => setLoading(false));
+  }, [sessionId]);
+
+  const title = useMemo(() => (mine ? `${mine.applicant.name} · ${mine.session_title || '面试'}` : '面试签到'), [mine]);
+
+  const doCheckin = async () => {
+    if (!mine) return;
+    await checkinInterview(mine.id, token || undefined);
+    message.success('签到成功');
+    setDone(true);
+  };
+
+  if (loading) return <Spin />;
+
+  if (done) {
+    return <Result status="success" title="签到成功" subTitle={title} />;
+  }
+
+  return (
+    <Card title="面试签到">
+      {!mine ? (
+        <Result status="info" title="没有待签到的面试" />
+      ) : (
+        <Space direction="vertical" size={16} style={{ width: '100%' }}>
+          <div>{title}</div>
+          <div>地点：{mine.location || '-'}</div>
+          <div>预约：{mine.scheduled_time || '待定'}</div>
+          {qr && (
+            <img alt="签到二维码" src={`data:image/png;base64,${qr}`} style={{ width: 220 }} />
+          )}
+          <Button type="primary" disabled={mine.status !== 0} onClick={() => void doCheckin()}>
+            {mine.status === 0 ? '手动签到' : '已签到或不可签到'}
+          </Button>
+        </Space>
+      )}
+    </Card>
+  );
+};
+
+export default CheckinPage;

--- a/frontend/src/pages/interview/MyInterviewPage.tsx
+++ b/frontend/src/pages/interview/MyInterviewPage.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Card, Table, Tabs } from 'antd';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { getMyInterviews } from '@/api/interview';
+import type { Interview, InterviewRecordStatus } from '@/types/api';
+import { InterviewStatusMap, ResultMap } from './meta';
+
+const groups: Array<{ key: string; label: string; status?: InterviewRecordStatus }> = [
+  { key: 'pending', label: '待面试', status: 0 },
+  { key: 'ongoing', label: '进行中', status: 2 },
+  { key: 'done', label: '已完成', status: 3 },
+  { key: 'all', label: '全部' },
+];
+
+const MyInterviewPage: React.FC = () => {
+  const [tab, setTab] = useState('pending');
+  const [list, setList] = useState<Interview[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const g = groups.find((x) => x.key === tab);
+      setList(await getMyInterviews(g?.status));
+    } finally {
+      setLoading(false);
+    }
+  }, [tab]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  return (
+    <Card title="我的面试">
+      <Tabs
+        activeKey={tab}
+        onChange={setTab}
+        items={groups.map((g) => ({
+          key: g.key,
+          label: g.label,
+          children: (
+            <Table
+              rowKey="id"
+              loading={loading}
+              dataSource={list}
+              columns={[
+                { title: '面试者', render: (_, r) => r.applicant.name },
+                { title: '场次', dataIndex: 'session_title' },
+                { title: '地点', dataIndex: 'location' },
+                { title: '预约时间', dataIndex: 'scheduled_time' },
+                { title: '面试官', render: (_, r) => r.evaluators.map((e) => e.name).join('、') || '-' },
+                { title: '状态', dataIndex: 'status', render: (v: number) => <StatusTag status={v} mapping={InterviewStatusMap} /> },
+                { title: '结果', dataIndex: 'result', render: (v: number) => <StatusTag status={v} mapping={ResultMap} /> },
+                { title: '得分', dataIndex: 'score', render: (v?: number) => (v == null ? '-' : v) },
+              ]}
+            />
+          ),
+        }))}
+      />
+    </Card>
+  );
+};
+
+export default MyInterviewPage;

--- a/frontend/src/pages/interview/ScorePage.tsx
+++ b/frontend/src/pages/interview/ScorePage.tsx
@@ -1,0 +1,164 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Button, Card, Descriptions, Form, Input, InputNumber, Modal, Space, Table, message,
+} from 'antd';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { usePermission } from '@/hooks/usePermission';
+import {
+  createDimension, deleteDimension, endInterview, getDimensions, getEvaluationSummary,
+  getInterviewList, startInterview, submitEvaluations, submitInterviewResult, updateDimension,
+} from '@/api/interview';
+import type { EvaluationDimension, EvaluationSummary, Interview } from '@/types/api';
+import { InterviewStatusMap, ResultMap } from './meta';
+
+const ScorePage: React.FC = () => {
+  const canEval = usePermission('interview:evaluate');
+  const canManage = usePermission('interview:manage');
+  const [list, setList] = useState<Interview[]>([]);
+  const [dims, setDims] = useState<EvaluationDimension[]>([]);
+  const [current, setCurrent] = useState<Interview | null>(null);
+  const [summary, setSummary] = useState<EvaluationSummary | null>(null);
+  const [form] = Form.useForm();
+
+  const load = useCallback(async () => {
+    const [iv, d] = await Promise.all([
+      getInterviewList({ page: 1, page_size: 50 }),
+      getDimensions(),
+    ]);
+    setList(iv.list);
+    setDims(d);
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const openScore = async (record: Interview) => {
+    setCurrent(record);
+    const s = await getEvaluationSummary(record.id);
+    setSummary(s);
+    form.setFieldsValue({
+      items: dims.map((d) => ({ dimension: d.name, score: undefined, comment: '' })),
+    });
+  };
+
+  return (
+    <Card title="面试评分">
+      <Table
+        rowKey="id"
+        dataSource={list}
+        columns={[
+          { title: '面试者', render: (_, r) => r.applicant.name },
+          { title: '场次', dataIndex: 'session_title' },
+          { title: '状态', dataIndex: 'status', render: (v: number) => <StatusTag status={v} mapping={InterviewStatusMap} /> },
+          { title: '得分', dataIndex: 'score', render: (v?: number) => (v == null ? '-' : v) },
+          { title: '结果', dataIndex: 'result', render: (v: number) => <StatusTag status={v} mapping={ResultMap} /> },
+          {
+            title: '操作',
+            render: (_, r) => (
+              <Space>
+                {canEval && r.status === 1 && <Button type="link" size="small" onClick={() => startInterview(r.id).then(load)}>开始</Button>}
+                {canEval && r.status === 2 && <Button type="link" size="small" onClick={() => endInterview(r.id).then(load)}>结束</Button>}
+                {canEval && (r.status === 2 || r.status === 3) && (
+                  <Button type="link" size="small" onClick={() => void openScore(r)}>评分</Button>
+                )}
+                {canManage && r.status === 3 && r.result === 0 && (
+                  <Button type="link" size="small" onClick={() => {
+                    Modal.confirm({
+                      title: '提交结果',
+                      content: (
+                        <SelectResult onPick={async (result, comment) => {
+                          await submitInterviewResult(r.id, result, comment);
+                          message.success('结果已提交');
+                          await load();
+                        }} />
+                      ),
+                      okButtonProps: { style: { display: 'none' } },
+                    });
+                  }}>出结果</Button>
+                )}
+              </Space>
+            ),
+          },
+        ]}
+      />
+      {canManage && (
+        <Card size="small" title="评分维度" style={{ marginTop: 16 }}>
+          <Space wrap>
+            {dims.map((d) => (
+              <span key={d.id}>
+                {d.name}（权重 {d.weight}，满分 {d.max_score}）
+                <Button type="link" size="small" onClick={() => {
+                  const name = window.prompt('维度名称', d.name);
+                  if (!name) return;
+                  void updateDimension(d.id, { name }).then(load);
+                }}>改</Button>
+                <Button type="link" size="small" danger onClick={() => deleteDimension(d.id).then(load)}>删</Button>
+              </span>
+            ))}
+            <Button size="small" onClick={() => {
+              const name = window.prompt('新维度名称');
+              if (!name) return;
+              void createDimension({ name, weight: 0.2, max_score: 100 }).then(load);
+            }}>新增维度</Button>
+          </Space>
+        </Card>
+      )}
+      <Modal
+        title={current ? `评分 · ${current.applicant.name}` : '评分'}
+        open={!!current}
+        onCancel={() => setCurrent(null)}
+        onOk={() => form.submit()}
+        width={720}
+      >
+        {summary && (
+          <Descriptions size="small" column={3} style={{ marginBottom: 12 }}>
+            <Descriptions.Item label="平均分">{summary.average_score}</Descriptions.Item>
+            <Descriptions.Item label="加权分">{summary.weighted_score}</Descriptions.Item>
+            <Descriptions.Item label="已评人数">{summary.evaluations.length}</Descriptions.Item>
+          </Descriptions>
+        )}
+        <Form
+          form={form}
+          onFinish={async (values: { items: Array<{ dimension: string; score: number; comment: string }> }) => {
+            if (!current) return;
+            await submitEvaluations(current.id, values.items);
+            message.success('评分已提交');
+            setCurrent(null);
+            await load();
+          }}
+        >
+          <Form.List name="items">
+            {(fields) => fields.map((field) => (
+              <Space key={field.key} align="baseline" style={{ display: 'flex', marginBottom: 8 }}>
+                <Form.Item {...field} name={[field.name, 'dimension']} rules={[{ required: true }]}>
+                  <Input disabled style={{ width: 120 }} />
+                </Form.Item>
+                <Form.Item {...field} name={[field.name, 'score']} rules={[{ required: true, message: '请打分' }]}>
+                  <InputNumber min={0} max={100} />
+                </Form.Item>
+                <Form.Item {...field} name={[field.name, 'comment']}>
+                  <Input placeholder="评语" style={{ width: 280 }} />
+                </Form.Item>
+              </Space>
+            ))}
+          </Form.List>
+        </Form>
+      </Modal>
+    </Card>
+  );
+};
+
+const SelectResult: React.FC<{ onPick: (r: 1 | 2 | 3, c: string) => Promise<void> }> = ({ onPick }) => {
+  const [comment, setComment] = useState('');
+  return (
+    <Space direction="vertical" style={{ width: '100%', marginTop: 8 }}>
+      <Input.TextArea rows={2} placeholder="评语" value={comment} onChange={(e) => setComment(e.target.value)} />
+      <Space>
+        <Button type="primary" onClick={() => void onPick(1, comment)}>通过</Button>
+        <Button danger onClick={() => void onPick(2, comment)}>不通过</Button>
+        <Button onClick={() => void onPick(3, comment)}>待定</Button>
+      </Space>
+    </Space>
+  );
+};
+
+export default ScorePage;

--- a/frontend/src/pages/interview/SessionFormModal.tsx
+++ b/frontend/src/pages/interview/SessionFormModal.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect } from 'react';
+import { DatePicker, Form, Input, InputNumber, Modal, Select } from 'antd';
+import dayjs from 'dayjs';
+import type { InterviewSession, MemberDepartmentOption } from '@/types/api';
+
+interface Props {
+  open: boolean;
+  editing: InterviewSession | null;
+  departments: MemberDepartmentOption[];
+  onCancel: () => void;
+  onSubmit: (values: Record<string, unknown>) => Promise<void>;
+}
+
+const SessionFormModal: React.FC<Props> = ({ open, editing, departments, onCancel, onSubmit }) => {
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    if (!open) return;
+    if (editing) {
+      form.setFieldsValue({
+        ...editing,
+        time_range: [dayjs(editing.start_time), dayjs(editing.end_time)],
+      });
+    } else {
+      form.resetFields();
+      form.setFieldsValue({ round: 1, max_candidates: 20 });
+    }
+  }, [open, editing, form]);
+
+  return (
+    <Modal
+      title={editing ? '编辑场次' : '新建场次'}
+      open={open}
+      onCancel={onCancel}
+      onOk={() => form.submit()}
+      destroyOnClose
+    >
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={async (values) => {
+          const range = values.time_range as [dayjs.Dayjs, dayjs.Dayjs];
+          await onSubmit({
+            title: values.title,
+            round: values.round,
+            department_id: values.department_id,
+            start_time: range[0].toISOString(),
+            end_time: range[1].toISOString(),
+            location: values.location,
+            online_link: values.online_link,
+            max_candidates: values.max_candidates,
+            description: values.description,
+          });
+        }}
+      >
+        <Form.Item name="title" label="场次名称" rules={[{ required: true, message: '请输入名称' }]}>
+          <Input maxLength={200} />
+        </Form.Item>
+        <Form.Item name="round" label="轮次" rules={[{ required: true }]}>
+          <InputNumber min={1} max={20} style={{ width: '100%' }} />
+        </Form.Item>
+        <Form.Item name="department_id" label="部门">
+          <Select
+            allowClear
+            options={departments.map((d) => ({ label: d.name, value: d.id }))}
+            placeholder="可选"
+          />
+        </Form.Item>
+        <Form.Item name="time_range" label="时间" rules={[{ required: true, message: '请选择时间' }]}>
+          <DatePicker.RangePicker showTime style={{ width: '100%' }} />
+        </Form.Item>
+        <Form.Item name="location" label="地点">
+          <Input />
+        </Form.Item>
+        <Form.Item name="online_link" label="线上链接">
+          <Input />
+        </Form.Item>
+        <Form.Item name="max_candidates" label="最大人数" rules={[{ required: true }]}>
+          <InputNumber min={1} max={500} style={{ width: '100%' }} />
+        </Form.Item>
+        <Form.Item name="description" label="说明">
+          <Input.TextArea rows={3} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default SessionFormModal;

--- a/frontend/src/pages/interview/SessionPage.tsx
+++ b/frontend/src/pages/interview/SessionPage.tsx
@@ -1,0 +1,226 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Button, Card, Image, Input, Modal, Select, Space, Table, Tabs, message,
+} from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { usePermission } from '@/hooks/usePermission';
+import { getMemberDepartments, getApplicationList } from '@/api/member';
+import { getUserList } from '@/api/user';
+import {
+  assignEvaluators, createInterview, createSession, deleteSession, endSession,
+  getInterviewList, getSessionList, getSessionQRCode, startSession, updateSession,
+} from '@/api/interview';
+import type {
+  Interview, InterviewSession, InterviewSessionStatus, MemberApplication, MemberDepartmentOption,
+} from '@/types/api';
+import { InterviewStatusMap, ResultMap, SessionStatusMap } from './meta';
+import SessionFormModal from './SessionFormModal';
+
+const SessionPage: React.FC = () => {
+  const canManage = usePermission('interview:manage');
+  const [sessions, setSessions] = useState<InterviewSession[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState<InterviewSessionStatus | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<InterviewSession | null>(null);
+  const [departments, setDepartments] = useState<MemberDepartmentOption[]>([]);
+  const [current, setCurrent] = useState<InterviewSession | null>(null);
+  const [records, setRecords] = useState<Interview[]>([]);
+  const [qr, setQr] = useState<string>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getSessionList({ page, page_size: 10, status });
+      setSessions(res.list);
+      setTotal(res.total);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, status]);
+
+  useEffect(() => {
+    void load();
+    void getMemberDepartments().then(setDepartments).catch(() => undefined);
+  }, [load]);
+
+  const loadRecords = async (session: InterviewSession) => {
+    setCurrent(session);
+    const res = await getInterviewList({ session_id: session.id, page: 1, page_size: 50 });
+    setRecords(res.list);
+  };
+
+  const sessionColumns: ColumnsType<InterviewSession> = [
+    { title: '名称', dataIndex: 'title' },
+    { title: '轮次', dataIndex: 'round', width: 70 },
+    { title: '部门', dataIndex: 'department_name', width: 100, render: (v?: string) => v || '-' },
+    { title: '地点', dataIndex: 'location' },
+    { title: '开始', dataIndex: 'start_time', width: 170 },
+    { title: '人数', key: 'n', width: 90, render: (_, r) => `${r.candidate_count}/${r.max_candidates}` },
+    { title: '状态', dataIndex: 'status', width: 90, render: (v: number) => <StatusTag status={v} mapping={SessionStatusMap} /> },
+    {
+      title: '操作',
+      width: 280,
+      render: (_, record) => (
+        <Space wrap>
+          <Button type="link" size="small" onClick={() => void loadRecords(record)}>面试者</Button>
+          {canManage && record.status === 0 && (
+            <Button type="link" size="small" onClick={() => { setEditing(record); setFormOpen(true); }}>编辑</Button>
+          )}
+          {canManage && record.status === 0 && (
+            <Button type="link" size="small" onClick={() => startSession(record.id).then(load)}>开始</Button>
+          )}
+          {canManage && record.status === 1 && (
+            <Button type="link" size="small" onClick={() => endSession(record.id).then(load)}>结束</Button>
+          )}
+          {canManage && (
+            <Button type="link" size="small" onClick={() => getSessionQRCode(record.id).then((q) => setQr(q.png_base64))}>二维码</Button>
+          )}
+          {canManage && (record.status === 0 || record.status === 3) && (
+            <Button type="link" size="small" danger onClick={() => {
+              Modal.confirm({ title: '删除该场次？', onOk: () => deleteSession(record.id).then(load) });
+            }}>删除</Button>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  const importApplicant = async () => {
+    if (!current) return;
+    const apps = await getApplicationList({ page: 1, page_size: 50, status: 2 });
+    let selected = '';
+    Modal.confirm({
+      title: '从入会申请导入',
+      content: (
+        <Select
+          style={{ width: '100%', marginTop: 12 }}
+          placeholder="选择面试中的申请"
+          options={apps.list.map((a: MemberApplication) => ({
+            label: `${a.real_name}（${a.student_no}）`,
+            value: a.id,
+          }))}
+          onChange={(v) => { selected = v; }}
+        />
+      ),
+      onOk: async () => {
+        if (!selected) return;
+        await createInterview({ session_id: current.id, application_id: selected });
+        message.success('已导入');
+        await loadRecords(current);
+        await load();
+      },
+    });
+  };
+
+  const assign = async (record: Interview) => {
+    const users = await getUserList({ page: 1, page_size: 50 });
+    let ids: string[] = record.evaluators.map((e) => e.id);
+    Modal.confirm({
+      title: '分配面试官',
+      content: (
+        <Select
+          mode="multiple"
+          style={{ width: '100%', marginTop: 12 }}
+          defaultValue={ids}
+          options={users.list.map((u) => ({ label: u.real_name || u.username, value: u.id }))}
+          onChange={(v) => { ids = v; }}
+        />
+      ),
+      onOk: async () => {
+        await assignEvaluators(record.id, ids);
+        message.success('已分配并通知');
+        if (current) await loadRecords(current);
+      },
+    });
+  };
+
+  return (
+    <Card title="面试安排">
+      <Tabs
+        items={[
+          {
+            key: 'sessions',
+            label: '场次管理',
+            children: (
+              <>
+                <Space style={{ marginBottom: 16 }}>
+                  <Select
+                    allowClear
+                    placeholder="状态"
+                    style={{ width: 140 }}
+                    value={status}
+                    onChange={setStatus}
+                    options={Object.entries(SessionStatusMap).map(([k, v]) => ({ value: Number(k), label: v.text }))}
+                  />
+                  {canManage && (
+                    <Button type="primary" icon={<PlusOutlined />} onClick={() => { setEditing(null); setFormOpen(true); }}>
+                      新建场次
+                    </Button>
+                  )}
+                </Space>
+                <Table
+                  rowKey="id"
+                  loading={loading}
+                  columns={sessionColumns}
+                  dataSource={sessions}
+                  pagination={{ current: page, total, onChange: setPage }}
+                />
+              </>
+            ),
+          },
+          {
+            key: 'records',
+            label: current ? `面试者 · ${current.title}` : '面试者',
+            children: (
+              <>
+                <Space style={{ marginBottom: 16 }}>
+                  <Input disabled value={current ? current.title : '请先在场次中选择'} style={{ width: 240 }} />
+                  {canManage && current && <Button onClick={() => void importApplicant()}>导入申请</Button>}
+                </Space>
+                <Table
+                  rowKey="id"
+                  dataSource={records}
+                  columns={[
+                    { title: '面试者', render: (_, r) => r.applicant.name },
+                    { title: '学号', dataIndex: 'student_no' },
+                    { title: '面试官', render: (_, r) => r.evaluators.map((e) => e.name).join('、') || '-' },
+                    { title: '状态', dataIndex: 'status', render: (v: number) => <StatusTag status={v} mapping={InterviewStatusMap} /> },
+                    { title: '结果', dataIndex: 'result', render: (v: number) => <StatusTag status={v} mapping={ResultMap} /> },
+                    ...(canManage ? [{
+                      title: '操作',
+                      render: (_: unknown, r: Interview) => (
+                        <Button type="link" size="small" onClick={() => void assign(r)}>分配面试官</Button>
+                      ),
+                    }] : []),
+                  ]}
+                />
+              </>
+            ),
+          },
+        ]}
+      />
+      <SessionFormModal
+        open={formOpen}
+        editing={editing}
+        departments={departments}
+        onCancel={() => setFormOpen(false)}
+        onSubmit={async (values) => {
+          if (editing) await updateSession(editing.id, values);
+          else await createSession(values as never);
+          setFormOpen(false);
+          await load();
+        }}
+      />
+      <Modal title="签到二维码" open={!!qr} footer={null} onCancel={() => setQr(undefined)}>
+        {qr && <Image src={`data:image/png;base64,${qr}`} alt="签到二维码" />}
+      </Modal>
+    </Card>
+  );
+};
+
+export default SessionPage;

--- a/frontend/src/pages/interview/SessionPage.tsx
+++ b/frontend/src/pages/interview/SessionPage.tsx
@@ -90,27 +90,49 @@ const SessionPage: React.FC = () => {
     },
   ];
 
-  const importApplicant = async () => {
+  const importApplicant = async (mode: 'application' | 'user') => {
     if (!current) return;
-    const apps = await getApplicationList({ page: 1, page_size: 50, status: 2 });
     let selected = '';
+    if (mode === 'application') {
+      const apps = await getApplicationList({ page: 1, page_size: 50 });
+      Modal.confirm({
+        title: '从入会申请导入',
+        content: (
+          <Select
+            style={{ width: '100%', marginTop: 12 }}
+            placeholder="选择申请"
+            options={apps.list.map((a: MemberApplication) => ({
+              label: `${a.real_name}（${a.student_no}）`,
+              value: a.id,
+            }))}
+            onChange={(v) => { selected = v; }}
+          />
+        ),
+        onOk: async () => {
+          if (!selected) return;
+          await createInterview({ session_id: current.id, application_id: selected });
+          message.success('已导入');
+          await loadRecords(current);
+          await load();
+        },
+      });
+      return;
+    }
+    const users = await getUserList({ page: 1, page_size: 50 });
     Modal.confirm({
-      title: '从入会申请导入',
+      title: '手动添加面试者',
       content: (
         <Select
           style={{ width: '100%', marginTop: 12 }}
-          placeholder="选择面试中的申请"
-          options={apps.list.map((a: MemberApplication) => ({
-            label: `${a.real_name}（${a.student_no}）`,
-            value: a.id,
-          }))}
+          placeholder="选择用户"
+          options={users.list.map((u) => ({ label: u.real_name || u.username, value: u.id }))}
           onChange={(v) => { selected = v; }}
         />
       ),
       onOk: async () => {
         if (!selected) return;
-        await createInterview({ session_id: current.id, application_id: selected });
-        message.success('已导入');
+        await createInterview({ session_id: current.id, applicant_id: selected });
+        message.success('已添加');
         await loadRecords(current);
         await load();
       },
@@ -180,7 +202,12 @@ const SessionPage: React.FC = () => {
               <>
                 <Space style={{ marginBottom: 16 }}>
                   <Input disabled value={current ? current.title : '请先在场次中选择'} style={{ width: 240 }} />
-                  {canManage && current && <Button onClick={() => void importApplicant()}>导入申请</Button>}
+                  {canManage && current && (
+                    <>
+                      <Button onClick={() => void importApplicant('application')}>导入申请</Button>
+                      <Button onClick={() => void importApplicant('user')}>手动添加</Button>
+                    </>
+                  )}
                 </Space>
                 <Table
                   rowKey="id"

--- a/frontend/src/pages/interview/StatsPage.tsx
+++ b/frontend/src/pages/interview/StatsPage.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Col, Empty, Row, Spin, Statistic } from 'antd';
+import ReactECharts from 'echarts-for-react';
+import { getInterviewStats } from '@/api/interview';
+import type { InterviewStats } from '@/types/api';
+
+const StatsPage: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [stats, setStats] = useState<InterviewStats | null>(null);
+
+  useEffect(() => {
+    getInterviewStats()
+      .then(setStats)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <Spin />;
+  if (!stats) return <Empty />;
+
+  return (
+    <Card title="面试统计">
+      <Row gutter={16} style={{ marginBottom: 16 }}>
+        <Col span={6}><Statistic title="总场次/记录" value={stats.total} /></Col>
+        <Col span={6}><Statistic title="通过" value={stats.pass_count} /></Col>
+        <Col span={6}><Statistic title="不通过" value={stats.fail_count} /></Col>
+        <Col span={6}><Statistic title="通过率" value={stats.pass_rate} suffix="%" /></Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Card size="small" title="评分分布">
+            {stats.score_buckets.every((b) => b.count === 0) ? (
+              <Empty />
+            ) : (
+              <ReactECharts
+                style={{ height: 300 }}
+                option={{
+                  tooltip: { trigger: 'axis' },
+                  xAxis: { type: 'category', data: stats.score_buckets.map((b) => b.range) },
+                  yAxis: { type: 'value', minInterval: 1 },
+                  series: [{ type: 'bar', data: stats.score_buckets.map((b) => b.count) }],
+                }}
+              />
+            )}
+          </Card>
+        </Col>
+        <Col span={12}>
+          <Card size="small" title="各部门面试人数">
+            {stats.by_department.length === 0 ? (
+              <Empty />
+            ) : (
+              <ReactECharts
+                style={{ height: 300 }}
+                option={{
+                  tooltip: { trigger: 'axis' },
+                  xAxis: { type: 'category', data: stats.by_department.map((d) => d.department) },
+                  yAxis: { type: 'value', minInterval: 1 },
+                  series: [
+                    { name: '人数', type: 'bar', data: stats.by_department.map((d) => d.count) },
+                    { name: '通过', type: 'bar', data: stats.by_department.map((d) => d.pass_count) },
+                  ],
+                }}
+              />
+            )}
+          </Card>
+        </Col>
+      </Row>
+    </Card>
+  );
+};
+
+export default StatsPage;

--- a/frontend/src/pages/interview/meta.ts
+++ b/frontend/src/pages/interview/meta.ts
@@ -1,0 +1,24 @@
+import type { StatusMap } from '@/types/common';
+
+export const SessionStatusMap: StatusMap = {
+  0: { color: 'default', text: '待开始' },
+  1: { color: 'processing', text: '进行中' },
+  2: { color: 'success', text: '已结束' },
+  3: { color: 'error', text: '已取消' },
+};
+
+export const InterviewStatusMap: StatusMap = {
+  0: { color: 'default', text: '待面试' },
+  1: { color: 'cyan', text: '已签到' },
+  2: { color: 'processing', text: '面试中' },
+  3: { color: 'success', text: '已完成' },
+  4: { color: 'warning', text: '缺席' },
+  5: { color: 'error', text: '已取消' },
+};
+
+export const ResultMap: StatusMap = {
+  0: { color: 'default', text: '未出结果' },
+  1: { color: 'success', text: '通过' },
+  2: { color: 'error', text: '不通过' },
+  3: { color: 'warning', text: '待定' },
+};

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -19,6 +19,11 @@ const AuditList = lazy(() => import('@/pages/system/audit/AuditList'));
 const FileList = lazy(() => import('@/pages/file/FileList'));
 const ApplicationPage = lazy(() => import('@/pages/member/application/ApplicationPage'));
 const ProfilePage = lazy(() => import('@/pages/member/profile/ProfilePage'));
+const InterviewSessionPage = lazy(() => import('@/pages/interview/SessionPage'));
+const InterviewScorePage = lazy(() => import('@/pages/interview/ScorePage'));
+const InterviewMyPage = lazy(() => import('@/pages/interview/MyInterviewPage'));
+const InterviewStatsPage = lazy(() => import('@/pages/interview/StatsPage'));
+const InterviewCheckinPage = lazy(() => import('@/pages/interview/CheckinPage'));
 const WorkflowDesigner = lazy(() => import('@/pages/workflow/designer/DesignerPage'));
 const Forbidden = lazy(() => import('@/pages/error/Forbidden'));
 const NotFound = lazy(() => import('@/pages/error/NotFound'));
@@ -138,13 +143,28 @@ const routes: AppRouteObject[] = [
         children: [
           {
             path: 'list',
-            element: <div style={{ padding: 24 }}>面试安排（开发中）</div>,
-            meta: { title: '面试安排' },
+            element: lazyGuarded(InterviewSessionPage, 'interview:read'),
+            meta: { title: '面试安排', permission: 'interview:read' },
           },
           {
-            path: 'flow',
-            element: <div style={{ padding: 24 }}>面试流程（开发中）</div>,
-            meta: { title: '面试流程' },
+            path: 'score',
+            element: lazyGuarded(InterviewScorePage, 'interview:evaluate'),
+            meta: { title: '面试评分', permission: 'interview:evaluate' },
+          },
+          {
+            path: 'my',
+            element: lazyWrap(InterviewMyPage),
+            meta: { title: '我的面试' },
+          },
+          {
+            path: 'stats',
+            element: lazyGuarded(InterviewStatsPage, 'interview:read'),
+            meta: { title: '面试统计', permission: 'interview:read' },
+          },
+          {
+            path: 'checkin',
+            element: lazyWrap(InterviewCheckinPage),
+            meta: { title: '面试签到' },
           },
         ],
       },

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -376,64 +376,136 @@ export interface MemberDepartmentOption {
 // 面试
 // ============================================================
 
-export type InterviewStatus = 0 | 1 | 2 | 3;
-// 0=待安排 1=已安排 2=进行中 3=已完成
+export type InterviewSessionStatus = 0 | 1 | 2 | 3;
+// 0待开始 1进行中 2已结束 3已取消
 
-export interface Interview {
+export type InterviewRecordStatus = 0 | 1 | 2 | 3 | 4 | 5;
+// 0待面试 1已签到 2面试中 3已完成 4缺席 5已取消
+
+export type InterviewResult = 0 | 1 | 2 | 3;
+// 0未出 1通过 2不通过 3待定
+
+export interface InterviewPerson {
   id: string;
-  application_id: string;
-  applicant_name: string;
-  round: number; // 第几轮
-  type: number; // 1=技术面 2=综合面 3=HR面
-  status: InterviewStatus;
-  interviewer_ids: string[];
-  interviewer_names: string[];
-  scheduled_at?: string;
-  location?: string;
-  duration?: number; // 分钟
-  score?: number;
-  result?: string;
-  notes?: string;
+  name: string;
+}
+
+export interface InterviewSession {
+  id: string;
+  title: string;
+  round: number;
+  department_id?: string;
+  department_name?: string;
+  start_time: string;
+  end_time: string;
+  location: string;
+  online_link?: string;
+  status: InterviewSessionStatus;
+  max_candidates: number;
+  description: string;
+  candidate_count: number;
   created_at: string;
   updated_at: string;
 }
 
-export interface InterviewEvaluation {
+export interface Interview {
   id: string;
-  interview_id: string;
-  interviewer_id: string;
-  interviewer_name: string;
-  score: number;
-  comment: string;
-  recommendation: number; // 1=强烈推荐 2=推荐 3=待定 4=不推荐
+  session_id?: string;
+  session_title?: string;
+  applicant: InterviewPerson;
+  student_no?: string;
+  application_id?: string;
+  status: InterviewRecordStatus;
+  scheduled_time?: string;
+  actual_start_time?: string;
+  actual_end_time?: string;
+  result: InterviewResult;
+  result_comment?: string;
+  location?: string;
+  duration?: number;
+  score?: number;
+  evaluators: InterviewPerson[];
+  department_name?: string;
   created_at: string;
+  updated_at: string;
+}
+
+export interface InterviewQRCode {
+  session_id: string;
+  token: string;
+  checkin_path: string;
+  png_base64: string;
+}
+
+export interface EvaluationDimension {
+  id: string;
+  name: string;
+  weight: number;
+  max_score: number;
+  sort_order: number;
+}
+
+export interface DimensionScore {
+  dimension: string;
+  score: number;
+  comment?: string;
+}
+
+export interface EvaluatorScores {
+  evaluator: InterviewPerson;
+  scores: DimensionScore[];
+  total_score: number;
+}
+
+export interface EvaluationSummary {
+  interview_id: string;
+  applicant: InterviewPerson;
+  evaluations: EvaluatorScores[];
+  average_score: number;
+  weighted_score: number;
+}
+
+export interface InterviewStats {
+  total: number;
+  pass_count: number;
+  fail_count: number;
+  pending_count: number;
+  pass_rate: number;
+  score_buckets: Array<{ range: string; count: number }>;
+  by_department: Array<{ department: string; count: number; pass_count: number }>;
+}
+
+export interface CreateSessionParams {
+  title: string;
+  round: number;
+  department_id?: string;
+  start_time: string;
+  end_time: string;
+  location?: string;
+  online_link?: string;
+  max_candidates: number;
+  description?: string;
 }
 
 export interface CreateInterviewParams {
-  application_id: string;
-  round: number;
-  type: number;
-  interviewer_ids: string[];
-  scheduled_at?: string;
+  session_id: string;
+  applicant_id?: string;
+  application_id?: string;
+  scheduled_time?: string;
   location?: string;
   duration?: number;
 }
 
-export interface UpdateInterviewParams {
-  status?: InterviewStatus;
-  interviewer_ids?: string[];
-  scheduled_at?: string;
-  location?: string;
-  duration?: number;
-  result?: string;
-  notes?: string;
+export interface ListSessionParams extends ListParams {
+  status?: InterviewSessionStatus;
+  department_id?: string;
+  round?: number;
 }
 
 export interface ListInterviewParams extends ListParams {
-  status?: InterviewStatus;
-  round?: number;
-  type?: number;
-  application_id?: string;
+  session_id?: string;
+  status?: InterviewRecordStatus;
+  result?: InterviewResult;
 }
 
 // ============================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 Issue #7 面试管理：场次 CRUD 与状态机、从入会申请导入或手动添加面试者、多选分配面试官并通知、签到二维码、按维度评分（去重/范围校验）、多官平均 + 加权汇总、提交结果后通知并回写入会申请、统计 API 与前端页面。

复用 `000011` 的 `interviews` / `interview_interviewers` / `interview_evaluations`，**不改已有列名**。新迁移 `000021` 补场次表、维度表、`session_id`/`applicant_id`/`result_code` 等列，以及 `interview:manage` / `interview:evaluate`。

## 关联 Issue

Related to #7（合入后再 Closes + `status:completed`）

## 测试方式

1. 跑 `000021` 迁移，再 `make seed` 赋 `interview:manage` / `interview:evaluate` 和新模板
2. 登录 `admin/admin123`，打开「面试安排」新建场次 → 导入申请或手动添加 → 分配面试官
3. 开始场次，查看签到二维码；面试者到「面试签到」手动签到
4. 面试官在「面试评分」按维度打分；管理员提交通过/不通过
5. 「面试统计」查看通过率、评分分布、部门柱状图

本地已走通：场次列表、新建「浏览器验收二面」、二维码、评分维度、ECharts 统计、`test` 用户签到成功。CI 在 `89331ab` 全绿。

## 截图

| 页面 | 截图 |
|------|------|
| 面试安排 | [面试安排场次列表](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterview_session_list.webp) |
| 签到二维码 | [签到二维码](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterview_session_qrcode.webp) |
| 新建场次 | [新建场次成功](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterview_session_created.webp) |
| 面试评分 | [评分页与维度](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterview_score_page.webp) |
| 面试统计 | [统计图表](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterview_stats_charts.webp) |
| 签到成功 | [测试用户签到成功](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterview_checkin_success.webp) |

## 注意事项

- 时间列继续用 `scheduled_at`，API 对外 `scheduled_time`
- 面试官列继续用 `interviewer_id`，API 对外 `evaluator_id`
- 结果整型走 `result_code`；干事申请仅「面试中」才会被结果回写
- `000021` 删除旧 UNIQUE 时需先 `DROP CONSTRAINT`
- 部署后须跑迁移并 `make seed`

## 检查清单

- [x] 代码遵循项目开发规范
- [x] 已添加单元测试
- [x] 浏览器走查通过
- [x] CI 通过（最新小修复会再跑一轮）
- [x] 没有硬编码敏感信息


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

