### PR TITLE
feat(meeting): 会议管理 + 等权/加权投票 (#8)

### DIFF
--- a/TEAM_DEV_GUIDE.md
+++ b/TEAM_DEV_GUIDE.md
@@ -73,7 +73,7 @@ StarByte/
 │   │   ├── file/                     # 文件管理（空目录，待开发）
 │   │   ├── internship/               # 实习管理（空目录，待开发）
 │   │   ├── interview/                # 面试管理（#7）
-│   │   ├── meeting/                  # 会议管理（空目录，待开发）
+│   │   ├── meeting/                  # 会议管理 + 投票（#8）
 │   │   ├── member/                   # 入会申请 + 人员档案（#6）
 │   │   ├── notification/             # 通知系统（空目录，待开发）
 │   │   ├── stats/                    # 数据统计（空目录，待开发）
@@ -243,7 +243,7 @@ response.ErrorWithCode(c, 2002, "用户名或密码错误") // 自定义错误�
 | 5000-5999 | 审计日志 | 5001 审计日志不存在, 5002 导出格式不支持 |
 | 6000-6999 | 会员模块 | 6001 申请不存在, 6003 重复申请, 6004 档案不存在 |
 | 7000-7999 | 面试模块 | 7001 场次不存在, 7002 记录不存在, 7003 时间冲突 |
-| 8000-8999 | 会议模块 | 8001 会议不存在, 8002 投票已结束 |
+| 8000-8999 | 会议模块 | 8001 会议不存在, 8002 状态不允许, 8006 投票未开始或已结束 |
 | 9000-9999 | 任务模块 | 9001 任务不存在, 9002 无权操作 |
 | 10000-10999 | 实习模块 | 10001 实习不存在, 10002 无权操作 |
 | 11000-11999 | 统计模块 | 11001 提供者不存在, 11002 参数无效 |
@@ -927,8 +927,8 @@ AI 系统提示词（见 8.2 节）已包含强制变更检查步骤。当开发
 | Issue | 标题 | 模块 | 依赖 | 备注 |
 |-------|------|------|------|------|
 | [#6](https://github.com/Yogdunana/StarByte/issues/6) | 入会申请 + 人员档案 | fullstack | #1, #2, #4 | 完成（`000020` 补列；勿另起表） |
-| [#7](https://github.com/Yogdunana/StarByte/issues/7) | 面试管理 | fullstack | #1, #2, #6 | 进行中（`000021` 补列；勿另起表） |
-| [#8](https://github.com/Yogdunana/StarByte/issues/8) | 会议管理 + 投票系统（等权 + 加权） | fullstack | #1, #4 | 含加权；#51 已并入 |
+| [#7](https://github.com/Yogdunana/StarByte/issues/7) | 面试管理 | fullstack | #1, #2, #6 | 完成（`000021` 补列；勿另起表） |
+| [#8](https://github.com/Yogdunana/StarByte/issues/8) | 会议管理 + 投票系统（等权 + 加权） | fullstack | #1, #4 | 进行中（`000022` 补列；勿另起表） |
 | [#9](https://github.com/Yogdunana/StarByte/issues/9) | 任务流转 | fullstack | #1, #4 | |
 | [#10](https://github.com/Yogdunana/StarByte/issues/10) | IT 实习管理 | fullstack | #1, #4 | |
 | [#11](https://github.com/Yogdunana/StarByte/issues/11) | 数据统计与可视化报表 | fullstack | #1, #5 | |

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -21,6 +21,9 @@ import (
 	interviewHandler "github.com/Yogdunana/StarByte/backend/internal/interview/handler"
 	interviewRepo "github.com/Yogdunana/StarByte/backend/internal/interview/repo"
 	interviewService "github.com/Yogdunana/StarByte/backend/internal/interview/service"
+	meetingHandler "github.com/Yogdunana/StarByte/backend/internal/meeting/handler"
+	meetingRepo "github.com/Yogdunana/StarByte/backend/internal/meeting/repo"
+	meetingService "github.com/Yogdunana/StarByte/backend/internal/meeting/service"
 	memberHandler "github.com/Yogdunana/StarByte/backend/internal/member/handler"
 	memberRepo "github.com/Yogdunana/StarByte/backend/internal/member/repo"
 	memberService "github.com/Yogdunana/StarByte/backend/internal/member/service"
@@ -215,6 +218,15 @@ func main() {
 	ivSvc := interviewService.NewInterviewService(ivSessionRepo, ivRecordRepo, ivEvalRepo, ivNotifier, memberSvc)
 	ivH := interviewHandler.NewInterviewHandler(ivSvc)
 
+	// 会议管理 + 投票
+	mtMeetingRepo := meetingRepo.NewMeetingRepo(database.DB())
+	mtAgendaRepo := meetingRepo.NewAgendaRepo(database.DB())
+	mtAttendeeRepo := meetingRepo.NewAttendeeRepo(database.DB())
+	mtVoteRepo := meetingRepo.NewVoteRepo(database.DB())
+	mtNotifier := meetingService.NewNotifier(notifSvc)
+	mtSvc := meetingService.NewMeetingService(mtMeetingRepo, mtAgendaRepo, mtAttendeeRepo, mtVoteRepo, mtNotifier)
+	mtH := meetingHandler.NewMeetingHandler(mtSvc)
+
 	// 审计日志模块
 	auditR := auditRepo.NewAuditRepo(database.DB())
 	auditSvc := auditService.NewAuditService(auditR, &cfg.MinIO)
@@ -279,6 +291,9 @@ func main() {
 
 		// 面试管理（/interviews）
 		interviewHandler.RegisterRoutes(protected, ivH, cacheService, database.DB(), deptRepo)
+
+		// 会议管理 + 投票（/meetings, /votes, /system/vote-weight-config）
+		meetingHandler.RegisterRoutes(protected, mtH, cacheService, database.DB(), deptRepo)
 
 		// 审计日志模块路由（/system/audit-logs，audit:read / audit:export / audit:archive）
 		auditHandler.RegisterRoutes(protected, auditH, cacheService)

--- a/backend/internal/meeting/dto/meeting.go
+++ b/backend/internal/meeting/dto/meeting.go
@@ -1,0 +1,115 @@
+package dto
+
+import "time"
+
+type Person struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type CreateMeetingRequest struct {
+	Title       string    `json:"title" binding:"required,max=200"`
+	Description string    `json:"description"`
+	StartTime   time.Time `json:"start_time" binding:"required"`
+	EndTime     time.Time `json:"end_time" binding:"required"`
+	Location    string    `json:"location" binding:"max=200"`
+	OnlineLink  string    `json:"online_link" binding:"max=500"`
+	MeetingType int16     `json:"meeting_type" binding:"required,oneof=1 2 3"`
+	UserIDs     []string  `json:"user_ids"`
+}
+
+type UpdateMeetingRequest struct {
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	StartTime   *time.Time `json:"start_time"`
+	EndTime     *time.Time `json:"end_time"`
+	Location    *string    `json:"location"`
+	OnlineLink  *string    `json:"online_link"`
+	MeetingType *int16     `json:"meeting_type"`
+}
+
+type ListMeetingRequest struct {
+	Page      int    `form:"page"`
+	PageSize  int    `form:"page_size"`
+	Status    *int16 `form:"status"`
+	StartDate string `form:"start_date"`
+	EndDate   string `form:"end_date"`
+	Keyword   string `form:"keyword"`
+}
+
+type CancelMeetingRequest struct {
+	Reason string `json:"reason" binding:"max=500"`
+}
+
+type MinutesRequest struct {
+	Minutes string `json:"minutes" binding:"required"`
+}
+
+type MeetingResponse struct {
+	ID             string    `json:"id"`
+	Title          string    `json:"title"`
+	Description    string    `json:"description"`
+	StartTime      time.Time `json:"start_time"`
+	EndTime        time.Time `json:"end_time"`
+	Location       string    `json:"location"`
+	OnlineLink     string    `json:"online_link,omitempty"`
+	Organizer      Person    `json:"organizer"`
+	Status         int16     `json:"status"`
+	MeetingType    int16     `json:"meeting_type"`
+	Minutes        string    `json:"minutes,omitempty"`
+	CancelReason   string    `json:"cancel_reason,omitempty"`
+	AttendeeCount  int64     `json:"attendee_count"`
+	CheckedInCount int64     `json:"checked_in_count"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type QRCodeResponse struct {
+	MeetingID   string `json:"meeting_id"`
+	Token       string `json:"token"`
+	CheckinPath string `json:"checkin_path"`
+	PNGBase64   string `json:"png_base64"`
+}
+
+type CreateAgendaRequest struct {
+	Title     string `json:"title" binding:"required,max=200"`
+	Content   string `json:"content"`
+	Duration  int    `json:"duration"`
+	Presenter string `json:"presenter" binding:"max=100"`
+	SortOrder int    `json:"sort_order"`
+}
+
+type UpdateAgendaRequest struct {
+	Title     *string `json:"title"`
+	Content   *string `json:"content"`
+	Duration  *int    `json:"duration"`
+	Presenter *string `json:"presenter"`
+	SortOrder *int    `json:"sort_order"`
+}
+
+type SortAgendasRequest struct {
+	AgendaIDs []string `json:"agenda_ids" binding:"required,min=1"`
+}
+
+type AgendaResponse struct {
+	ID        string `json:"id"`
+	MeetingID string `json:"meeting_id"`
+	Title     string `json:"title"`
+	Content   string `json:"content"`
+	Duration  int    `json:"duration"`
+	SortOrder int    `json:"sort_order"`
+	Presenter string `json:"presenter"`
+}
+
+type AddAttendeesRequest struct {
+	UserIDs []string `json:"user_ids" binding:"required,min=1"`
+}
+
+type AttendeeResponse struct {
+	ID           string  `json:"id"`
+	UserID       string  `json:"user_id"`
+	Name         string  `json:"name"`
+	PositionCode string  `json:"position_code,omitempty"`
+	Attended     bool    `json:"attended"`
+	CheckedInAt  *string `json:"checked_in_at,omitempty"`
+}

--- a/backend/internal/meeting/dto/vote.go
+++ b/backend/internal/meeting/dto/vote.go
@@ -1,0 +1,78 @@
+package dto
+
+import "time"
+
+type VoteOptionInput struct {
+	Key   string `json:"key" binding:"required,max=64"`
+	Label string `json:"label" binding:"required,max=200"`
+}
+
+type CreateVoteRequest struct {
+	Title       string            `json:"title" binding:"required,max=200"`
+	Description string            `json:"description"`
+	VoteType    int16             `json:"vote_type" binding:"required,oneof=1 2"`
+	IsAnonymous bool              `json:"is_anonymous"`
+	Options     []VoteOptionInput `json:"options" binding:"required,min=2,dive"`
+	Duration    int               `json:"duration"`
+}
+
+type CastVoteRequest struct {
+	OptionKey string `json:"option_key" binding:"required"`
+}
+
+type VoteOptionResponse struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+}
+
+type VoteResponse struct {
+	ID          string               `json:"id"`
+	MeetingID   string               `json:"meeting_id"`
+	Title       string               `json:"title"`
+	Description string               `json:"description"`
+	VoteType    int16                `json:"vote_type"`
+	IsAnonymous bool                 `json:"is_anonymous"`
+	Options     []VoteOptionResponse `json:"options"`
+	Status      int16                `json:"status"`
+	StartTime   *time.Time           `json:"start_time,omitempty"`
+	EndTime     *time.Time           `json:"end_time,omitempty"`
+	HasVoted    bool                 `json:"has_voted"`
+	CreatedAt   time.Time            `json:"created_at"`
+}
+
+type VoteResultItem struct {
+	OptionKey   string  `json:"option_key"`
+	OptionLabel string  `json:"option_label"`
+	Count       int     `json:"count"`
+	WeightTotal float64 `json:"weight_total"`
+}
+
+type VoteResultResponse struct {
+	ID          string           `json:"id"`
+	Title       string           `json:"title"`
+	VoteType    int16            `json:"vote_type"`
+	IsAnonymous bool             `json:"is_anonymous"`
+	Status      int16            `json:"status"`
+	Results     []VoteResultItem `json:"results"`
+	TotalVoters int              `json:"total_voters"`
+	TotalWeight float64          `json:"total_weight"`
+	StartTime   *time.Time       `json:"start_time,omitempty"`
+	EndTime     *time.Time       `json:"end_time,omitempty"`
+}
+
+type MyVoteResponse struct {
+	VoteID    string    `json:"vote_id"`
+	OptionKey string    `json:"option_key"`
+	Weight    float64   `json:"weight"`
+	VotedAt   time.Time `json:"voted_at"`
+}
+
+type VoteWeightConfigRequest struct {
+	Weights       map[string]float64 `json:"weights" binding:"required"`
+	DefaultWeight float64            `json:"default_weight" binding:"required,gt=0"`
+}
+
+type VoteWeightConfigResponse struct {
+	Weights       map[string]float64 `json:"weights"`
+	DefaultWeight float64            `json:"default_weight"`
+}

--- a/backend/internal/meeting/handler/agenda_handler.go
+++ b/backend/internal/meeting/handler/agenda_handler.go
@@ -1,0 +1,131 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// ListAgendas 议程列表
+// @Summary 议程列表
+// @Tags 会议
+// @Router /meetings/{id}/agendas [get]
+func (h *MeetingHandler) ListAgendas(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.ListAgendas(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// AddAgenda 添加议程
+// @Summary 添加议程
+// @Tags 会议
+// @Router /meetings/{id}/agendas [post]
+func (h *MeetingHandler) AddAgenda(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CreateAgendaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.AddAgenda(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateAgenda 更新议程
+// @Summary 更新议程
+// @Tags 会议
+// @Router /meetings/{id}/agendas/{aid} [put]
+func (h *MeetingHandler) UpdateAgenda(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	aid, err := parseNamedID(c, "aid")
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.UpdateAgendaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.UpdateAgenda(c.Request.Context(), id, aid, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// DeleteAgenda 删除议程
+// @Summary 删除议程
+// @Tags 会议
+// @Router /meetings/{id}/agendas/{aid} [delete]
+func (h *MeetingHandler) DeleteAgenda(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	aid, err := parseNamedID(c, "aid")
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if err := h.svc.DeleteAgenda(c.Request.Context(), id, aid); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+// SortAgendas 排序议程
+// @Summary 排序议程
+// @Tags 会议
+// @Router /meetings/{id}/agendas/sort [put]
+func (h *MeetingHandler) SortAgendas(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.SortAgendasRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	ids := make([]uuid.UUID, 0, len(req.AgendaIDs))
+	for _, raw := range req.AgendaIDs {
+		aid, err := uuid.Parse(raw)
+		if err != nil {
+			response.BadRequest(c, "无效的议程ID")
+			return
+		}
+		ids = append(ids, aid)
+	}
+	out, err := h.svc.SortAgendas(c.Request.Context(), id, ids)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}

--- a/backend/internal/meeting/handler/attendee_handler.go
+++ b/backend/internal/meeting/handler/attendee_handler.go
@@ -1,0 +1,110 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// ListAttendees 参会人列表
+// @Summary 参会人列表
+// @Tags 会议
+// @Router /meetings/{id}/attendees [get]
+func (h *MeetingHandler) ListAttendees(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.ListAttendees(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// AddAttendees 添加参会人
+// @Summary 添加参会人
+// @Tags 会议
+// @Router /meetings/{id}/attendees [post]
+func (h *MeetingHandler) AddAttendees(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.AddAttendeesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	uids := make([]uuid.UUID, 0, len(req.UserIDs))
+	for _, raw := range req.UserIDs {
+		uid, err := uuid.Parse(raw)
+		if err != nil {
+			response.BadRequest(c, "无效的用户ID")
+			return
+		}
+		uids = append(uids, uid)
+	}
+	out, err := h.svc.AddAttendees(c.Request.Context(), id, uids)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// RemoveAttendee 移除参会人
+// @Summary 移除参会人
+// @Tags 会议
+// @Router /meetings/{id}/attendees/{uid} [delete]
+func (h *MeetingHandler) RemoveAttendee(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	uid, err := parseNamedID(c, "uid")
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if err := h.svc.RemoveAttendee(c.Request.Context(), id, uid); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+// Checkin 会议签到
+// @Summary 会议签到
+// @Tags 会议
+// @Router /meetings/{id}/checkin [post]
+func (h *MeetingHandler) Checkin(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var body struct {
+		Token string `json:"token"`
+	}
+	_ = c.ShouldBindJSON(&body)
+	if body.Token == "" {
+		body.Token = c.Query("token")
+	}
+	out, err := h.svc.Checkin(c.Request.Context(), id, userID, body.Token)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}

--- a/backend/internal/meeting/handler/helper.go
+++ b/backend/internal/meeting/handler/helper.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func getUserID(c *gin.Context) (uuid.UUID, error) {
+	userIDStr := auth.GetUserID(c)
+	if userIDStr == "" {
+		return uuid.Nil, response.NewUnauthorizedError("用户未认证")
+	}
+	id, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的用户ID")
+	}
+	return id, nil
+}
+
+func parseID(c *gin.Context) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的ID")
+	}
+	return id, nil
+}
+
+func parseNamedID(c *gin.Context, name string) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Param(name))
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的ID")
+	}
+	return id, nil
+}
+
+func dataScope(c *gin.Context) *rbacModel.DataScopeCondition {
+	return middleware.GetDataScopeFromContext(c)
+}
+
+func defaultPage(page, pageSize int) (int, int) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	return page, pageSize
+}

--- a/backend/internal/meeting/handler/meeting_handler.go
+++ b/backend/internal/meeting/handler/meeting_handler.go
@@ -1,0 +1,224 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// CreateMeeting 创建会议
+// @Summary 创建会议
+// @Tags 会议
+// @Accept json
+// @Produce json
+// @Param request body dto.CreateMeetingRequest true "会议"
+// @Success 200 {object} response.Response
+// @Router /meetings [post]
+func (h *MeetingHandler) CreateMeeting(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CreateMeetingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.CreateMeeting(c.Request.Context(), userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// ListMeetings 会议列表
+// @Summary 会议列表
+// @Tags 会议
+// @Produce json
+// @Success 200 {object} response.Response
+// @Router /meetings [get]
+func (h *MeetingHandler) ListMeetings(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.ListMeetingRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	list, total, err := h.svc.ListMeetings(c.Request.Context(), userID, &req, dataScope(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	page, size := defaultPage(req.Page, req.PageSize)
+	response.Page(c, list, total, page, size)
+}
+
+// GetMeeting 会议详情
+// @Summary 会议详情
+// @Tags 会议
+// @Produce json
+// @Param id path string true "会议ID"
+// @Success 200 {object} response.Response
+// @Router /meetings/{id} [get]
+func (h *MeetingHandler) GetMeeting(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.GetMeeting(c.Request.Context(), id, dataScope(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateMeeting 更新会议
+// @Summary 更新会议
+// @Tags 会议
+// @Router /meetings/{id} [put]
+func (h *MeetingHandler) UpdateMeeting(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.UpdateMeetingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.UpdateMeeting(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// DeleteMeeting 删除会议
+// @Summary 删除会议
+// @Tags 会议
+// @Router /meetings/{id} [delete]
+func (h *MeetingHandler) DeleteMeeting(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if err := h.svc.DeleteMeeting(c.Request.Context(), id); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+// StartMeeting 开始会议
+// @Summary 开始会议
+// @Tags 会议
+// @Router /meetings/{id}/start [post]
+func (h *MeetingHandler) StartMeeting(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.StartMeeting(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// EndMeeting 结束会议
+// @Summary 结束会议
+// @Tags 会议
+// @Router /meetings/{id}/end [post]
+func (h *MeetingHandler) EndMeeting(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.EndMeeting(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// CancelMeeting 取消会议
+// @Summary 取消会议
+// @Tags 会议
+// @Router /meetings/{id}/cancel [post]
+func (h *MeetingHandler) CancelMeeting(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CancelMeetingRequest
+	_ = c.ShouldBindJSON(&req)
+	out, err := h.svc.CancelMeeting(c.Request.Context(), id, req.Reason)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateMinutes 更新纪要
+// @Summary 更新纪要
+// @Tags 会议
+// @Router /meetings/{id}/minutes [put]
+func (h *MeetingHandler) UpdateMinutes(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.MinutesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.UpdateMinutes(c.Request.Context(), id, req.Minutes)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// MeetingQRCode 签到二维码
+// @Summary 获取签到二维码
+// @Tags 会议
+// @Router /meetings/{id}/qrcode [get]
+func (h *MeetingHandler) MeetingQRCode(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	meta, png, err := h.svc.MeetingQRCode(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if c.Query("format") == "png" {
+		c.Header("Content-Type", "image/png")
+		c.Writer.WriteHeader(200)
+		_, _ = c.Writer.Write(png)
+		return
+	}
+	response.OK(c, meta)
+}

--- a/backend/internal/meeting/handler/routes.go
+++ b/backend/internal/meeting/handler/routes.go
@@ -1,0 +1,95 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/service"
+	rbacRepo "github.com/Yogdunana/StarByte/backend/internal/rbac/repo"
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type MeetingHandler struct {
+	svc service.MeetingService
+}
+
+func NewMeetingHandler(svc service.MeetingService) *MeetingHandler {
+	return &MeetingHandler{svc: svc}
+}
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
+}
+
+func withReadScope(
+	group *gin.RouterGroup,
+	cacheService rbacService.PermissionCacheService,
+	db *gorm.DB,
+	deptRepo rbacRepo.DepartmentRepo,
+) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission("meeting:read"))
+	g.Use(middleware.RequireDataScope("meeting"))
+	g.Use(middleware.PermissionRequired(cacheService))
+	g.Use(middleware.DataScopeMiddleware(db, deptRepo, cacheService))
+	return g
+}
+
+// RegisterRoutes 注册 /api/v1/meetings、/votes、/system/vote-weight-config。
+func RegisterRoutes(
+	r *gin.RouterGroup,
+	h *MeetingHandler,
+	cacheService rbacService.PermissionCacheService,
+	db *gorm.DB,
+	deptRepo rbacRepo.DepartmentRepo,
+) {
+	g := r.Group("/meetings")
+	g.POST("/:id/checkin", h.Checkin)
+
+	read := withReadScope(g, cacheService, db, deptRepo)
+	read.GET("", h.ListMeetings)
+	read.GET("/:id", h.GetMeeting)
+	read.GET("/:id/agendas", h.ListAgendas)
+	read.GET("/:id/attendees", h.ListAttendees)
+	read.GET("/:id/votes", h.ListVotes)
+
+	create := withPermission(g, "meeting:create", cacheService)
+	create.POST("", h.CreateMeeting)
+
+	update := withPermission(g, "meeting:update", cacheService)
+	update.PUT("/:id", h.UpdateMeeting)
+
+	del := withPermission(g, "meeting:delete", cacheService)
+	del.DELETE("/:id", h.DeleteMeeting)
+
+	manage := withPermission(g, "meeting:manage", cacheService)
+	manage.POST("/:id/start", h.StartMeeting)
+	manage.POST("/:id/end", h.EndMeeting)
+	manage.POST("/:id/cancel", h.CancelMeeting)
+	manage.PUT("/:id/minutes", h.UpdateMinutes)
+	manage.GET("/:id/qrcode", h.MeetingQRCode)
+	manage.POST("/:id/agendas", h.AddAgenda)
+	manage.PUT("/:id/agendas/sort", h.SortAgendas)
+	manage.PUT("/:id/agendas/:aid", h.UpdateAgenda)
+	manage.DELETE("/:id/agendas/:aid", h.DeleteAgenda)
+	manage.POST("/:id/attendees", h.AddAttendees)
+	manage.DELETE("/:id/attendees/:uid", h.RemoveAttendee)
+	manage.POST("/:id/votes", h.CreateVote)
+
+	votes := r.Group("/votes")
+	votes.POST("/:id/cast", h.CastVote)
+	votes.GET("/:id/my", h.MyVote)
+	voteRead := withReadScope(votes, cacheService, db, deptRepo)
+	voteRead.GET("/:id", h.GetVote)
+	voteRead.GET("/:id/result", h.VoteResult)
+	voteManage := withPermission(votes, "meeting:manage", cacheService)
+	voteManage.POST("/:id/close", h.CloseVote)
+
+	sysRead := withPermission(r, "meeting:read", cacheService)
+	sysRead.GET("/system/vote-weight-config", h.GetWeightConfig)
+	sysWrite := withPermission(r, "system:config", cacheService)
+	sysWrite.PUT("/system/vote-weight-config", h.UpdateWeightConfig)
+}

--- a/backend/internal/meeting/handler/vote_handler.go
+++ b/backend/internal/meeting/handler/vote_handler.go
@@ -1,0 +1,194 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// CreateVote 创建投票
+// @Summary 创建投票
+// @Tags 会议
+// @Router /meetings/{id}/votes [post]
+func (h *MeetingHandler) CreateVote(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CreateVoteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.CreateVote(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// ListVotes 投票列表
+// @Summary 投票列表
+// @Tags 会议
+// @Router /meetings/{id}/votes [get]
+func (h *MeetingHandler) ListVotes(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.ListVotes(c.Request.Context(), id, userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// GetVote 投票详情
+// @Summary 投票详情
+// @Tags 会议
+// @Router /votes/{id} [get]
+func (h *MeetingHandler) GetVote(c *gin.Context) {
+	userID, _ := getUserID(c)
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.GetVote(c.Request.Context(), id, userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// CastVote 投票
+// @Summary 投票
+// @Tags 会议
+// @Router /votes/{id}/cast [post]
+func (h *MeetingHandler) CastVote(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CastVoteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	if err := h.svc.CastVote(c.Request.Context(), id, userID, req.OptionKey); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+// VoteResult 投票结果
+// @Summary 投票结果
+// @Tags 会议
+// @Router /votes/{id}/result [get]
+func (h *MeetingHandler) VoteResult(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.VoteResult(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// CloseVote 关闭投票
+// @Summary 关闭投票
+// @Tags 会议
+// @Router /votes/{id}/close [post]
+func (h *MeetingHandler) CloseVote(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.CloseVote(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// MyVote 我的投票记录
+// @Summary 我的投票记录
+// @Tags 会议
+// @Router /votes/{id}/my [get]
+func (h *MeetingHandler) MyVote(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.MyVote(c.Request.Context(), id, userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// GetWeightConfig 获取权重配置
+// @Summary 获取权重配置
+// @Tags 会议
+// @Router /system/vote-weight-config [get]
+func (h *MeetingHandler) GetWeightConfig(c *gin.Context) {
+	out, err := h.svc.GetWeightConfig(c.Request.Context())
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateWeightConfig 更新权重配置
+// @Summary 更新权重配置
+// @Tags 会议
+// @Router /system/vote-weight-config [put]
+func (h *MeetingHandler) UpdateWeightConfig(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.VoteWeightConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.UpdateWeightConfig(c.Request.Context(), userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}

--- a/backend/internal/meeting/model/const.go
+++ b/backend/internal/meeting/model/const.go
@@ -1,0 +1,22 @@
+package model
+
+const (
+	MeetingPending   int16 = 0
+	MeetingOngoing   int16 = 1
+	MeetingEnded     int16 = 2
+	MeetingCancelled int16 = 3
+
+	MeetingTypeRegular int16 = 1
+	MeetingTypeAdhoc   int16 = 2
+	MeetingTypeOnline  int16 = 3
+
+	VoteEqual    int16 = 1
+	VoteWeighted int16 = 2
+
+	VotePending   int16 = 0
+	VoteOpen      int16 = 1
+	VoteClosed    int16 = 2
+	VoteCancelled int16 = 3
+
+	WeightConfigKey = "vote_weight_config"
+)

--- a/backend/internal/meeting/model/meeting.go
+++ b/backend/internal/meeting/model/meeting.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Meeting struct {
+	ID           uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	Title        string    `gorm:"type:varchar(200);not null" json:"title"`
+	Description  string    `gorm:"type:text" json:"description"`
+	Status       int16     `gorm:"type:smallint;not null;default:0" json:"status"`
+	MeetingType  int16     `gorm:"type:smallint;not null;default:1" json:"meeting_type"`
+	StartTime    time.Time `json:"start_time"`
+	EndTime      time.Time `json:"end_time"`
+	Location     string    `gorm:"type:varchar(200)" json:"location"`
+	OnlineLink   string    `gorm:"type:varchar(500);not null;default:''" json:"online_link"`
+	OrganizerID  uuid.UUID `gorm:"type:uuid;not null" json:"organizer_id"`
+	Minutes      string    `gorm:"type:text;not null;default:''" json:"minutes"`
+	QRToken      string    `gorm:"column:qr_token;type:varchar(64);not null;default:''" json:"-"`
+	CancelReason string    `gorm:"type:varchar(500);not null;default:''" json:"cancel_reason"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+func (Meeting) TableName() string { return "meetings" }
+
+type MeetingWithNames struct {
+	Meeting
+	OrganizerName  string `gorm:"column:organizer_name"`
+	AttendeeCount  int64  `gorm:"column:attendee_count"`
+	CheckedInCount int64  `gorm:"column:checked_in_count"`
+}
+
+type NamedUser struct {
+	ID           uuid.UUID
+	RealName     string
+	Username     string
+	PositionID   *uuid.UUID
+	PositionCode string
+}
+
+type Agenda struct {
+	ID          uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	MeetingID   uuid.UUID  `gorm:"type:uuid;not null" json:"meeting_id"`
+	Title       string     `gorm:"type:varchar(200);not null" json:"title"`
+	Description string     `gorm:"type:text" json:"description"`
+	SortOrder   int        `gorm:"not null;default:0" json:"sort_order"`
+	Duration    *int       `json:"duration"`
+	SpeakerID   *uuid.UUID `gorm:"type:uuid" json:"speaker_id"`
+	Presenter   string     `gorm:"type:varchar(100);not null;default:''" json:"presenter"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+func (Agenda) TableName() string { return "meeting_agendas" }
+
+type Attendee struct {
+	ID          uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	MeetingID   uuid.UUID  `gorm:"type:uuid;not null" json:"meeting_id"`
+	UserID      uuid.UUID  `gorm:"type:uuid;not null" json:"user_id"`
+	Attended    bool       `gorm:"default:false" json:"attended"`
+	CheckedInAt *time.Time `json:"checked_in_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+func (Attendee) TableName() string { return "meeting_attendees" }
+
+type AttendeeNamed struct {
+	Attendee
+	RealName     string `gorm:"column:real_name"`
+	Username     string `gorm:"column:username"`
+	PositionCode string `gorm:"column:position_code"`
+}

--- a/backend/internal/meeting/model/vote.go
+++ b/backend/internal/meeting/model/vote.go
@@ -1,0 +1,70 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Vote struct {
+	ID          uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	MeetingID   uuid.UUID  `gorm:"type:uuid;not null" json:"meeting_id"`
+	Title       string     `gorm:"type:varchar(200);not null" json:"title"`
+	Description string     `gorm:"type:text" json:"description"`
+	VoteType    int16      `gorm:"type:smallint;not null;default:1" json:"vote_type"`
+	Status      int16      `gorm:"type:smallint;not null;default:0" json:"status"`
+	IsAnonymous bool       `gorm:"not null;default:false" json:"is_anonymous"`
+	StartTime   *time.Time `json:"start_time"`
+	EndTime     *time.Time `json:"end_time"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+func (Vote) TableName() string { return "meeting_votes" }
+
+type VoteOption struct {
+	ID         uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	VoteID     uuid.UUID `gorm:"type:uuid;not null" json:"vote_id"`
+	OptionText string    `gorm:"type:varchar(200);not null" json:"option_text"`
+	OptionKey  string    `gorm:"type:varchar(64);not null" json:"option_key"`
+	SortOrder  int       `gorm:"not null;default:0" json:"sort_order"`
+}
+
+func (VoteOption) TableName() string { return "meeting_vote_options" }
+
+type VoteRecord struct {
+	ID        uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	VoteID    uuid.UUID `gorm:"type:uuid;not null" json:"vote_id"`
+	VoterID   uuid.UUID `gorm:"type:uuid;not null" json:"voter_id"`
+	OptionID  uuid.UUID `gorm:"type:uuid;not null" json:"option_id"`
+	OptionKey string    `gorm:"type:varchar(64);not null;default:''" json:"option_key"`
+	Weight    float64   `gorm:"type:numeric(8,2);not null;default:1" json:"weight"`
+	VotedAt   time.Time `json:"voted_at"`
+}
+
+func (VoteRecord) TableName() string { return "meeting_vote_records" }
+
+type VoteRecordNamed struct {
+	VoteRecord
+	VoterName string `gorm:"column:voter_name"`
+}
+
+type SystemConfig struct {
+	ID          uuid.UUID  `gorm:"type:uuid;primaryKey"`
+	ConfigKey   string     `gorm:"column:config_key;type:varchar(100);uniqueIndex"`
+	ConfigValue string     `gorm:"column:config_value;type:text"`
+	ConfigType  string     `gorm:"column:config_type;type:varchar(20)"`
+	Description string     `gorm:"type:varchar(255)"`
+	Category    string     `gorm:"type:varchar(50)"`
+	IsPublic    bool       `gorm:"column:is_public"`
+	UpdatedBy   *uuid.UUID `gorm:"type:uuid"`
+	UpdatedAt   time.Time
+	CreatedAt   time.Time
+}
+
+func (SystemConfig) TableName() string { return "configs" }
+
+type VoteWeightConfig struct {
+	Weights       map[string]float64 `json:"weights"`
+	DefaultWeight float64            `json:"default_weight"`
+}

--- a/backend/internal/meeting/repo/agenda_repo.go
+++ b/backend/internal/meeting/repo/agenda_repo.go
@@ -1,0 +1,66 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type AgendaRepo interface {
+	Create(ctx context.Context, a *model.Agenda) error
+	Update(ctx context.Context, a *model.Agenda) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Agenda, error)
+	ListByMeeting(ctx context.Context, meetingID uuid.UUID) ([]model.Agenda, error)
+	SaveSort(ctx context.Context, items []model.Agenda) error
+}
+
+type agendaRepo struct{ db *gorm.DB }
+
+func NewAgendaRepo(db *gorm.DB) AgendaRepo {
+	return &agendaRepo{db: db}
+}
+
+func (r *agendaRepo) Create(ctx context.Context, a *model.Agenda) error {
+	return r.db.WithContext(ctx).Create(a).Error
+}
+
+func (r *agendaRepo) Update(ctx context.Context, a *model.Agenda) error {
+	return r.db.WithContext(ctx).Save(a).Error
+}
+
+func (r *agendaRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.Agenda{}, "id = ?", id).Error
+}
+
+func (r *agendaRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Agenda, error) {
+	var a model.Agenda
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&a).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *agendaRepo) ListByMeeting(ctx context.Context, meetingID uuid.UUID) ([]model.Agenda, error) {
+	var rows []model.Agenda
+	err := r.db.WithContext(ctx).Where("meeting_id = ?", meetingID).Order("sort_order ASC, created_at ASC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *agendaRepo) SaveSort(ctx context.Context, items []model.Agenda) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for i := range items {
+			if err := tx.Model(&model.Agenda{}).Where("id = ?", items[i].ID).
+				Update("sort_order", items[i].SortOrder).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/backend/internal/meeting/repo/attendee_repo.go
+++ b/backend/internal/meeting/repo/attendee_repo.go
@@ -1,0 +1,71 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type AttendeeRepo interface {
+	Add(ctx context.Context, items []model.Attendee) error
+	Remove(ctx context.Context, meetingID, userID uuid.UUID) error
+	Get(ctx context.Context, meetingID, userID uuid.UUID) (*model.Attendee, error)
+	Update(ctx context.Context, a *model.Attendee) error
+	List(ctx context.Context, meetingID uuid.UUID) ([]model.AttendeeNamed, error)
+	IsAttendee(ctx context.Context, meetingID, userID uuid.UUID) (bool, error)
+}
+
+type attendeeRepo struct{ db *gorm.DB }
+
+func NewAttendeeRepo(db *gorm.DB) AttendeeRepo {
+	return &attendeeRepo{db: db}
+}
+
+func (r *attendeeRepo) Add(ctx context.Context, items []model.Attendee) error {
+	if len(items) == 0 {
+		return nil
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&items).Error
+}
+
+func (r *attendeeRepo) Remove(ctx context.Context, meetingID, userID uuid.UUID) error {
+	return r.db.WithContext(ctx).Where("meeting_id = ? AND user_id = ?", meetingID, userID).
+		Delete(&model.Attendee{}).Error
+}
+
+func (r *attendeeRepo) Get(ctx context.Context, meetingID, userID uuid.UUID) (*model.Attendee, error) {
+	var a model.Attendee
+	err := r.db.WithContext(ctx).Where("meeting_id = ? AND user_id = ?", meetingID, userID).First(&a).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *attendeeRepo) Update(ctx context.Context, a *model.Attendee) error {
+	return r.db.WithContext(ctx).Save(a).Error
+}
+
+func (r *attendeeRepo) List(ctx context.Context, meetingID uuid.UUID) ([]model.AttendeeNamed, error) {
+	var rows []model.AttendeeNamed
+	err := r.db.WithContext(ctx).Table("meeting_attendees AS a").
+		Select("a.*, COALESCE(u.real_name, u.username, '') AS real_name, COALESCE(u.username, '') AS username, COALESCE(p.code, '') AS position_code").
+		Joins("LEFT JOIN users u ON u.id = a.user_id").
+		Joins("LEFT JOIN positions p ON p.id = u.position_id").
+		Where("a.meeting_id = ?", meetingID).
+		Order("a.created_at ASC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *attendeeRepo) IsAttendee(ctx context.Context, meetingID, userID uuid.UUID) (bool, error) {
+	var n int64
+	err := r.db.WithContext(ctx).Model(&model.Attendee{}).
+		Where("meeting_id = ? AND user_id = ?", meetingID, userID).Count(&n).Error
+	return n > 0, err
+}

--- a/backend/internal/meeting/repo/helpers.go
+++ b/backend/internal/meeting/repo/helpers.go
@@ -1,0 +1,26 @@
+package repo
+
+import (
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"gorm.io/gorm"
+)
+
+func normalizePage(page, pageSize int) (int, int) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+	return page, pageSize
+}
+
+func applyScope(q *gorm.DB, scope *rbacModel.DataScopeCondition) *gorm.DB {
+	if scope == nil || scope.IsEmpty() {
+		return q
+	}
+	return q.Where(scope.Query, scope.Args...)
+}

--- a/backend/internal/meeting/repo/meeting_repo.go
+++ b/backend/internal/meeting/repo/meeting_repo.go
@@ -1,0 +1,113 @@
+package repo
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type MeetingRepo interface {
+	Create(ctx context.Context, m *model.Meeting) error
+	Update(ctx context.Context, m *model.Meeting) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Meeting, error)
+	GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.MeetingWithNames, error)
+	List(ctx context.Context, req *dto.ListMeetingRequest, scope *rbacModel.DataScopeCondition) ([]model.MeetingWithNames, int64, error)
+	GetUser(ctx context.Context, id uuid.UUID) (*model.NamedUser, error)
+}
+
+type meetingRepo struct{ db *gorm.DB }
+
+func NewMeetingRepo(db *gorm.DB) MeetingRepo {
+	return &meetingRepo{db: db}
+}
+
+func (r *meetingRepo) Create(ctx context.Context, m *model.Meeting) error {
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *meetingRepo) Update(ctx context.Context, m *model.Meeting) error {
+	return r.db.WithContext(ctx).Save(m).Error
+}
+
+func (r *meetingRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.Meeting{}, "id = ?", id).Error
+}
+
+func (r *meetingRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Meeting, error) {
+	var m model.Meeting
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&m).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (r *meetingRepo) namedQuery(ctx context.Context) *gorm.DB {
+	return r.db.WithContext(ctx).Table("meetings AS m").
+		Select(`m.*, COALESCE(u.real_name, u.username, '') AS organizer_name,
+			(SELECT COUNT(*) FROM meeting_attendees a WHERE a.meeting_id = m.id) AS attendee_count,
+			(SELECT COUNT(*) FROM meeting_attendees a WHERE a.meeting_id = m.id AND a.attended = true) AS checked_in_count`).
+		Joins("LEFT JOIN users u ON u.id = m.organizer_id")
+}
+
+func (r *meetingRepo) GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.MeetingWithNames, error) {
+	var row model.MeetingWithNames
+	err := r.namedQuery(ctx).Where("m.id = ?", id).First(&row).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *meetingRepo) List(ctx context.Context, req *dto.ListMeetingRequest, scope *rbacModel.DataScopeCondition) ([]model.MeetingWithNames, int64, error) {
+	q := r.namedQuery(ctx)
+	q = applyScope(q, scope)
+	if req.Status != nil {
+		q = q.Where("m.status = ?", *req.Status)
+	}
+	if kw := strings.TrimSpace(req.Keyword); kw != "" {
+		like := "%" + kw + "%"
+		q = q.Where("m.title ILIKE ? OR m.location ILIKE ?", like, like)
+	}
+	if req.StartDate != "" {
+		q = q.Where("m.start_time >= ?", req.StartDate)
+	}
+	if req.EndDate != "" {
+		q = q.Where("m.start_time <= ?", req.EndDate+" 23:59:59")
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	page, size := normalizePage(req.Page, req.PageSize)
+	var rows []model.MeetingWithNames
+	err := q.Order("m.start_time DESC").Offset((page - 1) * size).Limit(size).Find(&rows).Error
+	return rows, total, err
+}
+
+func (r *meetingRepo) GetUser(ctx context.Context, id uuid.UUID) (*model.NamedUser, error) {
+	var u model.NamedUser
+	err := r.db.WithContext(ctx).Table("users AS u").
+		Select("u.id, u.real_name, u.username, u.position_id, COALESCE(p.code, '') AS position_code").
+		Joins("LEFT JOIN positions p ON p.id = u.position_id").
+		Where("u.id = ?", id).First(&u).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}

--- a/backend/internal/meeting/repo/vote_repo.go
+++ b/backend/internal/meeting/repo/vote_repo.go
@@ -1,0 +1,126 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type VoteRepo interface {
+	CreateVote(ctx context.Context, v *model.Vote, options []model.VoteOption) error
+	UpdateVote(ctx context.Context, v *model.Vote) error
+	GetVote(ctx context.Context, id uuid.UUID) (*model.Vote, error)
+	ListByMeeting(ctx context.Context, meetingID uuid.UUID) ([]model.Vote, error)
+	ListOptions(ctx context.Context, voteID uuid.UUID) ([]model.VoteOption, error)
+	GetOptionByKey(ctx context.Context, voteID uuid.UUID, key string) (*model.VoteOption, error)
+	CreateRecord(ctx context.Context, rec *model.VoteRecord) error
+	GetRecord(ctx context.Context, voteID, userID uuid.UUID) (*model.VoteRecord, error)
+	ListRecords(ctx context.Context, voteID uuid.UUID) ([]model.VoteRecordNamed, error)
+	GetConfig(ctx context.Context, key string) (*model.SystemConfig, error)
+	UpsertConfig(ctx context.Context, cfg *model.SystemConfig) error
+}
+
+type voteRepo struct{ db *gorm.DB }
+
+func NewVoteRepo(db *gorm.DB) VoteRepo {
+	return &voteRepo{db: db}
+}
+
+func (r *voteRepo) CreateVote(ctx context.Context, v *model.Vote, options []model.VoteOption) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(v).Error; err != nil {
+			return err
+		}
+		if len(options) == 0 {
+			return nil
+		}
+		return tx.Create(&options).Error
+	})
+}
+
+func (r *voteRepo) UpdateVote(ctx context.Context, v *model.Vote) error {
+	return r.db.WithContext(ctx).Save(v).Error
+}
+
+func (r *voteRepo) GetVote(ctx context.Context, id uuid.UUID) (*model.Vote, error) {
+	var v model.Vote
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&v).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func (r *voteRepo) ListByMeeting(ctx context.Context, meetingID uuid.UUID) ([]model.Vote, error) {
+	var rows []model.Vote
+	err := r.db.WithContext(ctx).Where("meeting_id = ?", meetingID).Order("created_at DESC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *voteRepo) ListOptions(ctx context.Context, voteID uuid.UUID) ([]model.VoteOption, error) {
+	var rows []model.VoteOption
+	err := r.db.WithContext(ctx).Where("vote_id = ?", voteID).Order("sort_order ASC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *voteRepo) GetOptionByKey(ctx context.Context, voteID uuid.UUID, key string) (*model.VoteOption, error) {
+	var o model.VoteOption
+	err := r.db.WithContext(ctx).Where("vote_id = ? AND option_key = ?", voteID, key).First(&o).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &o, nil
+}
+
+func (r *voteRepo) CreateRecord(ctx context.Context, rec *model.VoteRecord) error {
+	return r.db.WithContext(ctx).Create(rec).Error
+}
+
+func (r *voteRepo) GetRecord(ctx context.Context, voteID, userID uuid.UUID) (*model.VoteRecord, error) {
+	var rec model.VoteRecord
+	err := r.db.WithContext(ctx).Where("vote_id = ? AND voter_id = ?", voteID, userID).First(&rec).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &rec, nil
+}
+
+func (r *voteRepo) ListRecords(ctx context.Context, voteID uuid.UUID) ([]model.VoteRecordNamed, error) {
+	var rows []model.VoteRecordNamed
+	err := r.db.WithContext(ctx).Table("meeting_vote_records AS r").
+		Select("r.*, COALESCE(u.real_name, u.username, '') AS voter_name").
+		Joins("LEFT JOIN users u ON u.id = r.voter_id").
+		Where("r.vote_id = ?", voteID).Find(&rows).Error
+	return rows, err
+}
+
+func (r *voteRepo) GetConfig(ctx context.Context, key string) (*model.SystemConfig, error) {
+	var c model.SystemConfig
+	err := r.db.WithContext(ctx).Where("config_key = ?", key).First(&c).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (r *voteRepo) UpsertConfig(ctx context.Context, cfg *model.SystemConfig) error {
+	if cfg.ID == uuid.Nil {
+		cfg.ID = uuid.New()
+		return r.db.WithContext(ctx).Create(cfg).Error
+	}
+	return r.db.WithContext(ctx).Save(cfg).Error
+}

--- a/backend/internal/meeting/service/agenda.go
+++ b/backend/internal/meeting/service/agenda.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *meetingService) AddAgenda(ctx context.Context, meetingID uuid.UUID, req *dto.CreateAgendaRequest) (*dto.AgendaResponse, error) {
+	if _, err := s.mustMeeting(ctx, meetingID); err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	a := &model.Agenda{
+		ID:          uuid.New(),
+		MeetingID:   meetingID,
+		Title:       req.Title,
+		Description: req.Content,
+		SortOrder:   req.SortOrder,
+		Presenter:   req.Presenter,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if req.Duration > 0 {
+		d := req.Duration
+		a.Duration = &d
+	}
+	if err := s.agendas.Create(ctx, a); err != nil {
+		return nil, fmt.Errorf("create agenda: %w", err)
+	}
+	out := mapAgenda(*a)
+	return &out, nil
+}
+
+func (s *meetingService) UpdateAgenda(ctx context.Context, meetingID, agendaID uuid.UUID, req *dto.UpdateAgendaRequest) (*dto.AgendaResponse, error) {
+	a, err := s.mustAgenda(ctx, meetingID, agendaID)
+	if err != nil {
+		return nil, err
+	}
+	if req.Title != nil {
+		a.Title = *req.Title
+	}
+	if req.Content != nil {
+		a.Description = *req.Content
+	}
+	if req.Presenter != nil {
+		a.Presenter = *req.Presenter
+	}
+	if req.SortOrder != nil {
+		a.SortOrder = *req.SortOrder
+	}
+	if req.Duration != nil {
+		d := *req.Duration
+		a.Duration = &d
+	}
+	a.UpdatedAt = time.Now()
+	if err := s.agendas.Update(ctx, a); err != nil {
+		return nil, fmt.Errorf("update agenda: %w", err)
+	}
+	out := mapAgenda(*a)
+	return &out, nil
+}
+
+func (s *meetingService) DeleteAgenda(ctx context.Context, meetingID, agendaID uuid.UUID) error {
+	if _, err := s.mustAgenda(ctx, meetingID, agendaID); err != nil {
+		return err
+	}
+	if err := s.agendas.Delete(ctx, agendaID); err != nil {
+		return fmt.Errorf("delete agenda: %w", err)
+	}
+	return nil
+}
+
+func (s *meetingService) SortAgendas(ctx context.Context, meetingID uuid.UUID, ids []uuid.UUID) ([]dto.AgendaResponse, error) {
+	if _, err := s.mustMeeting(ctx, meetingID); err != nil {
+		return nil, err
+	}
+	exist, err := s.agendas.ListByMeeting(ctx, meetingID)
+	if err != nil {
+		return nil, fmt.Errorf("list agendas: %w", err)
+	}
+	byID := map[uuid.UUID]model.Agenda{}
+	for _, a := range exist {
+		byID[a.ID] = a
+	}
+	items := make([]model.Agenda, 0, len(ids))
+	for i, id := range ids {
+		a, ok := byID[id]
+		if !ok {
+			return nil, response.NewError(response.CodeBadRequest, "议程不属于该会议")
+		}
+		a.SortOrder = i + 1
+		items = append(items, a)
+	}
+	if err := s.agendas.SaveSort(ctx, items); err != nil {
+		return nil, fmt.Errorf("sort agendas: %w", err)
+	}
+	return s.ListAgendas(ctx, meetingID)
+}
+
+func (s *meetingService) ListAgendas(ctx context.Context, meetingID uuid.UUID) ([]dto.AgendaResponse, error) {
+	if _, err := s.mustMeeting(ctx, meetingID); err != nil {
+		return nil, err
+	}
+	rows, err := s.agendas.ListByMeeting(ctx, meetingID)
+	if err != nil {
+		return nil, fmt.Errorf("list agendas: %w", err)
+	}
+	out := make([]dto.AgendaResponse, 0, len(rows))
+	for _, a := range rows {
+		out = append(out, mapAgenda(a))
+	}
+	return out, nil
+}
+
+func (s *meetingService) mustAgenda(ctx context.Context, meetingID, agendaID uuid.UUID) (*model.Agenda, error) {
+	a, err := s.agendas.GetByID(ctx, agendaID)
+	if err != nil {
+		return nil, fmt.Errorf("get agenda: %w", err)
+	}
+	if a == nil || a.MeetingID != meetingID {
+		return nil, response.NewError(response.CodeNotFound, "议程不存在")
+	}
+	return a, nil
+}

--- a/backend/internal/meeting/service/attendee.go
+++ b/backend/internal/meeting/service/attendee.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *meetingService) ListAttendees(ctx context.Context, meetingID uuid.UUID) ([]dto.AttendeeResponse, error) {
+	if _, err := s.mustMeeting(ctx, meetingID); err != nil {
+		return nil, err
+	}
+	rows, err := s.attendees.List(ctx, meetingID)
+	if err != nil {
+		return nil, fmt.Errorf("list attendees: %w", err)
+	}
+	out := make([]dto.AttendeeResponse, 0, len(rows))
+	for _, a := range rows {
+		out = append(out, mapAttendee(a))
+	}
+	return out, nil
+}
+
+func (s *meetingService) AddAttendees(ctx context.Context, meetingID uuid.UUID, userIDs []uuid.UUID) ([]dto.AttendeeResponse, error) {
+	m, err := s.mustMeeting(ctx, meetingID)
+	if err != nil {
+		return nil, err
+	}
+	if m.Status == model.MeetingEnded || m.Status == model.MeetingCancelled {
+		return nil, response.NewError(response.CodeMeetingInvalidState, "已结束或已取消的会议不可加人")
+	}
+	ids := uniqueUUIDs(userIDs)
+	if err := s.addAttendeeIDs(ctx, meetingID, ids); err != nil {
+		return nil, err
+	}
+	s.notifyMeeting(ctx, ids, tplMeetingNotice, m)
+	return s.ListAttendees(ctx, meetingID)
+}
+
+func (s *meetingService) RemoveAttendee(ctx context.Context, meetingID, userID uuid.UUID) error {
+	if _, err := s.mustMeeting(ctx, meetingID); err != nil {
+		return err
+	}
+	if err := s.attendees.Remove(ctx, meetingID, userID); err != nil {
+		return fmt.Errorf("remove attendee: %w", err)
+	}
+	return nil
+}
+
+func (s *meetingService) Checkin(ctx context.Context, meetingID, userID uuid.UUID, token string) (*dto.AttendeeResponse, error) {
+	m, err := s.mustMeeting(ctx, meetingID)
+	if err != nil {
+		return nil, err
+	}
+	if !canCheckinMeeting(m.Status) {
+		return nil, response.NewError(response.CodeMeetingInvalidState, "当前会议不可签到")
+	}
+	if token != "" && m.QRToken != "" && token != m.QRToken {
+		return nil, response.NewError(response.CodeBadRequest, "签到二维码无效")
+	}
+	att, err := s.attendees.Get(ctx, meetingID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get attendee: %w", err)
+	}
+	if att == nil {
+		return nil, response.NewError(response.CodeMeetingNotAttendee, "非参会人，无权签到")
+	}
+	if att.Attended {
+		return nil, response.NewError(response.CodeMeetingDupCheckin, "重复签到")
+	}
+	now := time.Now()
+	att.Attended = true
+	att.CheckedInAt = &now
+	if err := s.attendees.Update(ctx, att); err != nil {
+		return nil, fmt.Errorf("checkin: %w", err)
+	}
+	list, err := s.attendees.List(ctx, meetingID)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range list {
+		if row.UserID == userID {
+			out := mapAttendee(row)
+			return &out, nil
+		}
+	}
+	out := mapAttendee(model.AttendeeNamed{Attendee: *att})
+	return &out, nil
+}
+
+func (s *meetingService) addAttendeeIDs(ctx context.Context, meetingID uuid.UUID, userIDs []uuid.UUID) error {
+	now := time.Now()
+	items := make([]model.Attendee, 0, len(userIDs))
+	for _, uid := range userIDs {
+		items = append(items, model.Attendee{
+			ID: uuid.New(), MeetingID: meetingID, UserID: uid, CreatedAt: now,
+		})
+	}
+	if err := s.attendees.Add(ctx, items); err != nil {
+		return fmt.Errorf("add attendees: %w", err)
+	}
+	return nil
+}
+
+func (s *meetingService) attendeeIDs(ctx context.Context, meetingID uuid.UUID) ([]uuid.UUID, error) {
+	rows, err := s.attendees.List(ctx, meetingID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]uuid.UUID, 0, len(rows))
+	for _, a := range rows {
+		ids = append(ids, a.UserID)
+	}
+	return ids, nil
+}

--- a/backend/internal/meeting/service/mapper.go
+++ b/backend/internal/meeting/service/mapper.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+)
+
+func mapMeeting(row *model.MeetingWithNames) *dto.MeetingResponse {
+	return &dto.MeetingResponse{
+		ID:             row.ID.String(),
+		Title:          row.Title,
+		Description:    row.Description,
+		StartTime:      row.StartTime,
+		EndTime:        row.EndTime,
+		Location:       row.Location,
+		OnlineLink:     row.OnlineLink,
+		Organizer:      dto.Person{ID: row.OrganizerID.String(), Name: row.OrganizerName},
+		Status:         row.Status,
+		MeetingType:    row.MeetingType,
+		Minutes:        row.Minutes,
+		CancelReason:   row.CancelReason,
+		AttendeeCount:  row.AttendeeCount,
+		CheckedInCount: row.CheckedInCount,
+		CreatedAt:      row.CreatedAt,
+		UpdatedAt:      row.UpdatedAt,
+	}
+}
+
+func mapAgenda(a model.Agenda) dto.AgendaResponse {
+	dur := 0
+	if a.Duration != nil {
+		dur = *a.Duration
+	}
+	return dto.AgendaResponse{
+		ID:        a.ID.String(),
+		MeetingID: a.MeetingID.String(),
+		Title:     a.Title,
+		Content:   a.Description,
+		Duration:  dur,
+		SortOrder: a.SortOrder,
+		Presenter: a.Presenter,
+	}
+}
+
+func mapAttendee(a model.AttendeeNamed) dto.AttendeeResponse {
+	out := dto.AttendeeResponse{
+		ID:           a.ID.String(),
+		UserID:       a.UserID.String(),
+		Name:         a.RealName,
+		PositionCode: a.PositionCode,
+		Attended:     a.Attended,
+	}
+	if a.CheckedInAt != nil {
+		s := a.CheckedInAt.Format(time.RFC3339)
+		out.CheckedInAt = &s
+	}
+	return out
+}
+
+func mapVote(v *model.Vote, options []model.VoteOption, hasVoted bool) *dto.VoteResponse {
+	opts := make([]dto.VoteOptionResponse, 0, len(options))
+	for _, o := range options {
+		opts = append(opts, dto.VoteOptionResponse{Key: o.OptionKey, Label: o.OptionText})
+	}
+	return &dto.VoteResponse{
+		ID:          v.ID.String(),
+		MeetingID:   v.MeetingID.String(),
+		Title:       v.Title,
+		Description: v.Description,
+		VoteType:    v.VoteType,
+		IsAnonymous: v.IsAnonymous,
+		Options:     opts,
+		Status:      v.Status,
+		StartTime:   v.StartTime,
+		EndTime:     v.EndTime,
+		HasVoted:    hasVoted,
+		CreatedAt:   v.CreatedAt,
+	}
+}
+
+func displayName(u *model.NamedUser) string {
+	if u == nil {
+		return ""
+	}
+	if u.RealName != "" {
+		return u.RealName
+	}
+	return u.Username
+}

--- a/backend/internal/meeting/service/meeting.go
+++ b/backend/internal/meeting/service/meeting.go
@@ -1,0 +1,276 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	qrcode "github.com/skip2/go-qrcode"
+)
+
+func (s *meetingService) CreateMeeting(ctx context.Context, operator uuid.UUID, req *dto.CreateMeetingRequest) (*dto.MeetingResponse, error) {
+	if !req.EndTime.After(req.StartTime) {
+		return nil, response.NewError(response.CodeBadRequest, "结束时间必须晚于开始时间")
+	}
+	now := time.Now()
+	m := &model.Meeting{
+		ID:          uuid.New(),
+		Title:       req.Title,
+		Description: req.Description,
+		Status:      model.MeetingPending,
+		MeetingType: req.MeetingType,
+		StartTime:   req.StartTime,
+		EndTime:     req.EndTime,
+		Location:    req.Location,
+		OnlineLink:  req.OnlineLink,
+		OrganizerID: operator,
+		QRToken:     newQRToken(),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.meetings.Create(ctx, m); err != nil {
+		return nil, fmt.Errorf("create meeting: %w", err)
+	}
+	ids := uniqueUUIDs(append(parseUUIDList(req.UserIDs), operator))
+	if err := s.addAttendeeIDs(ctx, m.ID, ids); err != nil {
+		return nil, err
+	}
+	s.notifyMeeting(ctx, ids, tplMeetingNotice, m)
+	return s.GetMeeting(ctx, m.ID, nil)
+}
+
+func (s *meetingService) ListMeetings(ctx context.Context, viewer uuid.UUID, req *dto.ListMeetingRequest, scope *rbacModel.DataScopeCondition) ([]*dto.MeetingResponse, int64, error) {
+	rows, total, err := s.meetings.List(ctx, req, rewriteMeetingScope(scope, viewer))
+	if err != nil {
+		return nil, 0, fmt.Errorf("list meetings: %w", err)
+	}
+	out := make([]*dto.MeetingResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, mapMeeting(&rows[i]))
+	}
+	return out, total, nil
+}
+
+func (s *meetingService) GetMeeting(ctx context.Context, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.MeetingResponse, error) {
+	row, err := s.meetings.GetByIDWithNames(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get meeting: %w", err)
+	}
+	if row == nil {
+		return nil, response.NewError(response.CodeMeetingNotFound, "会议不存在")
+	}
+	_ = scope
+	return mapMeeting(row), nil
+}
+
+func (s *meetingService) UpdateMeeting(ctx context.Context, id uuid.UUID, req *dto.UpdateMeetingRequest) (*dto.MeetingResponse, error) {
+	m, err := s.mustMeeting(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canUpdateMeeting(m.Status) {
+		return nil, response.NewError(response.CodeMeetingInvalidState, "仅待开始会议可修改")
+	}
+	applyMeetingPatch(m, req)
+	if !m.EndTime.After(m.StartTime) {
+		return nil, response.NewError(response.CodeBadRequest, "结束时间必须晚于开始时间")
+	}
+	m.UpdatedAt = time.Now()
+	if err := s.meetings.Update(ctx, m); err != nil {
+		return nil, fmt.Errorf("update meeting: %w", err)
+	}
+	return s.GetMeeting(ctx, id, nil)
+}
+
+func (s *meetingService) DeleteMeeting(ctx context.Context, id uuid.UUID) error {
+	m, err := s.mustMeeting(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !canDeleteMeeting(m.Status) {
+		return response.NewError(response.CodeMeetingInvalidState, "进行中或已结束的会议不可删除")
+	}
+	if err := s.meetings.Delete(ctx, id); err != nil {
+		return fmt.Errorf("delete meeting: %w", err)
+	}
+	return nil
+}
+
+func (s *meetingService) StartMeeting(ctx context.Context, id uuid.UUID) (*dto.MeetingResponse, error) {
+	m, err := s.mustMeeting(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canStartMeeting(m.Status) {
+		return nil, response.NewError(response.CodeMeetingInvalidState, "仅待开始会议可开始")
+	}
+	m.Status = model.MeetingOngoing
+	m.UpdatedAt = time.Now()
+	if err := s.meetings.Update(ctx, m); err != nil {
+		return nil, fmt.Errorf("start meeting: %w", err)
+	}
+	ids, _ := s.attendeeIDs(ctx, id)
+	s.notifyMeeting(ctx, ids, tplMeetingStarted, m)
+	return s.GetMeeting(ctx, id, nil)
+}
+
+func (s *meetingService) EndMeeting(ctx context.Context, id uuid.UUID) (*dto.MeetingResponse, error) {
+	m, err := s.mustMeeting(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canEndMeeting(m.Status) {
+		return nil, response.NewError(response.CodeMeetingInvalidState, "仅进行中会议可结束")
+	}
+	m.Status = model.MeetingEnded
+	m.UpdatedAt = time.Now()
+	if err := s.meetings.Update(ctx, m); err != nil {
+		return nil, fmt.Errorf("end meeting: %w", err)
+	}
+	ids, _ := s.attendeeIDs(ctx, id)
+	s.notifyMeeting(ctx, ids, tplMeetingEnded, m)
+	return s.GetMeeting(ctx, id, nil)
+}
+
+func (s *meetingService) CancelMeeting(ctx context.Context, id uuid.UUID, reason string) (*dto.MeetingResponse, error) {
+	m, err := s.mustMeeting(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canCancelMeeting(m.Status) {
+		return nil, response.NewError(response.CodeMeetingInvalidState, "当前状态不可取消")
+	}
+	m.Status = model.MeetingCancelled
+	m.CancelReason = reason
+	m.UpdatedAt = time.Now()
+	if err := s.meetings.Update(ctx, m); err != nil {
+		return nil, fmt.Errorf("cancel meeting: %w", err)
+	}
+	return s.GetMeeting(ctx, id, nil)
+}
+
+func (s *meetingService) UpdateMinutes(ctx context.Context, id uuid.UUID, minutes string) (*dto.MeetingResponse, error) {
+	m, err := s.mustMeeting(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	m.Minutes = minutes
+	m.UpdatedAt = time.Now()
+	if err := s.meetings.Update(ctx, m); err != nil {
+		return nil, fmt.Errorf("update minutes: %w", err)
+	}
+	return s.GetMeeting(ctx, id, nil)
+}
+
+func (s *meetingService) MeetingQRCode(ctx context.Context, id uuid.UUID) (*dto.QRCodeResponse, []byte, error) {
+	m, err := s.mustMeeting(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	if m.QRToken == "" {
+		m.QRToken = newQRToken()
+		m.UpdatedAt = time.Now()
+		if err := s.meetings.Update(ctx, m); err != nil {
+			return nil, nil, fmt.Errorf("save qr token: %w", err)
+		}
+	}
+	path := "/meeting/checkin?meeting_id=" + id.String() + "&token=" + m.QRToken
+	png, err := qrcode.Encode(path, qrcode.Medium, 256)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode qr: %w", err)
+	}
+	return &dto.QRCodeResponse{
+		MeetingID: id.String(), Token: m.QRToken, CheckinPath: path,
+		PNGBase64: base64.StdEncoding.EncodeToString(png),
+	}, png, nil
+}
+
+func (s *meetingService) mustMeeting(ctx context.Context, id uuid.UUID) (*model.Meeting, error) {
+	m, err := s.meetings.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get meeting: %w", err)
+	}
+	if m == nil {
+		return nil, response.NewError(response.CodeMeetingNotFound, "会议不存在")
+	}
+	return m, nil
+}
+
+func applyMeetingPatch(m *model.Meeting, req *dto.UpdateMeetingRequest) {
+	if req.Title != nil {
+		m.Title = *req.Title
+	}
+	if req.Description != nil {
+		m.Description = *req.Description
+	}
+	if req.StartTime != nil {
+		m.StartTime = *req.StartTime
+	}
+	if req.EndTime != nil {
+		m.EndTime = *req.EndTime
+	}
+	if req.Location != nil {
+		m.Location = *req.Location
+	}
+	if req.OnlineLink != nil {
+		m.OnlineLink = *req.OnlineLink
+	}
+	if req.MeetingType != nil {
+		m.MeetingType = *req.MeetingType
+	}
+}
+
+func rewriteMeetingScope(scope *rbacModel.DataScopeCondition, userID uuid.UUID) *rbacModel.DataScopeCondition {
+	if scope == nil || scope.IsEmpty() {
+		return scope
+	}
+	if scope.Query == "1 = 0" {
+		return &rbacModel.DataScopeCondition{
+			Query: "m.organizer_id = ? OR m.id IN (SELECT meeting_id FROM meeting_attendees WHERE user_id = ?)",
+			Args:  []interface{}{userID, userID},
+		}
+	}
+	q := strings.ReplaceAll(scope.Query, "department_id", "u.department_id")
+	return &rbacModel.DataScopeCondition{Query: q, Args: scope.Args}
+}
+
+func newQRToken() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return hex.EncodeToString([]byte(uuid.New().String()))
+	}
+	return hex.EncodeToString(b)
+}
+
+func parseUUIDList(raw []string) []uuid.UUID {
+	out := make([]uuid.UUID, 0, len(raw))
+	for _, s := range raw {
+		id, err := uuid.Parse(s)
+		if err == nil {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func uniqueUUIDs(ids []uuid.UUID) []uuid.UUID {
+	seen := map[uuid.UUID]struct{}{}
+	out := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}

--- a/backend/internal/meeting/service/meeting_test.go
+++ b/backend/internal/meeting/service/meeting_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func requireAppError(t *testing.T, err error, code int) {
+	t.Helper()
+	require.Error(t, err)
+	var app *response.AppError
+	require.ErrorAs(t, err, &app)
+	require.Equal(t, code, app.Code)
+}
+
+func seedMeeting(t *testing.T, svc *meetingService, mm *memMeetings, status int16) (*model.Meeting, uuid.UUID) {
+	t.Helper()
+	org := uuid.New()
+	start := time.Now().Add(time.Hour)
+	out, err := svc.CreateMeeting(context.Background(), org, &dto.CreateMeetingRequest{
+		Title: "例会", StartTime: start, EndTime: start.Add(time.Hour), MeetingType: 1, Location: "A101",
+	})
+	require.NoError(t, err)
+	id := uuid.MustParse(out.ID)
+	m, _ := mm.GetByID(context.Background(), id)
+	m.Status = status
+	_ = mm.Update(context.Background(), m)
+	return m, org
+}
+
+func TestCreateAndStartMeeting(t *testing.T) {
+	svc, mm, _, _ := newTestSvc()
+	start := time.Now().Add(time.Hour)
+	out, err := svc.CreateMeeting(context.Background(), uuid.New(), &dto.CreateMeetingRequest{
+		Title: "秋招例会", StartTime: start, EndTime: start.Add(2 * time.Hour), MeetingType: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, model.MeetingPending, out.Status)
+	started, err := svc.StartMeeting(context.Background(), uuid.MustParse(out.ID))
+	require.NoError(t, err)
+	require.Equal(t, model.MeetingOngoing, started.Status)
+	_, err = svc.StartMeeting(context.Background(), uuid.MustParse(out.ID))
+	requireAppError(t, err, response.CodeMeetingInvalidState)
+	_ = mm
+}
+
+func TestCheckinRules(t *testing.T) {
+	svc, mm, _, _ := newTestSvc()
+	m, org := seedMeeting(t, svc, mm, model.MeetingOngoing)
+	_, err := svc.Checkin(context.Background(), m.ID, uuid.New(), "")
+	requireAppError(t, err, response.CodeMeetingNotAttendee)
+	first, err := svc.Checkin(context.Background(), m.ID, org, "")
+	require.NoError(t, err)
+	require.True(t, first.Attended)
+	_, err = svc.Checkin(context.Background(), m.ID, org, "")
+	requireAppError(t, err, response.CodeMeetingDupCheckin)
+}
+
+func TestCastVoteRules(t *testing.T) {
+	svc, mm, _, vv := newTestSvc()
+	m, org := seedMeeting(t, svc, mm, model.MeetingOngoing)
+	guest := uuid.New()
+	vote, err := svc.CreateVote(context.Background(), m.ID, &dto.CreateVoteRequest{
+		Title: "方向", VoteType: model.VoteEqual,
+		Options: []dto.VoteOptionInput{{Key: "web", Label: "Web"}, {Key: "ai", Label: "AI"}},
+	})
+	require.NoError(t, err)
+	vid := uuid.MustParse(vote.ID)
+	err = svc.CastVote(context.Background(), vid, guest, "web")
+	requireAppError(t, err, response.CodeVoteNoAccess)
+	err = svc.CastVote(context.Background(), vid, org, "none")
+	requireAppError(t, err, response.CodeVoteOptionGone)
+	require.NoError(t, svc.CastVote(context.Background(), vid, org, "web"))
+	err = svc.CastVote(context.Background(), vid, org, "ai")
+	requireAppError(t, err, response.CodeVoteDuplicate)
+	_, err = svc.MyVote(context.Background(), vid, org)
+	require.NoError(t, err)
+	res, err := svc.VoteResult(context.Background(), vid)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.TotalVoters)
+	require.Equal(t, 1.0, res.TotalWeight)
+	_ = vv
+}
+
+func TestAnonymousMyVoteHidden(t *testing.T) {
+	svc, mm, _, _ := newTestSvc()
+	m, org := seedMeeting(t, svc, mm, model.MeetingOngoing)
+	vote, err := svc.CreateVote(context.Background(), m.ID, &dto.CreateVoteRequest{
+		Title: "匿名", VoteType: 1, IsAnonymous: true,
+		Options: []dto.VoteOptionInput{{Key: "a", Label: "A"}, {Key: "b", Label: "B"}},
+	})
+	require.NoError(t, err)
+	vid := uuid.MustParse(vote.ID)
+	require.NoError(t, svc.CastVote(context.Background(), vid, org, "a"))
+	_, err = svc.MyVote(context.Background(), vid, org)
+	requireAppError(t, err, response.CodeVoteAnonymousHidden)
+}
+
+func TestWeightedVoteUsesPosition(t *testing.T) {
+	svc, mm, _, _ := newTestSvc()
+	m, org := seedMeeting(t, svc, mm, model.MeetingOngoing)
+	mm.users[org] = &model.NamedUser{ID: org, RealName: "社长", PositionCode: "president"}
+	vote, err := svc.CreateVote(context.Background(), m.ID, &dto.CreateVoteRequest{
+		Title: "加权", VoteType: model.VoteWeighted,
+		Options: []dto.VoteOptionInput{{Key: "yes", Label: "同意"}, {Key: "no", Label: "反对"}},
+	})
+	require.NoError(t, err)
+	vid := uuid.MustParse(vote.ID)
+	require.NoError(t, svc.CastVote(context.Background(), vid, org, "yes"))
+	res, err := svc.VoteResult(context.Background(), vid)
+	require.NoError(t, err)
+	require.Equal(t, 5.0, res.TotalWeight)
+}

--- a/backend/internal/meeting/service/mem_test.go
+++ b/backend/internal/meeting/service/mem_test.go
@@ -1,0 +1,290 @@
+package service
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/google/uuid"
+)
+
+type memMeetings struct {
+	mu    sync.Mutex
+	items map[uuid.UUID]*model.Meeting
+	users map[uuid.UUID]*model.NamedUser
+}
+
+func newMemMeetings() *memMeetings {
+	return &memMeetings{items: map[uuid.UUID]*model.Meeting{}, users: map[uuid.UUID]*model.NamedUser{}}
+}
+
+func (m *memMeetings) Create(_ context.Context, row *model.Meeting) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *row
+	m.items[row.ID] = &cp
+	return nil
+}
+func (m *memMeetings) Update(_ context.Context, row *model.Meeting) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *row
+	m.items[row.ID] = &cp
+	return nil
+}
+func (m *memMeetings) Delete(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.items, id)
+	return nil
+}
+func (m *memMeetings) GetByID(_ context.Context, id uuid.UUID) (*model.Meeting, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	row := m.items[id]
+	if row == nil {
+		return nil, nil
+	}
+	cp := *row
+	return &cp, nil
+}
+func (m *memMeetings) GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.MeetingWithNames, error) {
+	row, err := m.GetByID(ctx, id)
+	if err != nil || row == nil {
+		return nil, err
+	}
+	return &model.MeetingWithNames{Meeting: *row, OrganizerName: "组织者"}, nil
+}
+func (m *memMeetings) List(_ context.Context, _ *dto.ListMeetingRequest, _ *rbacModel.DataScopeCondition) ([]model.MeetingWithNames, int64, error) {
+	return nil, 0, nil
+}
+func (m *memMeetings) GetUser(_ context.Context, id uuid.UUID) (*model.NamedUser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.users[id], nil
+}
+
+type memAgendas struct {
+	mu    sync.Mutex
+	items map[uuid.UUID]*model.Agenda
+}
+
+func newMemAgendas() *memAgendas { return &memAgendas{items: map[uuid.UUID]*model.Agenda{}} }
+
+func (m *memAgendas) Create(_ context.Context, a *model.Agenda) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *a
+	m.items[a.ID] = &cp
+	return nil
+}
+func (m *memAgendas) Update(_ context.Context, a *model.Agenda) error {
+	return m.Create(context.Background(), a)
+}
+func (m *memAgendas) Delete(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.items, id)
+	return nil
+}
+func (m *memAgendas) GetByID(_ context.Context, id uuid.UUID) (*model.Agenda, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.items[id] == nil {
+		return nil, nil
+	}
+	cp := *m.items[id]
+	return &cp, nil
+}
+func (m *memAgendas) ListByMeeting(_ context.Context, meetingID uuid.UUID) ([]model.Agenda, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.Agenda
+	for _, a := range m.items {
+		if a.MeetingID == meetingID {
+			out = append(out, *a)
+		}
+	}
+	return out, nil
+}
+func (m *memAgendas) SaveSort(_ context.Context, items []model.Agenda) error {
+	for i := range items {
+		_ = m.Create(context.Background(), &items[i])
+	}
+	return nil
+}
+
+type memAttendees struct {
+	mu    sync.Mutex
+	items map[string]*model.Attendee
+}
+
+func newMemAttendees() *memAttendees { return &memAttendees{items: map[string]*model.Attendee{}} }
+
+func attKey(mid, uid uuid.UUID) string { return mid.String() + ":" + uid.String() }
+
+func (m *memAttendees) Add(_ context.Context, items []model.Attendee) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := range items {
+		cp := items[i]
+		m.items[attKey(cp.MeetingID, cp.UserID)] = &cp
+	}
+	return nil
+}
+func (m *memAttendees) Remove(_ context.Context, meetingID, userID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.items, attKey(meetingID, userID))
+	return nil
+}
+func (m *memAttendees) Get(_ context.Context, meetingID, userID uuid.UUID) (*model.Attendee, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	row := m.items[attKey(meetingID, userID)]
+	if row == nil {
+		return nil, nil
+	}
+	cp := *row
+	return &cp, nil
+}
+func (m *memAttendees) Update(_ context.Context, a *model.Attendee) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *a
+	m.items[attKey(a.MeetingID, a.UserID)] = &cp
+	return nil
+}
+func (m *memAttendees) List(_ context.Context, meetingID uuid.UUID) ([]model.AttendeeNamed, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.AttendeeNamed
+	for _, a := range m.items {
+		if a.MeetingID == meetingID {
+			out = append(out, model.AttendeeNamed{Attendee: *a, RealName: "用户"})
+		}
+	}
+	return out, nil
+}
+func (m *memAttendees) IsAttendee(_ context.Context, meetingID, userID uuid.UUID) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.items[attKey(meetingID, userID)]
+	return ok, nil
+}
+
+type memVotes struct {
+	mu      sync.Mutex
+	votes   map[uuid.UUID]*model.Vote
+	options map[uuid.UUID][]model.VoteOption
+	records map[string]*model.VoteRecord
+	cfg     *model.SystemConfig
+}
+
+func newMemVotes() *memVotes {
+	return &memVotes{
+		votes:   map[uuid.UUID]*model.Vote{},
+		options: map[uuid.UUID][]model.VoteOption{},
+		records: map[string]*model.VoteRecord{},
+	}
+}
+
+func recKey(vid, uid uuid.UUID) string { return vid.String() + ":" + uid.String() }
+
+func (m *memVotes) CreateVote(_ context.Context, v *model.Vote, options []model.VoteOption) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *v
+	m.votes[v.ID] = &cp
+	m.options[v.ID] = append([]model.VoteOption{}, options...)
+	return nil
+}
+func (m *memVotes) UpdateVote(_ context.Context, v *model.Vote) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *v
+	m.votes[v.ID] = &cp
+	return nil
+}
+func (m *memVotes) GetVote(_ context.Context, id uuid.UUID) (*model.Vote, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.votes[id] == nil {
+		return nil, nil
+	}
+	cp := *m.votes[id]
+	return &cp, nil
+}
+func (m *memVotes) ListByMeeting(_ context.Context, meetingID uuid.UUID) ([]model.Vote, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.Vote
+	for _, v := range m.votes {
+		if v.MeetingID == meetingID {
+			out = append(out, *v)
+		}
+	}
+	return out, nil
+}
+func (m *memVotes) ListOptions(_ context.Context, voteID uuid.UUID) ([]model.VoteOption, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]model.VoteOption{}, m.options[voteID]...), nil
+}
+func (m *memVotes) GetOptionByKey(_ context.Context, voteID uuid.UUID, key string) (*model.VoteOption, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, o := range m.options[voteID] {
+		if o.OptionKey == key {
+			cp := o
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+func (m *memVotes) CreateRecord(_ context.Context, rec *model.VoteRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *rec
+	m.records[recKey(rec.VoteID, rec.VoterID)] = &cp
+	return nil
+}
+func (m *memVotes) GetRecord(_ context.Context, voteID, userID uuid.UUID) (*model.VoteRecord, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	row := m.records[recKey(voteID, userID)]
+	if row == nil {
+		return nil, nil
+	}
+	cp := *row
+	return &cp, nil
+}
+func (m *memVotes) ListRecords(_ context.Context, voteID uuid.UUID) ([]model.VoteRecordNamed, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.VoteRecordNamed
+	for _, r := range m.records {
+		if r.VoteID == voteID {
+			out = append(out, model.VoteRecordNamed{VoteRecord: *r})
+		}
+	}
+	return out, nil
+}
+func (m *memVotes) GetConfig(_ context.Context, _ string) (*model.SystemConfig, error) {
+	return m.cfg, nil
+}
+func (m *memVotes) UpsertConfig(_ context.Context, cfg *model.SystemConfig) error {
+	cp := *cfg
+	m.cfg = &cp
+	return nil
+}
+
+func newTestSvc() (*meetingService, *memMeetings, *memAttendees, *memVotes) {
+	mm := newMemMeetings()
+	aa := newMemAttendees()
+	vv := newMemVotes()
+	svc := NewMeetingService(mm, newMemAgendas(), aa, vv, nil).(*meetingService)
+	return svc, mm, aa, vv
+}

--- a/backend/internal/meeting/service/notify.go
+++ b/backend/internal/meeting/service/notify.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	notifdto "github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	notifsvc "github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+const (
+	tplMeetingNotice  = "meeting_notice"
+	tplMeetingStarted = "meeting_started"
+	tplMeetingEnded   = "meeting_ended"
+)
+
+type notificationAdapter struct {
+	inner notifsvc.NotificationService
+}
+
+func NewNotifier(inner notifsvc.NotificationService) Notifier {
+	if inner == nil {
+		return nil
+	}
+	return &notificationAdapter{inner: inner}
+}
+
+func (a *notificationAdapter) Send(ctx context.Context, userIDs []uuid.UUID, template string, vars map[string]interface{}) error {
+	if len(userIDs) == 0 {
+		return nil
+	}
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      userIDs,
+		TemplateCode: template,
+		Variables:    vars,
+		Channels:     []string{"in_app", "websocket"},
+	})
+}
+
+func (s *meetingService) notifyMeeting(ctx context.Context, userIDs []uuid.UUID, template string, m *model.Meeting) {
+	if s.notify == nil || len(userIDs) == 0 {
+		return
+	}
+	vars := map[string]interface{}{
+		"title":      m.Title,
+		"start_time": m.StartTime.Format("2006-01-02 15:04"),
+		"location":   m.Location,
+	}
+	if err := s.notify.Send(ctx, userIDs, template, vars); err != nil {
+		logger.Warn("send meeting notify failed", zap.Error(err), zap.String("tpl", template))
+	}
+}

--- a/backend/internal/meeting/service/result.go
+++ b/backend/internal/meeting/service/result.go
@@ -1,0 +1,21 @@
+package service
+
+import "github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+
+type optionAgg struct {
+	Count  int
+	Weight float64
+}
+
+func CalculateVoteResult(records []model.VoteRecord) (map[string]optionAgg, int, float64) {
+	agg := map[string]optionAgg{}
+	var totalWeight float64
+	for _, r := range records {
+		cur := agg[r.OptionKey]
+		cur.Count++
+		cur.Weight += r.Weight
+		agg[r.OptionKey] = cur
+		totalWeight += r.Weight
+	}
+	return agg, len(records), totalWeight
+}

--- a/backend/internal/meeting/service/result_test.go
+++ b/backend/internal/meeting/service/result_test.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateVoteResult_EqualAndWeighted(t *testing.T) {
+	recs := []model.VoteRecord{
+		{OptionKey: "web", Weight: 1},
+		{OptionKey: "web", Weight: 5},
+		{OptionKey: "ai", Weight: 3},
+	}
+	agg, total, tw := CalculateVoteResult(recs)
+	require.Equal(t, 3, total)
+	require.Equal(t, 9.0, tw)
+	require.Equal(t, 2, agg["web"].Count)
+	require.Equal(t, 6.0, agg["web"].Weight)
+	require.Equal(t, 1, agg["ai"].Count)
+	require.Equal(t, 3.0, agg["ai"].Weight)
+}

--- a/backend/internal/meeting/service/service.go
+++ b/backend/internal/meeting/service/service.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/repo"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/google/uuid"
+)
+
+type Notifier interface {
+	Send(ctx context.Context, userIDs []uuid.UUID, template string, vars map[string]interface{}) error
+}
+
+type MeetingService interface {
+	CreateMeeting(ctx context.Context, operator uuid.UUID, req *dto.CreateMeetingRequest) (*dto.MeetingResponse, error)
+	ListMeetings(ctx context.Context, viewer uuid.UUID, req *dto.ListMeetingRequest, scope *rbacModel.DataScopeCondition) ([]*dto.MeetingResponse, int64, error)
+	GetMeeting(ctx context.Context, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.MeetingResponse, error)
+	UpdateMeeting(ctx context.Context, id uuid.UUID, req *dto.UpdateMeetingRequest) (*dto.MeetingResponse, error)
+	DeleteMeeting(ctx context.Context, id uuid.UUID) error
+	StartMeeting(ctx context.Context, id uuid.UUID) (*dto.MeetingResponse, error)
+	EndMeeting(ctx context.Context, id uuid.UUID) (*dto.MeetingResponse, error)
+	CancelMeeting(ctx context.Context, id uuid.UUID, reason string) (*dto.MeetingResponse, error)
+	UpdateMinutes(ctx context.Context, id uuid.UUID, minutes string) (*dto.MeetingResponse, error)
+	MeetingQRCode(ctx context.Context, id uuid.UUID) (*dto.QRCodeResponse, []byte, error)
+
+	AddAgenda(ctx context.Context, meetingID uuid.UUID, req *dto.CreateAgendaRequest) (*dto.AgendaResponse, error)
+	UpdateAgenda(ctx context.Context, meetingID, agendaID uuid.UUID, req *dto.UpdateAgendaRequest) (*dto.AgendaResponse, error)
+	DeleteAgenda(ctx context.Context, meetingID, agendaID uuid.UUID) error
+	SortAgendas(ctx context.Context, meetingID uuid.UUID, ids []uuid.UUID) ([]dto.AgendaResponse, error)
+	ListAgendas(ctx context.Context, meetingID uuid.UUID) ([]dto.AgendaResponse, error)
+
+	ListAttendees(ctx context.Context, meetingID uuid.UUID) ([]dto.AttendeeResponse, error)
+	AddAttendees(ctx context.Context, meetingID uuid.UUID, userIDs []uuid.UUID) ([]dto.AttendeeResponse, error)
+	RemoveAttendee(ctx context.Context, meetingID, userID uuid.UUID) error
+	Checkin(ctx context.Context, meetingID, userID uuid.UUID, token string) (*dto.AttendeeResponse, error)
+
+	CreateVote(ctx context.Context, meetingID uuid.UUID, req *dto.CreateVoteRequest) (*dto.VoteResponse, error)
+	ListVotes(ctx context.Context, meetingID, viewer uuid.UUID) ([]*dto.VoteResponse, error)
+	GetVote(ctx context.Context, id, viewer uuid.UUID) (*dto.VoteResponse, error)
+	CastVote(ctx context.Context, voteID, userID uuid.UUID, optionKey string) error
+	VoteResult(ctx context.Context, id uuid.UUID) (*dto.VoteResultResponse, error)
+	CloseVote(ctx context.Context, id uuid.UUID) (*dto.VoteResponse, error)
+	MyVote(ctx context.Context, voteID, userID uuid.UUID) (*dto.MyVoteResponse, error)
+
+	GetWeightConfig(ctx context.Context) (*dto.VoteWeightConfigResponse, error)
+	UpdateWeightConfig(ctx context.Context, operator uuid.UUID, req *dto.VoteWeightConfigRequest) (*dto.VoteWeightConfigResponse, error)
+}
+
+type meetingService struct {
+	meetings  repo.MeetingRepo
+	agendas   repo.AgendaRepo
+	attendees repo.AttendeeRepo
+	votes     repo.VoteRepo
+	notify    Notifier
+}
+
+func NewMeetingService(
+	meetings repo.MeetingRepo,
+	agendas repo.AgendaRepo,
+	attendees repo.AttendeeRepo,
+	votes repo.VoteRepo,
+	notify Notifier,
+) MeetingService {
+	return &meetingService{
+		meetings: meetings, agendas: agendas, attendees: attendees, votes: votes, notify: notify,
+	}
+}

--- a/backend/internal/meeting/service/state.go
+++ b/backend/internal/meeting/service/state.go
@@ -1,0 +1,35 @@
+package service
+
+import "github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+
+func canUpdateMeeting(status int16) bool {
+	return status == model.MeetingPending
+}
+
+func canDeleteMeeting(status int16) bool {
+	return status == model.MeetingPending || status == model.MeetingCancelled
+}
+
+func canStartMeeting(status int16) bool {
+	return status == model.MeetingPending
+}
+
+func canEndMeeting(status int16) bool {
+	return status == model.MeetingOngoing
+}
+
+func canCancelMeeting(status int16) bool {
+	return status == model.MeetingPending || status == model.MeetingOngoing
+}
+
+func canCheckinMeeting(status int16) bool {
+	return status == model.MeetingPending || status == model.MeetingOngoing
+}
+
+func canCreateVote(status int16) bool {
+	return status == model.MeetingPending || status == model.MeetingOngoing
+}
+
+func canCastVote(status int16) bool {
+	return status == model.VoteOpen
+}

--- a/backend/internal/meeting/service/state_test.go
+++ b/backend/internal/meeting/service/state_test.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMeetingStateGuards(t *testing.T) {
+	require.True(t, canStartMeeting(model.MeetingPending))
+	require.False(t, canStartMeeting(model.MeetingOngoing))
+	require.True(t, canEndMeeting(model.MeetingOngoing))
+	require.False(t, canEndMeeting(model.MeetingPending))
+	require.True(t, canCancelMeeting(model.MeetingPending))
+	require.True(t, canCancelMeeting(model.MeetingOngoing))
+	require.False(t, canCancelMeeting(model.MeetingEnded))
+	require.True(t, canDeleteMeeting(model.MeetingPending))
+	require.False(t, canDeleteMeeting(model.MeetingOngoing))
+	require.True(t, canCheckinMeeting(model.MeetingOngoing))
+	require.False(t, canCreateVote(model.MeetingEnded))
+	require.True(t, canCastVote(model.VoteOpen))
+	require.False(t, canCastVote(model.VoteClosed))
+}

--- a/backend/internal/meeting/service/vote.go
+++ b/backend/internal/meeting/service/vote.go
@@ -1,0 +1,226 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *meetingService) CreateVote(ctx context.Context, meetingID uuid.UUID, req *dto.CreateVoteRequest) (*dto.VoteResponse, error) {
+	m, err := s.mustMeeting(ctx, meetingID)
+	if err != nil {
+		return nil, err
+	}
+	if !canCreateVote(m.Status) {
+		return nil, response.NewError(response.CodeMeetingInvalidState, "当前会议不可发起投票")
+	}
+	if err := validateOptions(req.Options); err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	end := (*time.Time)(nil)
+	if req.Duration > 0 {
+		t := now.Add(time.Duration(req.Duration) * time.Second)
+		end = &t
+	}
+	v := &model.Vote{
+		ID: uuid.New(), MeetingID: meetingID, Title: req.Title, Description: req.Description,
+		VoteType: req.VoteType, Status: model.VoteOpen, IsAnonymous: req.IsAnonymous,
+		StartTime: &now, EndTime: end, CreatedAt: now, UpdatedAt: now,
+	}
+	opts := make([]model.VoteOption, 0, len(req.Options))
+	for i, o := range req.Options {
+		opts = append(opts, model.VoteOption{
+			ID: uuid.New(), VoteID: v.ID, OptionText: o.Label, OptionKey: o.Key, SortOrder: i + 1,
+		})
+	}
+	if err := s.votes.CreateVote(ctx, v, opts); err != nil {
+		return nil, fmt.Errorf("create vote: %w", err)
+	}
+	return mapVote(v, opts, false), nil
+}
+
+func (s *meetingService) ListVotes(ctx context.Context, meetingID, viewer uuid.UUID) ([]*dto.VoteResponse, error) {
+	if _, err := s.mustMeeting(ctx, meetingID); err != nil {
+		return nil, err
+	}
+	rows, err := s.votes.ListByMeeting(ctx, meetingID)
+	if err != nil {
+		return nil, fmt.Errorf("list votes: %w", err)
+	}
+	out := make([]*dto.VoteResponse, 0, len(rows))
+	for i := range rows {
+		item, err := s.voteDTO(ctx, &rows[i], viewer)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func (s *meetingService) GetVote(ctx context.Context, id, viewer uuid.UUID) (*dto.VoteResponse, error) {
+	v, err := s.mustVote(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return s.voteDTO(ctx, v, viewer)
+}
+
+func (s *meetingService) CastVote(ctx context.Context, voteID, userID uuid.UUID, optionKey string) error {
+	v, err := s.ensureVoteOpen(ctx, voteID)
+	if err != nil {
+		return err
+	}
+	ok, err := s.attendees.IsAttendee(ctx, v.MeetingID, userID)
+	if err != nil {
+		return fmt.Errorf("check attendee: %w", err)
+	}
+	if !ok {
+		return response.NewError(response.CodeVoteNoAccess, "无权投票（非参会人）")
+	}
+	exist, err := s.votes.GetRecord(ctx, voteID, userID)
+	if err != nil {
+		return fmt.Errorf("get record: %w", err)
+	}
+	if exist != nil {
+		return response.NewError(response.CodeVoteDuplicate, "重复投票")
+	}
+	opt, err := s.votes.GetOptionByKey(ctx, voteID, optionKey)
+	if err != nil {
+		return fmt.Errorf("get option: %w", err)
+	}
+	if opt == nil {
+		return response.NewError(response.CodeVoteOptionGone, "投票选项不存在")
+	}
+	weight := 1.0
+	if v.VoteType == model.VoteWeighted {
+		cfg, err := s.loadWeight(ctx)
+		if err != nil {
+			return err
+		}
+		u, _ := s.meetings.GetUser(ctx, userID)
+		code := ""
+		if u != nil {
+			code = u.PositionCode
+		}
+		weight = ResolveWeight(cfg, code, v.VoteType)
+	}
+	rec := &model.VoteRecord{
+		ID: uuid.New(), VoteID: voteID, VoterID: userID, OptionID: opt.ID,
+		OptionKey: opt.OptionKey, Weight: weight, VotedAt: time.Now(),
+	}
+	if err := s.votes.CreateRecord(ctx, rec); err != nil {
+		return fmt.Errorf("cast vote: %w", err)
+	}
+	return nil
+}
+
+func (s *meetingService) VoteResult(ctx context.Context, id uuid.UUID) (*dto.VoteResultResponse, error) {
+	v, err := s.ensureExpiredClosed(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	opts, err := s.votes.ListOptions(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("list options: %w", err)
+	}
+	recs, err := s.votes.ListRecords(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("list records: %w", err)
+	}
+	plain := make([]model.VoteRecord, 0, len(recs))
+	for _, r := range recs {
+		plain = append(plain, r.VoteRecord)
+	}
+	agg, total, totalW := CalculateVoteResult(plain)
+	items := make([]dto.VoteResultItem, 0, len(opts))
+	for _, o := range opts {
+		a := agg[o.OptionKey]
+		items = append(items, dto.VoteResultItem{
+			OptionKey: o.OptionKey, OptionLabel: o.OptionText, Count: a.Count, WeightTotal: a.Weight,
+		})
+	}
+	return &dto.VoteResultResponse{
+		ID: v.ID.String(), Title: v.Title, VoteType: v.VoteType, IsAnonymous: v.IsAnonymous,
+		Status: v.Status, Results: items, TotalVoters: total, TotalWeight: totalW,
+		StartTime: v.StartTime, EndTime: v.EndTime,
+	}, nil
+}
+
+func (s *meetingService) CloseVote(ctx context.Context, id uuid.UUID) (*dto.VoteResponse, error) {
+	v, err := s.mustVote(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if v.Status != model.VoteOpen && v.Status != model.VotePending {
+		return nil, response.NewError(response.CodeVoteNotOpen, "投票未开始或已结束")
+	}
+	v.Status = model.VoteClosed
+	now := time.Now()
+	v.EndTime = &now
+	v.UpdatedAt = now
+	if err := s.votes.UpdateVote(ctx, v); err != nil {
+		return nil, fmt.Errorf("close vote: %w", err)
+	}
+	return s.voteDTO(ctx, v, uuid.Nil)
+}
+
+func (s *meetingService) MyVote(ctx context.Context, voteID, userID uuid.UUID) (*dto.MyVoteResponse, error) {
+	v, err := s.mustVote(ctx, voteID)
+	if err != nil {
+		return nil, err
+	}
+	if v.IsAnonymous {
+		return nil, response.NewError(response.CodeVoteAnonymousHidden, "匿名投票无法查看个人记录")
+	}
+	rec, err := s.votes.GetRecord(ctx, voteID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get record: %w", err)
+	}
+	if rec == nil {
+		return nil, response.NewError(response.CodeNotFound, "尚未投票")
+	}
+	return &dto.MyVoteResponse{
+		VoteID: voteID.String(), OptionKey: rec.OptionKey, Weight: rec.Weight, VotedAt: rec.VotedAt,
+	}, nil
+}
+
+func (s *meetingService) GetWeightConfig(ctx context.Context) (*dto.VoteWeightConfigResponse, error) {
+	cfg, err := s.loadWeight(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &dto.VoteWeightConfigResponse{Weights: cfg.Weights, DefaultWeight: cfg.DefaultWeight}, nil
+}
+
+func (s *meetingService) UpdateWeightConfig(ctx context.Context, operator uuid.UUID, req *dto.VoteWeightConfigRequest) (*dto.VoteWeightConfigResponse, error) {
+	raw, err := json.Marshal(model.VoteWeightConfig{Weights: req.Weights, DefaultWeight: req.DefaultWeight})
+	if err != nil {
+		return nil, response.NewError(response.CodeBadRequest, "权重配置无效")
+	}
+	exist, err := s.votes.GetConfig(ctx, model.WeightConfigKey)
+	if err != nil {
+		return nil, fmt.Errorf("get config: %w", err)
+	}
+	now := time.Now()
+	if exist == nil {
+		exist = &model.SystemConfig{
+			ID: uuid.New(), ConfigKey: model.WeightConfigKey, ConfigType: "json",
+			Description: "会议加权投票职务权重", Category: "meeting",
+		}
+	}
+	exist.ConfigValue = string(raw)
+	exist.UpdatedBy = &operator
+	exist.UpdatedAt = now
+	if err := s.votes.UpsertConfig(ctx, exist); err != nil {
+		return nil, fmt.Errorf("save config: %w", err)
+	}
+	return &dto.VoteWeightConfigResponse{Weights: req.Weights, DefaultWeight: req.DefaultWeight}, nil
+}

--- a/backend/internal/meeting/service/vote_expire_test.go
+++ b/backend/internal/meeting/service/vote_expire_test.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVoteAutoCloseOnExpire(t *testing.T) {
+	svc, mm, _, _ := newTestSvc()
+	m, org := seedMeeting(t, svc, mm, model.MeetingOngoing)
+	vote, err := svc.CreateVote(context.Background(), m.ID, &dto.CreateVoteRequest{
+		Title: "限时", VoteType: 1, Duration: 1,
+		Options: []dto.VoteOptionInput{{Key: "a", Label: "A"}, {Key: "b", Label: "B"}},
+	})
+	require.NoError(t, err)
+	vid := uuid.MustParse(vote.ID)
+	past := time.Now().Add(-time.Second)
+	row, _ := svc.votes.GetVote(context.Background(), vid)
+	row.EndTime = &past
+	_ = svc.votes.UpdateVote(context.Background(), row)
+	err = svc.CastVote(context.Background(), vid, org, "a")
+	requireAppError(t, err, response.CodeVoteNotOpen)
+	got, err := svc.GetVote(context.Background(), vid, org)
+	require.NoError(t, err)
+	require.Equal(t, model.VoteClosed, got.Status)
+}

--- a/backend/internal/meeting/service/vote_helper.go
+++ b/backend/internal/meeting/service/vote_helper.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *meetingService) loadWeight(ctx context.Context) (model.VoteWeightConfig, error) {
+	row, err := s.votes.GetConfig(ctx, model.WeightConfigKey)
+	if err != nil {
+		return model.VoteWeightConfig{}, fmt.Errorf("get weight config: %w", err)
+	}
+	if row == nil {
+		return DefaultWeightConfig(), nil
+	}
+	return parseWeightConfig(row.ConfigValue), nil
+}
+
+func (s *meetingService) mustVote(ctx context.Context, id uuid.UUID) (*model.Vote, error) {
+	v, err := s.votes.GetVote(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get vote: %w", err)
+	}
+	if v == nil {
+		return nil, response.NewError(response.CodeVoteNotFound, "投票不存在")
+	}
+	return v, nil
+}
+
+func (s *meetingService) ensureExpiredClosed(ctx context.Context, id uuid.UUID) (*model.Vote, error) {
+	v, err := s.mustVote(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if v.Status == model.VoteOpen && v.EndTime != nil && !v.EndTime.After(time.Now()) {
+		v.Status = model.VoteClosed
+		v.UpdatedAt = time.Now()
+		if err := s.votes.UpdateVote(ctx, v); err != nil {
+			return nil, fmt.Errorf("auto close vote: %w", err)
+		}
+	}
+	return v, nil
+}
+
+func (s *meetingService) ensureVoteOpen(ctx context.Context, id uuid.UUID) (*model.Vote, error) {
+	v, err := s.ensureExpiredClosed(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canCastVote(v.Status) {
+		return nil, response.NewError(response.CodeVoteNotOpen, "投票未开始或已结束")
+	}
+	return v, nil
+}
+
+func (s *meetingService) voteDTO(ctx context.Context, v *model.Vote, viewer uuid.UUID) (*dto.VoteResponse, error) {
+	v, err := s.ensureExpiredClosed(ctx, v.ID)
+	if err != nil {
+		return nil, err
+	}
+	opts, err := s.votes.ListOptions(ctx, v.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list options: %w", err)
+	}
+	hasVoted := false
+	if viewer != uuid.Nil {
+		rec, err := s.votes.GetRecord(ctx, v.ID, viewer)
+		if err != nil {
+			return nil, err
+		}
+		hasVoted = rec != nil
+	}
+	return mapVote(v, opts, hasVoted), nil
+}
+
+func validateOptions(opts []dto.VoteOptionInput) error {
+	seen := map[string]struct{}{}
+	for _, o := range opts {
+		if o.Key == "" || o.Label == "" {
+			return response.NewError(response.CodeBadRequest, "选项 key/label 不能为空")
+		}
+		if _, ok := seen[o.Key]; ok {
+			return response.NewError(response.CodeBadRequest, "选项 key 重复")
+		}
+		seen[o.Key] = struct{}{}
+	}
+	return nil
+}

--- a/backend/internal/meeting/service/weight.go
+++ b/backend/internal/meeting/service/weight.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+)
+
+func DefaultWeightConfig() model.VoteWeightConfig {
+	return model.VoteWeightConfig{
+		Weights: map[string]float64{
+			"president":      5,
+			"vice_president": 4,
+			"minister":       3,
+			"deputy":         2,
+			"vice_minister":  2,
+			"officer":        1,
+		},
+		DefaultWeight: 1,
+	}
+}
+
+func parseWeightConfig(raw string) model.VoteWeightConfig {
+	cfg := DefaultWeightConfig()
+	if raw == "" {
+		return cfg
+	}
+	var parsed model.VoteWeightConfig
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return cfg
+	}
+	if parsed.Weights == nil {
+		parsed.Weights = cfg.Weights
+	}
+	if parsed.DefaultWeight <= 0 {
+		parsed.DefaultWeight = cfg.DefaultWeight
+	}
+	return parsed
+}
+
+func ResolveWeight(cfg model.VoteWeightConfig, positionCode string, voteType int16) float64 {
+	if voteType != model.VoteWeighted {
+		return 1
+	}
+	if w, ok := cfg.Weights[positionCode]; ok {
+		return w
+	}
+	if positionCode == "vice_minister" {
+		if w, ok := cfg.Weights["deputy"]; ok {
+			return w
+		}
+	}
+	if positionCode == "deputy" {
+		if w, ok := cfg.Weights["vice_minister"]; ok {
+			return w
+		}
+	}
+	if cfg.DefaultWeight > 0 {
+		return cfg.DefaultWeight
+	}
+	return 1
+}

--- a/backend/internal/meeting/service/weight_test.go
+++ b/backend/internal/meeting/service/weight_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/meeting/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveWeight_EqualAlwaysOne(t *testing.T) {
+	cfg := DefaultWeightConfig()
+	require.Equal(t, 1.0, ResolveWeight(cfg, "president", model.VoteEqual))
+}
+
+func TestResolveWeight_FromConfig(t *testing.T) {
+	cfg := DefaultWeightConfig()
+	require.Equal(t, 5.0, ResolveWeight(cfg, "president", model.VoteWeighted))
+	require.Equal(t, 3.0, ResolveWeight(cfg, "minister", model.VoteWeighted))
+	require.Equal(t, 2.0, ResolveWeight(cfg, "vice_minister", model.VoteWeighted))
+	require.Equal(t, 2.0, ResolveWeight(cfg, "deputy", model.VoteWeighted))
+	require.Equal(t, 1.0, ResolveWeight(cfg, "unknown", model.VoteWeighted))
+}
+
+func TestParseWeightConfig_Fallback(t *testing.T) {
+	cfg := parseWeightConfig(`{"weights":{"president":9},"default_weight":2}`)
+	require.Equal(t, 9.0, cfg.Weights["president"])
+	require.Equal(t, 2.0, cfg.DefaultWeight)
+	bad := parseWeightConfig("not-json")
+	require.Equal(t, 5.0, bad.Weights["president"])
+}

--- a/backend/migrations/000022_meeting_management.down.sql
+++ b/backend/migrations/000022_meeting_management.down.sql
@@ -1,0 +1,27 @@
+DROP INDEX IF EXISTS uq_meeting_vote_options_key;
+
+ALTER TABLE meeting_vote_records
+    DROP COLUMN IF EXISTS weight,
+    DROP COLUMN IF EXISTS option_key;
+
+ALTER TABLE meeting_vote_options
+    DROP COLUMN IF EXISTS option_key;
+
+ALTER TABLE meeting_votes
+    DROP COLUMN IF EXISTS updated_at;
+
+ALTER TABLE meeting_attendees
+    DROP COLUMN IF EXISTS checked_in_at;
+
+ALTER TABLE meeting_agendas
+    DROP COLUMN IF EXISTS presenter,
+    DROP COLUMN IF EXISTS updated_at;
+
+ALTER TABLE meetings
+    DROP COLUMN IF EXISTS online_link,
+    DROP COLUMN IF EXISTS minutes,
+    DROP COLUMN IF EXISTS qr_token,
+    DROP COLUMN IF EXISTS cancel_reason;
+
+DELETE FROM permissions WHERE code = 'meeting:manage';
+DELETE FROM configs WHERE config_key = 'vote_weight_config';

--- a/backend/migrations/000022_meeting_management.up.sql
+++ b/backend/migrations/000022_meeting_management.up.sql
@@ -1,0 +1,60 @@
+-- ============================================================
+-- 000022_meeting_management.up.sql
+-- Issue #8：复用 000012 表，不改已有列名
+-- meetings.status 对齐 Issue：0待开始 1进行中 2已结束 3已取消
+-- meetings.meeting_type 保持 000012：1例会 2临时 3线上（投票类型在 meeting_votes）
+-- meeting_agendas.description 对外映射 content；speaker_id 保留
+-- meeting_vote_records.voter_id 对外映射 user_id
+-- ============================================================
+
+ALTER TABLE meetings
+    ADD COLUMN IF NOT EXISTS online_link VARCHAR(500) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS minutes TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS qr_token VARCHAR(64) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS cancel_reason VARCHAR(500) NOT NULL DEFAULT '';
+
+ALTER TABLE meeting_agendas
+    ADD COLUMN IF NOT EXISTS presenter VARCHAR(100) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE meeting_attendees
+    ADD COLUMN IF NOT EXISTS checked_in_at TIMESTAMP;
+
+ALTER TABLE meeting_votes
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE meeting_vote_options
+    ADD COLUMN IF NOT EXISTS option_key VARCHAR(64) NOT NULL DEFAULT '';
+
+UPDATE meeting_vote_options
+SET option_key = 'opt_' || id::text
+WHERE option_key = '' OR option_key IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_meeting_vote_options_key
+    ON meeting_vote_options (vote_id, option_key);
+
+ALTER TABLE meeting_vote_records
+    ADD COLUMN IF NOT EXISTS weight NUMERIC(8,2) NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS option_key VARCHAR(64) NOT NULL DEFAULT '';
+
+UPDATE meeting_vote_records r
+SET option_key = o.option_key
+FROM meeting_vote_options o
+WHERE r.option_id = o.id AND (r.option_key = '' OR r.option_key IS NULL);
+
+INSERT INTO permissions (id, name, code, resource, action, description, type, is_system, status)
+VALUES
+    (uuid_generate_v4(), '会议管理', 'meeting:manage', 'meeting', 'manage', '会议状态、议程、参会人与投票管理', 2, true, 0)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO configs (id, config_key, config_value, config_type, description, category, is_public)
+VALUES (
+    uuid_generate_v4(),
+    'vote_weight_config',
+    '{"weights":{"president":5,"vice_president":4,"minister":3,"deputy":2,"vice_minister":2,"officer":1},"default_weight":1}',
+    'json',
+    '会议加权投票职务权重',
+    'meeting',
+    false
+)
+ON CONFLICT (config_key) DO NOTHING;

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -97,8 +97,16 @@ const (
 	CodeInterviewSessionFull  = 7009 // 超过最大候选人数
 
 	// ===== Meeting module (8000-8999) =====
-	CodeMeetingNotFound = 8001 // 会议不存在
-	CodeVoteClosed      = 8002 // 投票已结束
+	CodeMeetingNotFound     = 8001 // 会议不存在
+	CodeMeetingInvalidState = 8002 // 会议状态不允许该操作
+	CodeMeetingNotAttendee  = 8003 // 非参会人，无权签到
+	CodeMeetingDupCheckin   = 8004 // 重复签到
+	CodeVoteNotFound        = 8005 // 投票不存在
+	CodeVoteNotOpen         = 8006 // 投票未开始或已结束
+	CodeVoteDuplicate       = 8007 // 重复投票
+	CodeVoteNoAccess        = 8008 // 无权投票（非参会人）
+	CodeVoteOptionGone      = 8009 // 投票选项不存在
+	CodeVoteAnonymousHidden = 8010 // 匿名投票无法查看个人记录
 
 	// ===== Task module (9000-9999) =====
 	CodeTaskNotFound = 9001 // 任务不存在

--- a/backend/scripts/seed_rbac.go
+++ b/backend/scripts/seed_rbac.go
@@ -73,6 +73,7 @@ func allSeedPermissions() []seedPerm {
 		seedPerm{Name: "面试评分", Code: "interview:evaluate", Resource: "interview", Action: "evaluate"},
 	)
 	perms = append(perms, moduleCRUD("meeting", "会议")...)
+	perms = append(perms, seedPerm{Name: "会议管理", Code: "meeting:manage", Resource: "meeting", Action: "manage"})
 	perms = append(perms, moduleCRUD("task", "任务")...)
 	perms = append(perms, moduleCRUD("internship", "实习")...)
 	perms = append(perms, moduleCRUD("workflow", "流程")...)
@@ -180,6 +181,7 @@ func seedRolePermissions(db *gorm.DB) error {
 			    AND p.action IN ('create','update'))
 			OR (p.resource = 'member' AND p.action IN ('approve','export','manage'))
 			OR (p.resource = 'interview' AND p.action IN ('manage','evaluate'))
+			OR (p.resource = 'meeting' AND p.action = 'manage')
 		)
 		ON CONFLICT (role_id, permission_id) DO NOTHING
 	`).Error; err != nil {

--- a/backend/scripts/seed_templates.go
+++ b/backend/scripts/seed_templates.go
@@ -43,6 +43,18 @@ var seedTemplatesData = []seedTemplate{
 		Schema: `{"title":"string","start_time":"string","location":"string"}`,
 	},
 	{
+		Code: "meeting_started", Name: "会议开始", Category: "meeting",
+		Title:  "会议已开始：{{.title}}",
+		Body:   "会议「{{.title}}」已开始，地点 {{.location}}。",
+		Schema: `{"title":"string","start_time":"string","location":"string"}`,
+	},
+	{
+		Code: "meeting_ended", Name: "会议结束", Category: "meeting",
+		Title:  "会议已结束：{{.title}}",
+		Body:   "会议「{{.title}}」已结束。",
+		Schema: `{"title":"string","start_time":"string","location":"string"}`,
+	},
+	{
 		Code: "discipline_notice", Name: "处分通知", Category: "system",
 		Title:  "纪律处分通知",
 		Body:   "{{.real_name}}，你收到纪律处分：{{.title}}。",

--- a/frontend/src/api/meeting.ts
+++ b/frontend/src/api/meeting.ts
@@ -2,8 +2,11 @@ import request from './request';
 import type {
   Meeting,
   MeetingAgenda,
+  MeetingAttendee,
   MeetingVote,
-  VoteRecord,
+  MeetingQRCode,
+  VoteResult,
+  VoteWeightConfig,
   CreateMeetingParams,
   UpdateMeetingParams,
   CreateVoteParams,
@@ -11,65 +14,118 @@ import type {
   PageResponse,
 } from '@/types/api';
 
-// ============================================================
-// 会议
-// ============================================================
-
-// 获取会议列表
 export function getMeetingList(params: ListMeetingParams): Promise<PageResponse<Meeting>> {
   return request.get('/meetings', { params });
 }
 
-// 获取会议详情
 export function getMeetingDetail(id: string): Promise<Meeting> {
   return request.get(`/meetings/${id}`);
 }
 
-// 创建会议
 export function createMeeting(data: CreateMeetingParams): Promise<Meeting> {
   return request.post('/meetings', data);
 }
 
-// 更新会议
 export function updateMeeting(id: string, data: UpdateMeetingParams): Promise<Meeting> {
   return request.put(`/meetings/${id}`, data);
 }
 
-// 删除会议
 export function deleteMeeting(id: string): Promise<void> {
   return request.delete(`/meetings/${id}`);
 }
 
-// 获取会议议程
+export function startMeeting(id: string): Promise<Meeting> {
+  return request.post(`/meetings/${id}/start`);
+}
+
+export function endMeeting(id: string): Promise<Meeting> {
+  return request.post(`/meetings/${id}/end`);
+}
+
+export function cancelMeeting(id: string, reason?: string): Promise<Meeting> {
+  return request.post(`/meetings/${id}/cancel`, { reason });
+}
+
+export function updateMinutes(id: string, minutes: string): Promise<Meeting> {
+  return request.put(`/meetings/${id}/minutes`, { minutes });
+}
+
+export function getMeetingQRCode(id: string): Promise<MeetingQRCode> {
+  return request.get(`/meetings/${id}/qrcode`);
+}
+
 export function getMeetingAgendas(meetingId: string): Promise<MeetingAgenda[]> {
   return request.get(`/meetings/${meetingId}/agendas`);
 }
 
-// ============================================================
-// 投票
-// ============================================================
+export function addAgenda(meetingId: string, data: {
+  title: string; content?: string; duration?: number; presenter?: string; sort_order?: number;
+}): Promise<MeetingAgenda> {
+  return request.post(`/meetings/${meetingId}/agendas`, data);
+}
 
-// 获取会议投票列表
+export function updateAgenda(meetingId: string, agendaId: string, data: {
+  title?: string; content?: string; duration?: number; presenter?: string;
+}): Promise<MeetingAgenda> {
+  return request.put(`/meetings/${meetingId}/agendas/${agendaId}`, data);
+}
+
+export function deleteAgenda(meetingId: string, agendaId: string): Promise<void> {
+  return request.delete(`/meetings/${meetingId}/agendas/${agendaId}`);
+}
+
+export function sortAgendas(meetingId: string, agenda_ids: string[]): Promise<MeetingAgenda[]> {
+  return request.put(`/meetings/${meetingId}/agendas/sort`, { agenda_ids });
+}
+
+export function getAttendees(meetingId: string): Promise<MeetingAttendee[]> {
+  return request.get(`/meetings/${meetingId}/attendees`);
+}
+
+export function addAttendees(meetingId: string, user_ids: string[]): Promise<MeetingAttendee[]> {
+  return request.post(`/meetings/${meetingId}/attendees`, { user_ids });
+}
+
+export function removeAttendee(meetingId: string, userId: string): Promise<void> {
+  return request.delete(`/meetings/${meetingId}/attendees/${userId}`);
+}
+
+export function checkinMeeting(meetingId: string, token?: string): Promise<MeetingAttendee> {
+  return request.post(`/meetings/${meetingId}/checkin`, { token });
+}
+
 export function getMeetingVotes(meetingId: string): Promise<MeetingVote[]> {
   return request.get(`/meetings/${meetingId}/votes`);
 }
 
-// 获取投票详情
+export function createVote(meetingId: string, data: CreateVoteParams): Promise<MeetingVote> {
+  return request.post(`/meetings/${meetingId}/votes`, data);
+}
+
 export function getVoteDetail(voteId: string): Promise<MeetingVote> {
-  return request.get(`/meetings/votes/${voteId}`);
+  return request.get(`/votes/${voteId}`);
 }
 
-// 创建投票
-export function createVote(data: CreateVoteParams): Promise<MeetingVote> {
-  return request.post('/meetings/votes', data);
+export function castVote(voteId: string, option_key: string): Promise<void> {
+  return request.post(`/votes/${voteId}/cast`, { option_key });
 }
 
-// 提交投票
-export function submitVote(voteId: string, optionIds: string[]): Promise<void> {
-  return request.post(`/meetings/votes/${voteId}/cast`, { option_ids: optionIds });
+export function getVoteResult(voteId: string): Promise<VoteResult> {
+  return request.get(`/votes/${voteId}/result`);
 }
 
-// 获取投票记录
-export function getVoteRecords(voteId: string): Promise<VoteRecord[]> {
-  return request.get(`/meetings/votes/${voteId}/records`);
+export function closeVote(voteId: string): Promise<MeetingVote> {
+  return request.post(`/votes/${voteId}/close`);
+}
+
+export function getMyVote(voteId: string): Promise<{ option_key: string; weight: number; voted_at: string }> {
+  return request.get(`/votes/${voteId}/my`);
+}
+
+export function getVoteWeightConfig(): Promise<VoteWeightConfig> {
+  return request.get('/system/vote-weight-config');
+}
+
+export function updateVoteWeightConfig(data: VoteWeightConfig): Promise<VoteWeightConfig> {
+  return request.put('/system/vote-weight-config', data);
 }

--- a/frontend/src/pages/meeting/CheckinPage.tsx
+++ b/frontend/src/pages/meeting/CheckinPage.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { Button, Card, Result, Space, Spin, message } from 'antd';
+import { checkinMeeting, getAttendees, getMeetingDetail, getMeetingQRCode } from '@/api/meeting';
+import { selectCurrentUser } from '@/store/slices/userSlice';
+import type { Meeting, MeetingAttendee } from '@/types/api';
+
+const CheckinPage: React.FC = () => {
+  const [params] = useSearchParams();
+  const meetingId = params.get('meeting_id') || '';
+  const token = params.get('token') || '';
+  const currentUser = useSelector(selectCurrentUser);
+  const [loading, setLoading] = useState(true);
+  const [meeting, setMeeting] = useState<Meeting | null>(null);
+  const [mine, setMine] = useState<MeetingAttendee | null>(null);
+  const [qr, setQr] = useState<string>();
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (!meetingId) {
+      setLoading(false);
+      return;
+    }
+    Promise.all([
+      getMeetingDetail(meetingId),
+      getAttendees(meetingId).catch(() => []),
+      getMeetingQRCode(meetingId).catch(() => undefined),
+    ])
+      .then(([m, list, code]) => {
+        setMeeting(m);
+        const own = list.find((a) => a.user_id === currentUser?.id) || null;
+        setMine(own);
+        if (code) setQr(code.png_base64);
+      })
+      .finally(() => setLoading(false));
+  }, [meetingId, currentUser]);
+
+  const doCheckin = async () => {
+    if (!meetingId) return;
+    await checkinMeeting(meetingId, token || undefined);
+    message.success('签到成功');
+    setDone(true);
+  };
+
+  if (loading) return <Spin />;
+  if (done) return <Result status="success" title="签到成功" subTitle={meeting?.title} />;
+
+  return (
+    <Card title="会议签到">
+      {!meeting ? (
+        <Result status="info" title="未指定会议" />
+      ) : !mine ? (
+        <Result status="warning" title="你不在参会人名单中" subTitle={meeting.title} />
+      ) : (
+        <Space direction="vertical" size={16} style={{ width: '100%' }}>
+          <div>{meeting.title}</div>
+          <div>地点：{meeting.location || '-'}</div>
+          <div>开始：{meeting.start_time?.replace('T', ' ').slice(0, 16)}</div>
+          {qr && <img alt="签到二维码" src={`data:image/png;base64,${qr}`} style={{ width: 220 }} />}
+          <Button type="primary" disabled={mine.attended} onClick={() => void doCheckin()}>
+            {mine.attended ? '已签到' : '手动签到'}
+          </Button>
+        </Space>
+      )}
+    </Card>
+  );
+};
+
+export default CheckinPage;

--- a/frontend/src/pages/meeting/DetailPage.tsx
+++ b/frontend/src/pages/meeting/DetailPage.tsx
@@ -1,0 +1,193 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button, Card, Input, Select, Space, Table, Tabs, message } from 'antd';
+import { ArrowDownOutlined, ArrowUpOutlined } from '@ant-design/icons';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { usePermission } from '@/hooks/usePermission';
+import { getUserList } from '@/api/user';
+import {
+  addAgenda, addAttendees, deleteAgenda, getAttendees, getMeetingAgendas, getMeetingDetail,
+  getMeetingQRCode, getMeetingVotes, removeAttendee, sortAgendas, updateAgenda, updateMinutes,
+} from '@/api/meeting';
+import type { Meeting, MeetingAgenda, MeetingAttendee, MeetingVote } from '@/types/api';
+import { MeetingStatusMap, MeetingTypeMap } from './meta';
+import VotePanel from './VotePanel';
+
+const DetailPage: React.FC = () => {
+  const { id = '' } = useParams();
+  const nav = useNavigate();
+  const canManage = usePermission('meeting:manage');
+  const [meeting, setMeeting] = useState<Meeting | null>(null);
+  const [agendas, setAgendas] = useState<MeetingAgenda[]>([]);
+  const [attendees, setAttendees] = useState<MeetingAttendee[]>([]);
+  const [votes, setVotes] = useState<MeetingVote[]>([]);
+  const [qr, setQr] = useState<string>();
+  const [minutes, setMinutes] = useState('');
+  const [userOpts, setUserOpts] = useState<Array<{ label: string; value: string }>>([]);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    const [m, a, t, v] = await Promise.all([
+      getMeetingDetail(id), getMeetingAgendas(id), getAttendees(id), getMeetingVotes(id),
+    ]);
+    setMeeting(m);
+    setAgendas(a);
+    setAttendees(t);
+    setVotes(v);
+    setMinutes(m.minutes || '');
+  }, [id]);
+
+  useEffect(() => { void load(); }, [load]);
+  useEffect(() => {
+    getUserList({ page: 1, page_size: 50 }).then((res) => {
+      setUserOpts(res.list.map((u) => ({ value: u.id, label: u.real_name || u.username })));
+    }).catch(() => undefined);
+  }, []);
+
+  const move = async (index: number, dir: -1 | 1) => {
+    const next = [...agendas];
+    const j = index + dir;
+    if (j < 0 || j >= next.length) return;
+    [next[index], next[j]] = [next[j], next[index]];
+    setAgendas(await sortAgendas(id, next.map((x) => x.id)));
+  };
+
+  if (!meeting) return <Card loading />;
+
+  return (
+    <Card
+      title={meeting.title}
+      extra={<Button onClick={() => nav('/meeting/list')}>返回列表</Button>}
+    >
+      <Space wrap style={{ marginBottom: 16 }}>
+        <StatusTag status={meeting.status} mapping={MeetingStatusMap} />
+        <span>{MeetingTypeMap[meeting.meeting_type]}</span>
+        <span>地点：{meeting.location || '-'}</span>
+        <span>组织者：{meeting.organizer?.name}</span>
+        <span>时间：{meeting.start_time?.replace('T', ' ').slice(0, 16)}</span>
+        {canManage && (
+          <Button onClick={() => getMeetingQRCode(id).then((c) => setQr(c.png_base64))}>签到二维码</Button>
+        )}
+      </Space>
+      {qr && <img alt="签到二维码" src={`data:image/png;base64,${qr}`} style={{ width: 180, marginBottom: 16 }} />}
+      <Tabs
+        items={[
+          {
+            key: 'agenda',
+            label: '议程',
+            children: (
+              <Space direction="vertical" style={{ width: '100%' }}>
+                {canManage && (
+                  <Button onClick={() => {
+                    const title = window.prompt('议程标题');
+                    if (!title) return;
+                    addAgenda(id, { title }).then(load);
+                  }}
+                  >
+                    添加议程
+                  </Button>
+                )}
+                <Table
+                  rowKey="id"
+                  dataSource={agendas}
+                  pagination={false}
+                  onRow={(_, index) => ({
+                    draggable: canManage,
+                    onDragStart: (e) => { e.dataTransfer.setData('text/plain', String(index)); },
+                    onDragOver: (e) => e.preventDefault(),
+                    onDrop: (e) => {
+                      e.preventDefault();
+                      const from = Number(e.dataTransfer.getData('text/plain'));
+                      const to = index ?? 0;
+                      if (Number.isNaN(from) || from === to) return;
+                      const next = [...agendas];
+                      const [item] = next.splice(from, 1);
+                      next.splice(to, 0, item);
+                      void sortAgendas(id, next.map((x) => x.id)).then(setAgendas);
+                    },
+                  })}
+                  columns={[
+                    { title: '顺序', dataIndex: 'sort_order', width: 70 },
+                    { title: '标题', dataIndex: 'title' },
+                    { title: '汇报人', dataIndex: 'presenter' },
+                    { title: '时长', dataIndex: 'duration', width: 80 },
+                    {
+                      title: '操作',
+                      width: 220,
+                      render: (_, __, index) => canManage && (
+                        <Space>
+                          <Button size="small" icon={<ArrowUpOutlined />} onClick={() => void move(index, -1)} />
+                          <Button size="small" icon={<ArrowDownOutlined />} onClick={() => void move(index, 1)} />
+                          <Button size="small" onClick={() => {
+                            const title = window.prompt('议程标题', agendas[index].title);
+                            if (!title) return;
+                            const presenter = window.prompt('汇报人', agendas[index].presenter || '') || '';
+                            void updateAgenda(id, agendas[index].id, { title, presenter }).then(load);
+                          }}
+                          >
+                            编辑
+                          </Button>
+                          <Button size="small" danger onClick={() => deleteAgenda(id, agendas[index].id).then(load)}>删</Button>
+                        </Space>
+                      ),
+                    },
+                  ]}
+                />
+              </Space>
+            ),
+          },
+          {
+            key: 'attendee',
+            label: '参会人',
+            children: (
+              <Space direction="vertical" style={{ width: '100%' }}>
+                {canManage && (
+                  <Select
+                    mode="multiple"
+                    placeholder="添加参会人"
+                    options={userOpts}
+                    style={{ width: 360 }}
+                    onChange={(ids: string[]) => { if (ids.length) addAttendees(id, ids).then(load); }}
+                  />
+                )}
+                <Table
+                  rowKey="id"
+                  dataSource={attendees}
+                  pagination={false}
+                  columns={[
+                    { title: '姓名', dataIndex: 'name' },
+                    { title: '职务', dataIndex: 'position_code' },
+                    { title: '签到', dataIndex: 'attended', render: (v: boolean) => (v ? '已签到' : '未签到') },
+                    {
+                      title: '操作',
+                      render: (_, r) => canManage && (
+                        <Button size="small" danger onClick={() => removeAttendee(id, r.user_id).then(load)}>移除</Button>
+                      ),
+                    },
+                  ]}
+                />
+              </Space>
+            ),
+          },
+          {
+            key: 'vote',
+            label: '投票',
+            children: <VotePanel meetingId={id} votes={votes} onRefresh={load} />,
+          },
+          {
+            key: 'minutes',
+            label: '纪要',
+            children: (
+              <Space direction="vertical" style={{ width: '100%' }}>
+                <Input.TextArea rows={8} value={minutes} onChange={(e) => setMinutes(e.target.value)} disabled={!canManage} />
+                {canManage && <Button type="primary" onClick={() => updateMinutes(id, minutes).then(() => message.success('已保存'))}>保存纪要</Button>}
+              </Space>
+            ),
+          },
+        ]}
+      />
+    </Card>
+  );
+};
+
+export default DetailPage;

--- a/frontend/src/pages/meeting/FormModal.tsx
+++ b/frontend/src/pages/meeting/FormModal.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect } from 'react';
+import { DatePicker, Form, Input, Modal, Select } from 'antd';
+import dayjs from 'dayjs';
+import type { Meeting } from '@/types/api';
+
+interface Props {
+  open: boolean;
+  editing: Meeting | null;
+  onCancel: () => void;
+  onSubmit: (values: Record<string, unknown>) => Promise<void>;
+}
+
+const FormModal: React.FC<Props> = ({ open, editing, onCancel, onSubmit }) => {
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    if (!open) return;
+    if (editing) {
+      form.setFieldsValue({
+        ...editing,
+        time_range: [dayjs(editing.start_time), dayjs(editing.end_time)],
+      });
+    } else {
+      form.resetFields();
+      form.setFieldsValue({ meeting_type: 1 });
+    }
+  }, [open, editing, form]);
+
+  return (
+    <Modal
+      title={editing ? '编辑会议' : '新建会议'}
+      open={open}
+      onCancel={onCancel}
+      onOk={() => form.submit()}
+      destroyOnClose
+    >
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={async (values) => {
+          const range = values.time_range as [dayjs.Dayjs, dayjs.Dayjs];
+          await onSubmit({
+            title: values.title,
+            description: values.description,
+            meeting_type: values.meeting_type,
+            location: values.location,
+            online_link: values.online_link,
+            start_time: range[0].toISOString(),
+            end_time: range[1].toISOString(),
+          });
+        }}
+      >
+        <Form.Item name="title" label="标题" rules={[{ required: true }]}>
+          <Input maxLength={200} />
+        </Form.Item>
+        <Form.Item name="meeting_type" label="类型" rules={[{ required: true }]}>
+          <Select
+            options={[
+              { value: 1, label: '例会' },
+              { value: 2, label: '临时会议' },
+              { value: 3, label: '线上会议' },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item name="time_range" label="时间" rules={[{ required: true }]}>
+          <DatePicker.RangePicker showTime style={{ width: '100%' }} />
+        </Form.Item>
+        <Form.Item name="location" label="地点">
+          <Input />
+        </Form.Item>
+        <Form.Item name="online_link" label="线上链接">
+          <Input />
+        </Form.Item>
+        <Form.Item name="description" label="说明">
+          <Input.TextArea rows={3} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default FormModal;

--- a/frontend/src/pages/meeting/ListPage.tsx
+++ b/frontend/src/pages/meeting/ListPage.tsx
@@ -1,0 +1,130 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Card, Input, Select, Space, Table, message } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { usePermission } from '@/hooks/usePermission';
+import {
+  cancelMeeting, createMeeting, deleteMeeting, endMeeting, getMeetingList, startMeeting, updateMeeting,
+} from '@/api/meeting';
+import type { Meeting, MeetingStatus } from '@/types/api';
+import { MeetingStatusMap, MeetingTypeMap } from './meta';
+import FormModal from './FormModal';
+
+const ListPage: React.FC = () => {
+  const nav = useNavigate();
+  const canCreate = usePermission('meeting:create');
+  const canManage = usePermission('meeting:manage');
+  const [list, setList] = useState<Meeting[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState<MeetingStatus | undefined>();
+  const [keyword, setKeyword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Meeting | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getMeetingList({ page, page_size: 10, status, keyword });
+      setList(res.list);
+      setTotal(res.total);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, status, keyword]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const columns: ColumnsType<Meeting> = [
+    { title: '标题', dataIndex: 'title' },
+    { title: '类型', dataIndex: 'meeting_type', width: 100, render: (v: number) => MeetingTypeMap[v] || '-' },
+    { title: '地点', dataIndex: 'location', render: (v?: string) => v || '-' },
+    { title: '开始', dataIndex: 'start_time', width: 180, render: (v: string) => v?.replace('T', ' ').slice(0, 16) },
+    { title: '组织者', key: 'org', width: 100, render: (_, r) => r.organizer?.name || '-' },
+    { title: '签到', key: 'n', width: 90, render: (_, r) => `${r.checked_in_count}/${r.attendee_count}` },
+    { title: '状态', dataIndex: 'status', width: 90, render: (v: number) => <StatusTag status={v} mapping={MeetingStatusMap} /> },
+    {
+      title: '操作',
+      width: 280,
+      render: (_, record) => (
+        <Space wrap>
+          <Button type="link" size="small" onClick={() => nav(`/meeting/${record.id}`)}>详情</Button>
+          {canManage && record.status === 0 && (
+            <Button type="link" size="small" onClick={() => { setEditing(record); setOpen(true); }}>编辑</Button>
+          )}
+          {canManage && record.status === 0 && (
+            <Button type="link" size="small" onClick={() => startMeeting(record.id).then(load)}>开始</Button>
+          )}
+          {canManage && record.status === 1 && (
+            <Button type="link" size="small" onClick={() => endMeeting(record.id).then(load)}>结束</Button>
+          )}
+          {canManage && (record.status === 0 || record.status === 1) && (
+            <Button type="link" size="small" onClick={() => cancelMeeting(record.id).then(load)}>取消</Button>
+          )}
+          {canManage && (record.status === 0 || record.status === 3) && (
+            <Button type="link" size="small" danger onClick={() => deleteMeeting(record.id).then(load)}>删除</Button>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Card
+      title="会议列表"
+      extra={canCreate && (
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => { setEditing(null); setOpen(true); }}>
+          新建会议
+        </Button>
+      )}
+    >
+      <Space style={{ marginBottom: 16 }}>
+        <Input.Search allowClear placeholder="搜索标题/地点" onSearch={(v) => { setKeyword(v); setPage(1); }} />
+        <Select
+          allowClear
+          placeholder="状态"
+          style={{ width: 140 }}
+          value={status}
+          onChange={(v) => { setStatus(v); setPage(1); }}
+          options={Object.entries(MeetingStatusMap).map(([k, v]) => ({ value: Number(k), label: v.text }))}
+        />
+      </Space>
+      <Table
+        rowKey="id"
+        loading={loading}
+        columns={columns}
+        dataSource={list}
+        pagination={{ current: page, total, pageSize: 10, onChange: setPage }}
+      />
+      <FormModal
+        open={open}
+        editing={editing}
+        onCancel={() => setOpen(false)}
+        onSubmit={async (values) => {
+          if (editing) {
+            await updateMeeting(editing.id, values);
+            message.success('已更新');
+          } else {
+            await createMeeting({
+              title: String(values.title),
+              description: values.description ? String(values.description) : undefined,
+              meeting_type: Number(values.meeting_type),
+              start_time: String(values.start_time),
+              end_time: String(values.end_time),
+              location: values.location ? String(values.location) : undefined,
+              online_link: values.online_link ? String(values.online_link) : undefined,
+            });
+            message.success('已创建');
+          }
+          setOpen(false);
+          await load();
+        }}
+      />
+    </Card>
+  );
+};
+
+export default ListPage;

--- a/frontend/src/pages/meeting/VotePanel.tsx
+++ b/frontend/src/pages/meeting/VotePanel.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Card, Empty, Form, Input, InputNumber, Progress, Radio, Space, Switch, message } from 'antd';
+import ReactECharts from 'echarts-for-react';
+import { usePermission } from '@/hooks/usePermission';
+import { castVote, closeVote, createVote, getVoteResult } from '@/api/meeting';
+import type { MeetingVote, VoteResult } from '@/types/api';
+import { VoteStatusMap, VoteTypeMap } from './meta';
+import StatusTag from '@/components/StatusTag/StatusTag';
+
+interface Props {
+  meetingId: string;
+  votes: MeetingVote[];
+  onRefresh: () => Promise<void>;
+}
+
+const VotePanel: React.FC<Props> = ({ meetingId, votes, onRefresh }) => {
+  const canManage = usePermission('meeting:manage');
+  const [form] = Form.useForm();
+  const [results, setResults] = useState<Record<string, VoteResult>>({});
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(t);
+  }, []);
+
+  useEffect(() => {
+    votes.forEach((v) => {
+      getVoteResult(v.id).then((r) => setResults((prev) => ({ ...prev, [v.id]: r }))).catch(() => undefined);
+    });
+  }, [votes]);
+
+  const remain = (v: MeetingVote) => {
+    if (!v.end_time || v.status !== 1) return '';
+    const ms = new Date(v.end_time).getTime() - now;
+    if (ms <= 0) return '已到期';
+    const s = Math.floor(ms / 1000);
+    return `剩余 ${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+  };
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }} size={16}>
+      {canManage && (
+        <Card size="small" title="发起投票">
+          <Form
+            form={form}
+            layout="vertical"
+            initialValues={{ vote_type: 1, duration: 300, is_anonymous: false }}
+            onFinish={async (values) => {
+              const labels = String(values.options || '').split('\n').map((s) => s.trim()).filter(Boolean);
+              if (labels.length < 2) {
+                message.error('至少两个选项，每行一个');
+                return;
+              }
+              await createVote(meetingId, {
+                title: values.title,
+                description: values.description,
+                vote_type: values.vote_type,
+                is_anonymous: values.is_anonymous,
+                duration: values.duration,
+                options: labels.map((label, i) => ({ key: `opt${i + 1}`, label })),
+              });
+              message.success('投票已开始');
+              form.resetFields();
+              await onRefresh();
+            }}
+          >
+            <Form.Item name="title" label="标题" rules={[{ required: true }]}><Input /></Form.Item>
+            <Form.Item name="description" label="说明"><Input.TextArea rows={2} /></Form.Item>
+            <Form.Item name="vote_type" label="类型">
+              <Radio.Group options={[{ value: 1, label: '等权' }, { value: 2, label: '加权' }]} />
+            </Form.Item>
+            <Form.Item name="is_anonymous" label="匿名" valuePropName="checked"><Switch /></Form.Item>
+            <Form.Item name="duration" label="时长（秒，0 为手动关闭）"><InputNumber min={0} style={{ width: '100%' }} /></Form.Item>
+            <Form.Item name="options" label="选项（每行一个）" rules={[{ required: true }]}>
+              <Input.TextArea rows={3} placeholder={'Web 开发\nAI/ML'} />
+            </Form.Item>
+            <Button type="primary" htmlType="submit">创建并开始</Button>
+          </Form>
+        </Card>
+      )}
+      {votes.length === 0 && <Empty description="暂无投票" />}
+      {votes.map((v) => {
+        const result = results[v.id];
+        const max = result ? Math.max(...result.results.map((r) => r.weight_total), 1) : 1;
+        return (
+          <Card
+            key={v.id}
+            size="small"
+            title={`${v.title} · ${VoteTypeMap[v.vote_type]}`}
+            extra={<Space><StatusTag status={v.status} mapping={VoteStatusMap} /><span>{remain(v)}</span></Space>}
+          >
+            <div style={{ marginBottom: 8 }}>{v.description}</div>
+            {v.status === 1 && !v.has_voted && (
+              <Space wrap>
+                {v.options.map((o) => (
+                  <Button key={o.key} onClick={() => castVote(v.id, o.key).then(() => { message.success('已投票'); void onRefresh(); })}>
+                    {o.label}
+                  </Button>
+                ))}
+              </Space>
+            )}
+            {v.has_voted && <div style={{ marginBottom: 8 }}>你已投票{v.is_anonymous ? '（匿名）' : ''}</div>}
+            {canManage && v.status === 1 && (
+              <Button size="small" onClick={() => closeVote(v.id).then(onRefresh)}>关闭投票</Button>
+            )}
+            {result && (
+              <>
+                {result.results.map((r) => (
+                  <div key={r.option_key} style={{ marginTop: 8 }}>
+                    <div>{r.option_label} · {r.count} 票 · 权重 {r.weight_total}</div>
+                    <Progress percent={Math.round((r.weight_total / max) * 100)} />
+                  </div>
+                ))}
+                <ReactECharts
+                  style={{ height: 260, marginTop: 12 }}
+                  option={{
+                    tooltip: { trigger: 'item' },
+                    legend: { bottom: 0 },
+                    series: [{
+                      type: 'pie',
+                      radius: ['35%', '65%'],
+                      data: result.results.map((r) => ({ name: r.option_label, value: r.weight_total })),
+                    }],
+                  }}
+                />
+              </>
+            )}
+          </Card>
+        );
+      })}
+    </Space>
+  );
+};
+
+export default VotePanel;

--- a/frontend/src/pages/meeting/WeightPage.tsx
+++ b/frontend/src/pages/meeting/WeightPage.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Card, Form, InputNumber, Space, message } from 'antd';
+import { usePermission } from '@/hooks/usePermission';
+import { getVoteWeightConfig, updateVoteWeightConfig } from '@/api/meeting';
+
+const fields = [
+  { key: 'president', label: '社长' },
+  { key: 'vice_president', label: '副社长' },
+  { key: 'minister', label: '部长' },
+  { key: 'deputy', label: '副部长' },
+  { key: 'officer', label: '干事' },
+];
+
+const WeightPage: React.FC = () => {
+  const canEdit = usePermission('system:config');
+  const [form] = Form.useForm();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getVoteWeightConfig()
+      .then((cfg) => {
+        form.setFieldsValue({
+          default_weight: cfg.default_weight,
+          ...cfg.weights,
+        });
+      })
+      .finally(() => setLoading(false));
+  }, [form]);
+
+  return (
+    <Card title="投票权重配置" loading={loading}>
+      <p>加权投票按职务读取此处配置，不硬编码。社长可用系统配置权限修改。</p>
+      <Form
+        form={form}
+        layout="vertical"
+        disabled={!canEdit}
+        onFinish={async (values) => {
+          const weights: Record<string, number> = {};
+          fields.forEach((f) => { weights[f.key] = Number(values[f.key]); });
+          weights.vice_minister = weights.deputy;
+          await updateVoteWeightConfig({
+            weights,
+            default_weight: Number(values.default_weight),
+          });
+          message.success('已保存');
+        }}
+      >
+        {fields.map((f) => (
+          <Form.Item key={f.key} name={f.key} label={f.label} rules={[{ required: true }]}>
+            <InputNumber min={0.1} step={0.5} style={{ width: 200 }} />
+          </Form.Item>
+        ))}
+        <Form.Item name="default_weight" label="默认权重" rules={[{ required: true }]}>
+          <InputNumber min={0.1} step={0.5} style={{ width: 200 }} />
+        </Form.Item>
+        {canEdit && (
+          <Space>
+            <Button type="primary" htmlType="submit">保存</Button>
+          </Space>
+        )}
+      </Form>
+    </Card>
+  );
+};
+
+export default WeightPage;

--- a/frontend/src/pages/meeting/meta.ts
+++ b/frontend/src/pages/meeting/meta.ts
@@ -1,0 +1,26 @@
+import type { StatusMap } from '@/types/common';
+
+export const MeetingStatusMap: StatusMap = {
+  0: { color: 'default', text: '待开始' },
+  1: { color: 'processing', text: '进行中' },
+  2: { color: 'success', text: '已结束' },
+  3: { color: 'error', text: '已取消' },
+};
+
+export const MeetingTypeMap: Record<number, string> = {
+  1: '例会',
+  2: '临时会议',
+  3: '线上会议',
+};
+
+export const VoteStatusMap: StatusMap = {
+  0: { color: 'default', text: '未开始' },
+  1: { color: 'processing', text: '投票中' },
+  2: { color: 'success', text: '已结束' },
+  3: { color: 'error', text: '已取消' },
+};
+
+export const VoteTypeMap: Record<number, string> = {
+  1: '等权投票',
+  2: '加权投票',
+};

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -24,6 +24,10 @@ const InterviewScorePage = lazy(() => import('@/pages/interview/ScorePage'));
 const InterviewMyPage = lazy(() => import('@/pages/interview/MyInterviewPage'));
 const InterviewStatsPage = lazy(() => import('@/pages/interview/StatsPage'));
 const InterviewCheckinPage = lazy(() => import('@/pages/interview/CheckinPage'));
+const MeetingListPage = lazy(() => import('@/pages/meeting/ListPage'));
+const MeetingDetailPage = lazy(() => import('@/pages/meeting/DetailPage'));
+const MeetingCheckinPage = lazy(() => import('@/pages/meeting/CheckinPage'));
+const MeetingWeightPage = lazy(() => import('@/pages/meeting/WeightPage'));
 const WorkflowDesigner = lazy(() => import('@/pages/workflow/designer/DesignerPage'));
 const Forbidden = lazy(() => import('@/pages/error/Forbidden'));
 const NotFound = lazy(() => import('@/pages/error/NotFound'));
@@ -174,13 +178,23 @@ const routes: AppRouteObject[] = [
         children: [
           {
             path: 'list',
-            element: <div style={{ padding: 24 }}>会议列表（开发中）</div>,
-            meta: { title: '会议列表' },
+            element: lazyGuarded(MeetingListPage, 'meeting:read'),
+            meta: { title: '会议列表', permission: 'meeting:read' },
           },
           {
             path: 'vote',
-            element: <div style={{ padding: 24 }}>投票管理（开发中）</div>,
-            meta: { title: '投票管理' },
+            element: lazyGuarded(MeetingWeightPage, 'meeting:read'),
+            meta: { title: '投票权重', permission: 'meeting:read' },
+          },
+          {
+            path: 'checkin',
+            element: lazyWrap(MeetingCheckinPage),
+            meta: { title: '会议签到' },
+          },
+          {
+            path: ':id',
+            element: lazyGuarded(MeetingDetailPage, 'meeting:read'),
+            meta: { title: '会议详情', permission: 'meeting:read' },
           },
         ],
       },

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -189,12 +189,12 @@ const routes: AppRouteObject[] = [
           {
             path: 'checkin',
             element: lazyWrap(MeetingCheckinPage),
-            meta: { title: '会议签到' },
+            meta: { title: '会议签到', hidden: true },
           },
           {
             path: ':id',
             element: lazyGuarded(MeetingDetailPage, 'meeting:read'),
-            meta: { title: '会议详情', permission: 'meeting:read' },
+            meta: { title: '会议详情', permission: 'meeting:read', hidden: true },
           },
         ],
       },

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -513,21 +513,28 @@ export interface ListInterviewParams extends ListParams {
 // ============================================================
 
 export type MeetingStatus = 0 | 1 | 2 | 3;
-// 0=草稿 1=已发布 2=进行中 3=已结束
+// 0=待开始 1=进行中 2=已结束 3=已取消
+
+export interface MeetingOrganizer {
+  id: string;
+  name: string;
+}
 
 export interface Meeting {
   id: string;
   title: string;
   description?: string;
   status: MeetingStatus;
-  meeting_type: number; // 1=例会 2=临时会议 3=线上
+  meeting_type: number; // 1=例会 2=临时 3=线上
   start_time: string;
   end_time: string;
   location?: string;
-  organizer_id: string;
-  organizer_name: string;
-  participant_ids: string[];
-  participant_count: number;
+  online_link?: string;
+  organizer: MeetingOrganizer;
+  minutes?: string;
+  cancel_reason?: string;
+  attendee_count: number;
+  checked_in_count: number;
   created_at: string;
   updated_at: string;
 }
@@ -536,45 +543,68 @@ export interface MeetingAgenda {
   id: string;
   meeting_id: string;
   title: string;
-  description?: string;
-  sort: number;
-  duration?: number;
-  speaker_id?: string;
-  speaker_name?: string;
+  content: string;
+  duration: number;
+  sort_order: number;
+  presenter: string;
 }
 
-export type VoteStatus = 0 | 1 | 2;
-// 0=未开始 1=进行中 2=已结束
+export interface MeetingAttendee {
+  id: string;
+  user_id: string;
+  name: string;
+  position_code?: string;
+  attended: boolean;
+  checked_in_at?: string;
+}
+
+export type VoteStatus = 0 | 1 | 2 | 3;
 
 export interface MeetingVote {
   id: string;
   meeting_id: string;
   title: string;
   description?: string;
-  vote_type: number; // 1=等权投票 2=加权投票
-  status: VoteStatus;
+  vote_type: 1 | 2;
   is_anonymous: boolean;
-  options: VoteOption[];
-  total_votes: number;
+  options: Array<{ key: string; label: string }>;
+  status: VoteStatus;
   start_time?: string;
   end_time?: string;
+  has_voted: boolean;
   created_at: string;
 }
 
-export interface VoteOption {
-  id: string;
-  text: string;
+export interface VoteResultItem {
+  option_key: string;
+  option_label: string;
   count: number;
-  weight?: number;
+  weight_total: number;
 }
 
-export interface VoteRecord {
+export interface VoteResult {
   id: string;
-  vote_id: string;
-  voter_id: string;
-  voter_name: string;
-  option_id: string;
-  voted_at: string;
+  title: string;
+  vote_type: 1 | 2;
+  is_anonymous: boolean;
+  status: VoteStatus;
+  results: VoteResultItem[];
+  total_voters: number;
+  total_weight: number;
+  start_time?: string;
+  end_time?: string;
+}
+
+export interface MeetingQRCode {
+  meeting_id: string;
+  token: string;
+  checkin_path: string;
+  png_base64: string;
+}
+
+export interface VoteWeightConfig {
+  weights: Record<string, number>;
+  default_weight: number;
 }
 
 export interface CreateMeetingParams {
@@ -584,35 +614,33 @@ export interface CreateMeetingParams {
   start_time: string;
   end_time: string;
   location?: string;
-  participant_ids: string[];
-  agendas?: Array<{ title: string; description?: string; sort: number }>;
+  online_link?: string;
+  user_ids?: string[];
 }
 
 export interface UpdateMeetingParams {
   title?: string;
   description?: string;
-  status?: MeetingStatus;
   meeting_type?: number;
   start_time?: string;
   end_time?: string;
   location?: string;
-  participant_ids?: string[];
+  online_link?: string;
 }
 
 export interface ListMeetingParams extends ListParams {
   status?: MeetingStatus;
-  meeting_type?: number;
+  start_date?: string;
+  end_date?: string;
 }
 
 export interface CreateVoteParams {
-  meeting_id: string;
   title: string;
   description?: string;
-  vote_type: number;
+  vote_type: 1 | 2;
   is_anonymous: boolean;
-  options: string[];
-  start_time?: string;
-  end_time?: string;
+  options: Array<{ key: string; label: string }>;
+  duration: number;
 }
 
 // ============================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 Issue #8 会议管理与投票（等权 + 加权）。复用 `000012` 表，**不改已有列名**，由迁移 `000022` 补列。

- 会议 CRUD + 待开始→进行中→已结束/已取消
- 议程 CRUD + 拖拽/上下排序
- 参会人添加/移除；签到（二维码 + 手动），8003/8004
- 等权投票权重=1；加权投票读 `configs.vote_weight_config`（不硬编码）
- 匿名投票不暴露个人记录（8010）；重复投票 8007
- 投票时长到期自动关闭
- 创建/开始/结束发送会议通知（失败只打日志）
- 前端：列表、详情（议程/参会人/投票/纪要）、签到、权重配置

## 关联 Issue

Closes #8

## 测试方式

1. 跑迁移 `000022`，再 `APP_ENV=dev make seed`
2. `cd backend && go test ./internal/meeting/service/`
3. 登录 `admin/admin123`：`/meeting/list` 建会 → 详情加人/议程 → 开始 → 等权/加权投票 → `/meeting/checkin` 签到
4. `/meeting/vote` 查看权重配置（修改需 `system:config`）

本地已验证：创建会议、开始、签到 8004、等权 8007、加权（社长职务权重 5）、CI 4/4 全绿。

## 截图 / GIF

| 页面/功能 | 截图 |
|----------|------|
| 会议列表 | [会议列表](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmeeting_list.webp) |
| 投票进度与饼图 | [会议投票](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmeeting_detail_vote.webp) |
| 权重配置 | [投票权重](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmeeting_weight.webp) |

## 注意事项

- `meetings.status` 对齐 Issue：0待开始 1进行中 2已结束 3已取消
- `meetings.meeting_type` 保持 1例会 2临时 3线上；投票类型在 `meeting_votes.vote_type`
- `speaker_id` / `voter_id` / `description` 列名保留，API 对外映射 presenter / user_id / content
- 权重配置键：`vote_weight_config`；`deputy` 与 `vice_minister` 互认
- 开发库是 `starbyte_dev`（`APP_ENV=dev`）
- 加权要生效需用户绑定 `positions`（无职务走 default_weight）

## 检查清单

- [x] 代码遵循项目开发规范
- [x] 已进行自测（单测 + API + 浏览器）
- [x] 已更新 TEAM_DEV_GUIDE
- [x] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

