### PR TITLE
feat(task): 任务流转看板、状态机与超时提醒 (#9)

### DIFF
--- a/TEAM_DEV_GUIDE.md
+++ b/TEAM_DEV_GUIDE.md
@@ -928,8 +928,8 @@ AI 系统提示词（见 8.2 节）已包含强制变更检查步骤。当开发
 |-------|------|------|------|------|
 | [#6](https://github.com/Yogdunana/StarByte/issues/6) | 入会申请 + 人员档案 | fullstack | #1, #2, #4 | 完成（`000020` 补列；勿另起表） |
 | [#7](https://github.com/Yogdunana/StarByte/issues/7) | 面试管理 | fullstack | #1, #2, #6 | 完成（`000021` 补列；勿另起表） |
-| [#8](https://github.com/Yogdunana/StarByte/issues/8) | 会议管理 + 投票系统（等权 + 加权） | fullstack | #1, #4 | 进行中（`000022` 补列；勿另起表） |
-| [#9](https://github.com/Yogdunana/StarByte/issues/9) | 任务流转 | fullstack | #1, #4 | |
+| [#8](https://github.com/Yogdunana/StarByte/issues/8) | 会议管理 + 投票系统（等权 + 加权） | fullstack | #1, #4 | 完成（`000022` 补列；勿另起表） |
+| [#9](https://github.com/Yogdunana/StarByte/issues/9) | 任务流转 | fullstack | #1, #4 | 进行中（`000023` 补列 + `task_logs`；勿另起表） |
 | [#10](https://github.com/Yogdunana/StarByte/issues/10) | IT 实习管理 | fullstack | #1, #4 | |
 | [#11](https://github.com/Yogdunana/StarByte/issues/11) | 数据统计与可视化报表 | fullstack | #1, #5 | |
 | #22 | 财务管理模块（一期预留接口） | fullstack | #1, #4 | |

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -34,6 +34,9 @@ import (
 	rbacHandler "github.com/Yogdunana/StarByte/backend/internal/rbac/handler"
 	rbacRepo "github.com/Yogdunana/StarByte/backend/internal/rbac/repo"
 	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	taskHandler "github.com/Yogdunana/StarByte/backend/internal/task/handler"
+	taskRepo "github.com/Yogdunana/StarByte/backend/internal/task/repo"
+	taskService "github.com/Yogdunana/StarByte/backend/internal/task/service"
 	"github.com/Yogdunana/StarByte/backend/internal/user/handler"
 	"github.com/Yogdunana/StarByte/backend/internal/user/repo"
 	"github.com/Yogdunana/StarByte/backend/internal/user/service"
@@ -227,6 +230,17 @@ func main() {
 	mtSvc := meetingService.NewMeetingService(mtMeetingRepo, mtAgendaRepo, mtAttendeeRepo, mtVoteRepo, mtNotifier)
 	mtH := meetingHandler.NewMeetingHandler(mtSvc)
 
+	// 任务流转
+	tkTaskRepo := taskRepo.NewTaskRepo(database.DB())
+	tkLogRepo := taskRepo.NewLogRepo(database.DB())
+	tkCommentRepo := taskRepo.NewCommentRepo(database.DB())
+	tkAttachRepo := taskRepo.NewAttachmentRepo(database.DB())
+	tkNotifier := taskService.NewNotifier(notifSvc)
+	tkSvc := taskService.NewTaskService(tkTaskRepo, tkLogRepo, tkCommentRepo, tkAttachRepo, tkNotifier, fileSvc, objectStore)
+	tkH := taskHandler.NewTaskHandler(tkSvc)
+	taskReminder := taskService.NewReminderScheduler(tkSvc)
+	taskReminder.Start()
+
 	// 审计日志模块
 	auditR := auditRepo.NewAuditRepo(database.DB())
 	auditSvc := auditService.NewAuditService(auditR, &cfg.MinIO)
@@ -295,6 +309,9 @@ func main() {
 		// 会议管理 + 投票（/meetings, /votes, /system/vote-weight-config）
 		meetingHandler.RegisterRoutes(protected, mtH, cacheService, database.DB(), deptRepo)
 
+		// 任务流转（/tasks，不与 /workflow/tasks 冲突）
+		taskHandler.RegisterRoutes(protected, tkH, cacheService, database.DB(), deptRepo)
+
 		// 审计日志模块路由（/system/audit-logs，audit:read / audit:export / audit:archive）
 		auditHandler.RegisterRoutes(protected, auditH, cacheService)
 	}
@@ -342,6 +359,7 @@ func main() {
 
 	// 停止审计日志归档定时任务
 	archiveScheduler.Stop()
+	taskReminder.Stop()
 
 	logger.Info("server exited")
 }

--- a/backend/internal/task/dto/extra.go
+++ b/backend/internal/task/dto/extra.go
@@ -1,0 +1,48 @@
+package dto
+
+import "time"
+
+type CommentRequest struct {
+	Content  string   `json:"content" binding:"required,max=2000"`
+	Mentions []string `json:"mentions"`
+}
+
+type CommentResponse struct {
+	ID        string    `json:"id"`
+	TaskID    string    `json:"task_id"`
+	UserID    string    `json:"user_id"`
+	User      Person    `json:"user"`
+	Content   string    `json:"content"`
+	Mentions  []string  `json:"mentions"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type LogResponse struct {
+	ID         string    `json:"id"`
+	ActionType string    `json:"action_type"`
+	OldValue   string    `json:"old_value"`
+	NewValue   string    `json:"new_value"`
+	Operator   Person    `json:"operator"`
+	Comment    string    `json:"comment"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+type AttachmentResponse struct {
+	ID         string    `json:"id"`
+	TaskID     string    `json:"task_id"`
+	FileID     string    `json:"file_id"`
+	FileName   string    `json:"file_name"`
+	FilePath   string    `json:"file_path"`
+	FileSize   int64     `json:"file_size"`
+	FileType   string    `json:"file_type"`
+	UploadedBy string    `json:"uploaded_by"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+type StatsResponse struct {
+	Total      int64            `json:"total"`
+	Overdue    int64            `json:"overdue"`
+	ByStatus   map[string]int64 `json:"by_status"`
+	ByPriority map[string]int64 `json:"by_priority"`
+}

--- a/backend/internal/task/dto/task.go
+++ b/backend/internal/task/dto/task.go
@@ -1,0 +1,106 @@
+package dto
+
+import "time"
+
+type Person struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Avatar string `json:"avatar,omitempty"`
+}
+
+type ParentRef struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+type CreateTaskRequest struct {
+	Title        string     `json:"title" binding:"required,max=200"`
+	Description  string     `json:"description"`
+	Priority     int16      `json:"priority" binding:"oneof=0 1 2 3"`
+	AssigneeID   string     `json:"assignee_id"`
+	DepartmentID string     `json:"department_id"`
+	DueDate      *time.Time `json:"due_date"`
+	Tags         []string   `json:"tags"`
+	ParentID     string     `json:"parent_id"`
+}
+
+type UpdateTaskRequest struct {
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	Priority    *int16     `json:"priority"`
+	DueDate     *time.Time `json:"due_date"`
+	Tags        []string   `json:"tags"`
+}
+
+type ListTaskRequest struct {
+	Page         int    `form:"page"`
+	PageSize     int    `form:"page_size"`
+	Status       *int16 `form:"status"`
+	Priority     *int16 `form:"priority"`
+	AssigneeID   string `form:"assignee_id"`
+	DepartmentID string `form:"department_id"`
+	Keyword      string `form:"keyword"`
+	Tags         string `form:"tags"`
+	SortBy       string `form:"sort_by"`
+	SortOrder    string `form:"sort_order"`
+	ParentID     string `form:"parent_id"`
+}
+
+type MyTaskRequest struct {
+	Page     int    `form:"page"`
+	PageSize int    `form:"page_size"`
+	Priority *int16 `form:"priority"`
+	Keyword  string `form:"keyword"`
+	Status   *int16 `form:"status"`
+}
+
+type StatsRequest struct {
+	DepartmentID string `form:"department_id"`
+	StartDate    string `form:"start_date"`
+	EndDate      string `form:"end_date"`
+}
+
+type TaskResponse struct {
+	ID              string      `json:"id"`
+	Title           string      `json:"title"`
+	Description     string      `json:"description"`
+	Priority        int16       `json:"priority"`
+	Status          int16       `json:"status"`
+	Assignee        *Person     `json:"assignee,omitempty"`
+	Creator         Person      `json:"creator"`
+	Department      *Person     `json:"department,omitempty"`
+	Parent          *ParentRef  `json:"parent,omitempty"`
+	Children        []TaskBrief `json:"children"`
+	DueDate         *time.Time  `json:"due_date,omitempty"`
+	CompletedAt     *time.Time  `json:"completed_at,omitempty"`
+	Tags            []string    `json:"tags"`
+	CommentCount    int64       `json:"comment_count"`
+	AttachmentCount int64       `json:"attachment_count"`
+	Progress        int16       `json:"progress"`
+	CreatedAt       time.Time   `json:"created_at"`
+	UpdatedAt       time.Time   `json:"updated_at"`
+}
+
+type TaskBrief struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Status int16  `json:"status"`
+}
+
+type AssignRequest struct {
+	AssigneeID string `json:"assignee_id" binding:"required"`
+}
+
+type TransferRequest struct {
+	NewAssigneeID string `json:"new_assignee_id" binding:"required"`
+	Reason        string `json:"reason" binding:"required,max=500"`
+}
+
+type StatusRequest struct {
+	Status  int16  `json:"status" binding:"oneof=0 1 2 3 4"`
+	Comment string `json:"comment" binding:"max=500"`
+}
+
+type UrgeRequest struct {
+	Message string `json:"message" binding:"max=500"`
+}

--- a/backend/internal/task/handler/extra_handler.go
+++ b/backend/internal/task/handler/extra_handler.go
@@ -1,0 +1,282 @@
+package handler
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// ListComments 评论列表
+// @Summary 任务评论列表
+// @Tags 任务
+// @Router /tasks/{id}/comments [get]
+func (h *TaskHandler) ListComments(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.ListComments(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// AddComment 添加评论
+// @Summary 添加任务评论
+// @Tags 任务
+// @Router /tasks/{id}/comments [post]
+func (h *TaskHandler) AddComment(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CommentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.AddComment(c.Request.Context(), id, userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateComment 更新评论
+// @Summary 更新任务评论
+// @Tags 任务
+// @Router /tasks/{id}/comments/{cid} [put]
+func (h *TaskHandler) UpdateComment(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	cid, err := parseNamedID(c, "cid")
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CommentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.UpdateComment(c.Request.Context(), id, cid, userID, req.Content)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// DeleteComment 删除评论
+// @Summary 删除任务评论
+// @Tags 任务
+// @Router /tasks/{id}/comments/{cid} [delete]
+func (h *TaskHandler) DeleteComment(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	cid, err := parseNamedID(c, "cid")
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if err := h.svc.DeleteComment(c.Request.Context(), id, cid, userID); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+// ListAttachments 附件列表
+// @Summary 任务附件列表
+// @Tags 任务
+// @Router /tasks/{id}/attachments [get]
+func (h *TaskHandler) ListAttachments(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.ListAttachments(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UploadAttachment 上传附件
+// @Summary 上传任务附件
+// @Tags 任务
+// @Router /tasks/{id}/attachments [post]
+func (h *TaskHandler) UploadAttachment(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	header, err := c.FormFile("file")
+	if err != nil {
+		response.BadRequest(c, "请选择要上传的文件")
+		return
+	}
+	out, err := h.svc.UploadAttachment(c.Request.Context(), id, userID, header)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// DownloadAttachment 下载附件
+// @Summary 下载任务附件
+// @Tags 任务
+// @Router /tasks/{id}/attachments/{aid} [get]
+func (h *TaskHandler) DownloadAttachment(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	aid, err := parseNamedID(c, "aid")
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	rc, filename, contentType, err := h.svc.DownloadAttachment(c.Request.Context(), id, aid)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	defer rc.Close()
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename*=UTF-8''%s", url.QueryEscape(filename)))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	c.Header("Content-Type", contentType)
+	c.Status(200)
+	_, _ = io.Copy(c.Writer, rc)
+}
+
+// DeleteAttachment 删除附件
+// @Summary 删除任务附件
+// @Tags 任务
+// @Router /tasks/{id}/attachments/{aid} [delete]
+func (h *TaskHandler) DeleteAttachment(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	aid, err := parseNamedID(c, "aid")
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if err := h.svc.DeleteAttachment(c.Request.Context(), id, aid, userID); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+func (h *TaskHandler) myKind(c *gin.Context, kind string) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.MyTaskRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	list, total, err := h.svc.ListMy(c.Request.Context(), userID, kind, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	page, size := defaultPage(req.Page, req.PageSize)
+	response.Page(c, list, total, page, size)
+}
+
+// MyTodo 我的待办
+// @Summary 我的待办
+// @Tags 任务
+// @Router /tasks/my/todo [get]
+func (h *TaskHandler) MyTodo(c *gin.Context) { h.myKind(c, "todo") }
+
+// MyDone 我的已办
+// @Summary 我的已办
+// @Tags 任务
+// @Router /tasks/my/done [get]
+func (h *TaskHandler) MyDone(c *gin.Context) { h.myKind(c, "done") }
+
+// MyCreated 我创建的
+// @Summary 我创建的任务
+// @Tags 任务
+// @Router /tasks/my/created [get]
+func (h *TaskHandler) MyCreated(c *gin.Context) { h.myKind(c, "created") }
+
+// MyOverdue 我的超期
+// @Summary 我的超期任务
+// @Tags 任务
+// @Router /tasks/my/overdue [get]
+func (h *TaskHandler) MyOverdue(c *gin.Context) { h.myKind(c, "overdue") }
+
+// Stats 任务统计
+// @Summary 任务统计
+// @Tags 任务
+// @Router /tasks/stats [get]
+func (h *TaskHandler) Stats(c *gin.Context) {
+	var req dto.StatsRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Stats(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}

--- a/backend/internal/task/handler/flow_handler.go
+++ b/backend/internal/task/handler/flow_handler.go
@@ -1,0 +1,133 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// Assign 分配任务
+// @Summary 分配任务
+// @Tags 任务
+// @Router /tasks/{id}/assign [post]
+func (h *TaskHandler) Assign(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.AssignRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Assign(c.Request.Context(), id, userID, req.AssigneeID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// Transfer 转办任务
+// @Summary 转办任务
+// @Tags 任务
+// @Router /tasks/{id}/transfer [post]
+func (h *TaskHandler) Transfer(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.TransferRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Transfer(c.Request.Context(), id, userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// ChangeStatus 更新状态
+// @Summary 更新任务状态
+// @Tags 任务
+// @Router /tasks/{id}/status [post]
+func (h *TaskHandler) ChangeStatus(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.StatusRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.ChangeStatus(c.Request.Context(), id, userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// Urge 催办
+// @Summary 催办任务
+// @Tags 任务
+// @Router /tasks/{id}/urge [post]
+func (h *TaskHandler) Urge(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.UrgeRequest
+	_ = c.ShouldBindJSON(&req)
+	if err := h.svc.Urge(c.Request.Context(), id, userID, req.Message); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}
+
+// ListLogs 流转记录
+// @Summary 任务流转记录
+// @Tags 任务
+// @Router /tasks/{id}/logs [get]
+func (h *TaskHandler) ListLogs(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.ListLogs(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}

--- a/backend/internal/task/handler/helper.go
+++ b/backend/internal/task/handler/helper.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func getUserID(c *gin.Context) (uuid.UUID, error) {
+	userIDStr := auth.GetUserID(c)
+	if userIDStr == "" {
+		return uuid.Nil, response.NewUnauthorizedError("用户未认证")
+	}
+	id, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的用户ID")
+	}
+	return id, nil
+}
+
+func parseID(c *gin.Context) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的ID")
+	}
+	return id, nil
+}
+
+func parseNamedID(c *gin.Context, name string) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Param(name))
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的ID")
+	}
+	return id, nil
+}
+
+func dataScope(c *gin.Context) *rbacModel.DataScopeCondition {
+	return middleware.GetDataScopeFromContext(c)
+}
+
+func defaultPage(page, pageSize int) (int, int) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	return page, pageSize
+}

--- a/backend/internal/task/handler/routes.go
+++ b/backend/internal/task/handler/routes.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	rbacRepo "github.com/Yogdunana/StarByte/backend/internal/rbac/repo"
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/internal/task/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type TaskHandler struct {
+	svc service.TaskService
+}
+
+func NewTaskHandler(svc service.TaskService) *TaskHandler {
+	return &TaskHandler{svc: svc}
+}
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
+}
+
+func withReadScope(
+	group *gin.RouterGroup,
+	cacheService rbacService.PermissionCacheService,
+	db *gorm.DB,
+	deptRepo rbacRepo.DepartmentRepo,
+) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission("task:read"))
+	g.Use(middleware.RequireDataScope("task"))
+	g.Use(middleware.PermissionRequired(cacheService))
+	g.Use(middleware.DataScopeMiddleware(db, deptRepo, cacheService))
+	return g
+}
+
+// RegisterRoutes 注册 /api/v1/tasks。静态路径必须在 /:id 之前。
+func RegisterRoutes(
+	r *gin.RouterGroup,
+	h *TaskHandler,
+	cacheService rbacService.PermissionCacheService,
+	db *gorm.DB,
+	deptRepo rbacRepo.DepartmentRepo,
+) {
+	g := r.Group("/tasks")
+	g.GET("/my/todo", h.MyTodo)
+	g.GET("/my/done", h.MyDone)
+	g.GET("/my/created", h.MyCreated)
+	g.GET("/my/overdue", h.MyOverdue)
+
+	read := withReadScope(g, cacheService, db, deptRepo)
+	read.GET("/stats", h.Stats)
+	read.GET("", h.ListTasks)
+	read.GET("/:id", h.GetTask)
+	read.GET("/:id/logs", h.ListLogs)
+	read.GET("/:id/comments", h.ListComments)
+	read.GET("/:id/attachments", h.ListAttachments)
+	read.GET("/:id/attachments/:aid", h.DownloadAttachment)
+
+	create := withPermission(g, "task:create", cacheService)
+	create.POST("", h.CreateTask)
+	create.POST("/:id/urge", h.Urge)
+
+	update := withPermission(g, "task:update", cacheService)
+	update.PUT("/:id", h.UpdateTask)
+	update.POST("/:id/status", h.ChangeStatus)
+	update.POST("/:id/attachments", h.UploadAttachment)
+	update.DELETE("/:id/attachments/:aid", h.DeleteAttachment)
+
+	del := withPermission(g, "task:delete", cacheService)
+	del.DELETE("/:id", h.DeleteTask)
+
+	assign := withPermission(g, "task:assign", cacheService)
+	assign.POST("/:id/assign", h.Assign)
+
+	transfer := withPermission(g, "task:transfer", cacheService)
+	transfer.POST("/:id/transfer", h.Transfer)
+
+	comment := withPermission(g, "task:comment", cacheService)
+	comment.POST("/:id/comments", h.AddComment)
+	comment.PUT("/:id/comments/:cid", h.UpdateComment)
+	comment.DELETE("/:id/comments/:cid", h.DeleteComment)
+}

--- a/backend/internal/task/handler/task_handler.go
+++ b/backend/internal/task/handler/task_handler.go
@@ -1,0 +1,127 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+// CreateTask 创建任务
+// @Summary 创建任务
+// @Tags 任务
+// @Accept json
+// @Produce json
+// @Param request body dto.CreateTaskRequest true "任务"
+// @Success 200 {object} response.Response
+// @Router /tasks [post]
+func (h *TaskHandler) CreateTask(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CreateTaskRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Create(c.Request.Context(), userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// ListTasks 任务列表
+// @Summary 任务列表
+// @Tags 任务
+// @Produce json
+// @Router /tasks [get]
+func (h *TaskHandler) ListTasks(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.ListTaskRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	list, total, err := h.svc.List(c.Request.Context(), userID, &req, dataScope(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	page, size := defaultPage(req.Page, req.PageSize)
+	response.Page(c, list, total, page, size)
+}
+
+// GetTask 任务详情
+// @Summary 任务详情
+// @Tags 任务
+// @Router /tasks/{id} [get]
+func (h *TaskHandler) GetTask(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	out, err := h.svc.Get(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// UpdateTask 更新任务
+// @Summary 更新任务
+// @Tags 任务
+// @Router /tasks/{id} [put]
+func (h *TaskHandler) UpdateTask(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.UpdateTaskRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Update(c.Request.Context(), id, userID, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// DeleteTask 删除任务
+// @Summary 删除任务
+// @Tags 任务
+// @Router /tasks/{id} [delete]
+func (h *TaskHandler) DeleteTask(c *gin.Context) {
+	id, err := parseID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	if err := h.svc.Delete(c.Request.Context(), id, userID); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, nil)
+}

--- a/backend/internal/task/model/const.go
+++ b/backend/internal/task/model/const.go
@@ -1,0 +1,25 @@
+package model
+
+const (
+	StatusPending   int16 = 0 // 待处理
+	StatusDoing     int16 = 1 // 进行中
+	StatusDone      int16 = 2 // 已完成
+	StatusCancelled int16 = 3 // 已取消
+	StatusHeld      int16 = 4 // 已挂起
+
+	PriorityLow    int16 = 0
+	PriorityMedium int16 = 1
+	PriorityHigh   int16 = 2
+	PriorityUrgent int16 = 3
+
+	ActionStatusChange = "status_change"
+	ActionAssign       = "assign"
+	ActionTransfer     = "transfer"
+	ActionComment      = "comment"
+	ActionUrge         = "urge"
+	ActionCreate       = "create"
+)
+
+func IsClosed(status int16) bool {
+	return status == StatusDone || status == StatusCancelled
+}

--- a/backend/internal/task/model/task.go
+++ b/backend/internal/task/model/task.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Task struct {
+	ID                uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	Title             string     `gorm:"type:varchar(200);not null" json:"title"`
+	Description       string     `gorm:"type:text" json:"description"`
+	Status            int16      `gorm:"type:smallint;not null;default:0" json:"status"`
+	Priority          int16      `gorm:"type:smallint;not null;default:1" json:"priority"`
+	CreatorID         uuid.UUID  `gorm:"type:uuid;not null" json:"creator_id"`
+	AssigneeID        *uuid.UUID `gorm:"type:uuid" json:"assignee_id"`
+	DepartmentID      *uuid.UUID `gorm:"type:uuid" json:"department_id"`
+	ParentID          *uuid.UUID `gorm:"type:uuid" json:"parent_id"`
+	DueDate           *time.Time `json:"due_date"`
+	Progress          int16      `gorm:"type:smallint;not null;default:0" json:"progress"`
+	Tags              string     `gorm:"type:varchar(500)" json:"tags"`
+	RelatedType       string     `gorm:"type:varchar(50)" json:"related_type"`
+	RelatedID         *uuid.UUID `gorm:"type:uuid" json:"related_id"`
+	SortOrder         int        `gorm:"not null;default:0" json:"sort_order"`
+	CompletedAt       *time.Time `json:"completed_at"`
+	DueRemindedAt     *time.Time `json:"due_reminded_at"`
+	OverdueRemindedAt *time.Time `json:"overdue_reminded_at"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+}
+
+func (Task) TableName() string { return "tasks" }
+
+type TaskWithNames struct {
+	Task
+	CreatorName     string `gorm:"column:creator_name"`
+	AssigneeName    string `gorm:"column:assignee_name"`
+	AssigneeAvatar  string `gorm:"column:assignee_avatar"`
+	DepartmentName  string `gorm:"column:department_name"`
+	ParentTitle     string `gorm:"column:parent_title"`
+	CommentCount    int64  `gorm:"column:comment_count"`
+	AttachmentCount int64  `gorm:"column:attachment_count"`
+}
+
+type NamedUser struct {
+	ID       uuid.UUID
+	RealName string
+	Username string
+	Avatar   string
+}
+
+type TaskLog struct {
+	ID         uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	TaskID     uuid.UUID `gorm:"type:uuid;not null" json:"task_id"`
+	ActionType string    `gorm:"type:varchar(32);not null" json:"action_type"`
+	OldValue   string    `gorm:"type:varchar(500);not null;default:''" json:"old_value"`
+	NewValue   string    `gorm:"type:varchar(500);not null;default:''" json:"new_value"`
+	OperatorID uuid.UUID `gorm:"type:uuid;not null" json:"operator_id"`
+	Comment    string    `gorm:"type:text;not null;default:''" json:"comment"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+func (TaskLog) TableName() string { return "task_logs" }
+
+type TaskLogNamed struct {
+	TaskLog
+	OperatorName string `gorm:"column:operator_name"`
+}
+
+type TaskComment struct {
+	ID        uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	TaskID    uuid.UUID `gorm:"type:uuid;not null" json:"task_id"`
+	AuthorID  uuid.UUID `gorm:"type:uuid;not null" json:"author_id"`
+	Content   string    `gorm:"type:text;not null" json:"content"`
+	Mentions  string    `gorm:"type:text;not null;default:'[]'" json:"mentions"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (TaskComment) TableName() string { return "task_comments" }
+
+type TaskCommentNamed struct {
+	TaskComment
+	AuthorName string `gorm:"column:author_name"`
+}
+
+type TaskAttachment struct {
+	ID         uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	TaskID     uuid.UUID  `gorm:"type:uuid;not null" json:"task_id"`
+	FileID     uuid.UUID  `gorm:"type:uuid;not null" json:"file_id"`
+	UploadedBy *uuid.UUID `gorm:"type:uuid" json:"uploaded_by"`
+	CreatedAt  time.Time  `json:"created_at"`
+}
+
+func (TaskAttachment) TableName() string { return "task_attachments" }
+
+type TaskAttachmentNamed struct {
+	TaskAttachment
+	FileName   string `gorm:"column:file_name"`
+	FilePath   string `gorm:"column:file_path"`
+	FileSize   int64  `gorm:"column:file_size"`
+	FileType   string `gorm:"column:file_type"`
+	UploaderID string `gorm:"column:uploader_id"`
+}

--- a/backend/internal/task/repo/extra_repo.go
+++ b/backend/internal/task/repo/extra_repo.go
@@ -1,0 +1,136 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type LogRepo interface {
+	Create(ctx context.Context, log *model.TaskLog) error
+	ListByTask(ctx context.Context, taskID uuid.UUID) ([]model.TaskLogNamed, error)
+}
+
+type logRepo struct{ db *gorm.DB }
+
+func NewLogRepo(db *gorm.DB) LogRepo { return &logRepo{db: db} }
+
+func (r *logRepo) Create(ctx context.Context, log *model.TaskLog) error {
+	return r.db.WithContext(ctx).Create(log).Error
+}
+
+func (r *logRepo) ListByTask(ctx context.Context, taskID uuid.UUID) ([]model.TaskLogNamed, error) {
+	var rows []model.TaskLogNamed
+	err := r.db.WithContext(ctx).Table("task_logs AS l").
+		Select("l.*, COALESCE(u.real_name, u.username, '') AS operator_name").
+		Joins("LEFT JOIN users u ON u.id = l.operator_id").
+		Where("l.task_id = ?", taskID).
+		Order("l.created_at DESC").Find(&rows).Error
+	return rows, err
+}
+
+type CommentRepo interface {
+	Create(ctx context.Context, c *model.TaskComment) error
+	Update(ctx context.Context, c *model.TaskComment) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.TaskComment, error)
+	ListByTask(ctx context.Context, taskID uuid.UUID) ([]model.TaskCommentNamed, error)
+}
+
+type commentRepo struct{ db *gorm.DB }
+
+func NewCommentRepo(db *gorm.DB) CommentRepo { return &commentRepo{db: db} }
+
+func (r *commentRepo) Create(ctx context.Context, c *model.TaskComment) error {
+	return r.db.WithContext(ctx).Create(c).Error
+}
+
+func (r *commentRepo) Update(ctx context.Context, c *model.TaskComment) error {
+	return r.db.WithContext(ctx).Save(c).Error
+}
+
+func (r *commentRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.TaskComment{}, "id = ?", id).Error
+}
+
+func (r *commentRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.TaskComment, error) {
+	var c model.TaskComment
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&c).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (r *commentRepo) ListByTask(ctx context.Context, taskID uuid.UUID) ([]model.TaskCommentNamed, error) {
+	var rows []model.TaskCommentNamed
+	err := r.db.WithContext(ctx).Table("task_comments AS c").
+		Select("c.*, COALESCE(u.real_name, u.username, '') AS author_name").
+		Joins("LEFT JOIN users u ON u.id = c.author_id").
+		Where("c.task_id = ?", taskID).
+		Order("c.created_at ASC").Find(&rows).Error
+	return rows, err
+}
+
+type AttachmentRepo interface {
+	Create(ctx context.Context, a *model.TaskAttachment) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.TaskAttachment, error)
+	GetNamed(ctx context.Context, id uuid.UUID) (*model.TaskAttachmentNamed, error)
+	ListByTask(ctx context.Context, taskID uuid.UUID) ([]model.TaskAttachmentNamed, error)
+}
+
+type attachmentRepo struct{ db *gorm.DB }
+
+func NewAttachmentRepo(db *gorm.DB) AttachmentRepo { return &attachmentRepo{db: db} }
+
+func (r *attachmentRepo) Create(ctx context.Context, a *model.TaskAttachment) error {
+	return r.db.WithContext(ctx).Create(a).Error
+}
+
+func (r *attachmentRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.TaskAttachment{}, "id = ?", id).Error
+}
+
+func (r *attachmentRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.TaskAttachment, error) {
+	var a model.TaskAttachment
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&a).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (r *attachmentRepo) namedQuery(ctx context.Context) *gorm.DB {
+	return r.db.WithContext(ctx).Table("task_attachments AS a").
+		Select(`a.*, COALESCE(f.original_name, f.name, '') AS file_name,
+			COALESCE(f.path, '') AS file_path, COALESCE(f.size, 0) AS file_size,
+			COALESCE(f.mime_type, '') AS file_type, COALESCE(a.uploaded_by::text, '') AS uploader_id`).
+		Joins("LEFT JOIN files f ON f.id = a.file_id")
+}
+
+func (r *attachmentRepo) GetNamed(ctx context.Context, id uuid.UUID) (*model.TaskAttachmentNamed, error) {
+	var row model.TaskAttachmentNamed
+	err := r.namedQuery(ctx).Where("a.id = ?", id).First(&row).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *attachmentRepo) ListByTask(ctx context.Context, taskID uuid.UUID) ([]model.TaskAttachmentNamed, error) {
+	var rows []model.TaskAttachmentNamed
+	err := r.namedQuery(ctx).Where("a.task_id = ?", taskID).Order("a.created_at DESC").Find(&rows).Error
+	return rows, err
+}

--- a/backend/internal/task/repo/helpers.go
+++ b/backend/internal/task/repo/helpers.go
@@ -1,0 +1,47 @@
+package repo
+
+import (
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"gorm.io/gorm"
+)
+
+func normalizePage(page, pageSize int) (int, int) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+	return page, pageSize
+}
+
+func applyScope(q *gorm.DB, scope *rbacModel.DataScopeCondition) *gorm.DB {
+	if scope == nil || scope.IsEmpty() {
+		return q
+	}
+	return q.Where(scope.Query, scope.Args...)
+}
+
+func allowedSort(sortBy, sortOrder string) (string, string) {
+	cols := map[string]string{
+		"created_at": "t.created_at",
+		"updated_at": "t.updated_at",
+		"due_date":   "t.due_date",
+		"priority":   "t.priority",
+		"status":     "t.status",
+		"sort_order": "t.sort_order",
+		"title":      "t.title",
+	}
+	col, ok := cols[sortBy]
+	if !ok {
+		col = "t.created_at"
+	}
+	order := "DESC"
+	if sortOrder == "asc" || sortOrder == "ASC" {
+		order = "ASC"
+	}
+	return col, order
+}

--- a/backend/internal/task/repo/query.go
+++ b/backend/internal/task/repo/query.go
@@ -1,0 +1,148 @@
+package repo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+func (r *taskRepo) ListMine(ctx context.Context, userID uuid.UUID, kind string, req *dto.MyTaskRequest) ([]model.TaskWithNames, int64, error) {
+	q := r.namedQuery(ctx)
+	now := time.Now()
+	switch kind {
+	case "todo":
+		q = q.Where("t.assignee_id = ? AND t.status IN ?", userID, []int16{model.StatusPending, model.StatusDoing, model.StatusHeld})
+	case "done":
+		q = q.Where("t.assignee_id = ? AND t.status = ?", userID, model.StatusDone)
+	case "created":
+		q = q.Where("t.creator_id = ?", userID)
+		if req.Status != nil {
+			q = q.Where("t.status = ?", *req.Status)
+		}
+	case "overdue":
+		q = q.Where("t.assignee_id = ? AND t.due_date IS NOT NULL AND t.due_date < ? AND t.status IN ?",
+			userID, now, []int16{model.StatusPending, model.StatusDoing, model.StatusHeld})
+	default:
+		q = q.Where("t.assignee_id = ?", userID)
+	}
+	if req.Priority != nil {
+		q = q.Where("t.priority = ?", *req.Priority)
+	}
+	if kw := strings.TrimSpace(req.Keyword); kw != "" {
+		like := "%" + kw + "%"
+		q = q.Where("t.title ILIKE ? OR t.description ILIKE ?", like, like)
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	page, size := normalizePage(req.Page, req.PageSize)
+	var rows []model.TaskWithNames
+	err := q.Order("t.due_date ASC NULLS LAST, t.created_at DESC").
+		Offset((page - 1) * size).Limit(size).Find(&rows).Error
+	return rows, total, err
+}
+
+func (r *taskRepo) ListChildren(ctx context.Context, parentID uuid.UUID) ([]model.Task, error) {
+	var rows []model.Task
+	err := r.db.WithContext(ctx).Where("parent_id = ?", parentID).Order("sort_order ASC, created_at ASC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *taskRepo) ListDueSoon(ctx context.Context, now, until time.Time) ([]model.Task, error) {
+	var rows []model.Task
+	err := r.db.WithContext(ctx).
+		Where("due_date IS NOT NULL AND due_date > ? AND due_date <= ? AND due_reminded_at IS NULL AND status IN ?",
+			now, until, []int16{model.StatusPending, model.StatusDoing, model.StatusHeld}).
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *taskRepo) ListOverdue(ctx context.Context, now time.Time) ([]model.Task, error) {
+	var rows []model.Task
+	err := r.db.WithContext(ctx).
+		Where("due_date IS NOT NULL AND due_date < ? AND overdue_reminded_at IS NULL AND status IN ?",
+			now, []int16{model.StatusPending, model.StatusDoing, model.StatusHeld}).
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *taskRepo) Stats(ctx context.Context, req *dto.StatsRequest, now time.Time) (*dto.StatsResponse, error) {
+	q := r.db.WithContext(ctx).Model(&model.Task{})
+	if req.DepartmentID != "" {
+		q = q.Where("department_id = ?", req.DepartmentID)
+	}
+	if req.StartDate != "" {
+		q = q.Where("created_at >= ?", req.StartDate)
+	}
+	if req.EndDate != "" {
+		q = q.Where("created_at <= ?", req.EndDate+" 23:59:59")
+	}
+	out := &dto.StatsResponse{
+		ByStatus:   map[string]int64{"pending": 0, "doing": 0, "done": 0, "cancelled": 0, "held": 0},
+		ByPriority: map[string]int64{"low": 0, "medium": 0, "high": 0, "urgent": 0},
+	}
+	if err := q.Count(&out.Total).Error; err != nil {
+		return nil, err
+	}
+	type pair struct {
+		K int16
+		C int64
+	}
+	var statuses []pair
+	if err := q.Select("status AS k, COUNT(*) AS c").Group("status").Scan(&statuses).Error; err != nil {
+		return nil, err
+	}
+	statusKeys := map[int16]string{0: "pending", 1: "doing", 2: "done", 3: "cancelled", 4: "held"}
+	for _, p := range statuses {
+		if name, ok := statusKeys[p.K]; ok {
+			out.ByStatus[name] = p.C
+		}
+	}
+	var prios []pair
+	if err := q.Select("priority AS k, COUNT(*) AS c").Group("priority").Scan(&prios).Error; err != nil {
+		return nil, err
+	}
+	prioKeys := map[int16]string{0: "low", 1: "medium", 2: "high", 3: "urgent"}
+	for _, p := range prios {
+		if name, ok := prioKeys[p.K]; ok {
+			out.ByPriority[name] = p.C
+		}
+	}
+	overdueQ := q.Where("due_date IS NOT NULL AND due_date < ? AND status IN ?",
+		now, []int16{model.StatusPending, model.StatusDoing, model.StatusHeld})
+	if err := overdueQ.Count(&out.Overdue).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *taskRepo) GetUser(ctx context.Context, id uuid.UUID) (*model.NamedUser, error) {
+	var u model.NamedUser
+	err := r.db.WithContext(ctx).Table("users").
+		Select("id, real_name, username, COALESCE(avatar_url, '') AS avatar").
+		Where("id = ?", id).First(&u).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (r *taskRepo) FindUsersByUsername(ctx context.Context, names []string) ([]model.NamedUser, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	var rows []model.NamedUser
+	err := r.db.WithContext(ctx).Table("users").
+		Select("id, real_name, username, COALESCE(avatar_url, '') AS avatar").
+		Where("username IN ?", names).Find(&rows).Error
+	return rows, err
+}

--- a/backend/internal/task/repo/task_repo.go
+++ b/backend/internal/task/repo/task_repo.go
@@ -1,0 +1,127 @@
+package repo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type TaskRepo interface {
+	Create(ctx context.Context, t *model.Task) error
+	Update(ctx context.Context, t *model.Task) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Task, error)
+	GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.TaskWithNames, error)
+	List(ctx context.Context, req *dto.ListTaskRequest, scope *rbacModel.DataScopeCondition) ([]model.TaskWithNames, int64, error)
+	ListMine(ctx context.Context, userID uuid.UUID, kind string, req *dto.MyTaskRequest) ([]model.TaskWithNames, int64, error)
+	ListChildren(ctx context.Context, parentID uuid.UUID) ([]model.Task, error)
+	ListDueSoon(ctx context.Context, now, until time.Time) ([]model.Task, error)
+	ListOverdue(ctx context.Context, now time.Time) ([]model.Task, error)
+	Stats(ctx context.Context, req *dto.StatsRequest, now time.Time) (*dto.StatsResponse, error)
+	GetUser(ctx context.Context, id uuid.UUID) (*model.NamedUser, error)
+	FindUsersByUsername(ctx context.Context, names []string) ([]model.NamedUser, error)
+}
+
+type taskRepo struct{ db *gorm.DB }
+
+func NewTaskRepo(db *gorm.DB) TaskRepo {
+	return &taskRepo{db: db}
+}
+
+func (r *taskRepo) Create(ctx context.Context, t *model.Task) error {
+	return r.db.WithContext(ctx).Create(t).Error
+}
+
+func (r *taskRepo) Update(ctx context.Context, t *model.Task) error {
+	return r.db.WithContext(ctx).Save(t).Error
+}
+
+func (r *taskRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.Task{}, "id = ?", id).Error
+}
+
+func (r *taskRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Task, error) {
+	var t model.Task
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&t).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (r *taskRepo) namedQuery(ctx context.Context) *gorm.DB {
+	return r.db.WithContext(ctx).Table("tasks AS t").
+		Select(`t.*,
+			COALESCE(c.real_name, c.username, '') AS creator_name,
+			COALESCE(a.real_name, a.username, '') AS assignee_name,
+			COALESCE(a.avatar_url, '') AS assignee_avatar,
+			COALESCE(d.name, '') AS department_name,
+			COALESCE(p.title, '') AS parent_title,
+			(SELECT COUNT(*) FROM task_comments tc WHERE tc.task_id = t.id) AS comment_count,
+			(SELECT COUNT(*) FROM task_attachments ta WHERE ta.task_id = t.id) AS attachment_count`).
+		Joins("LEFT JOIN users c ON c.id = t.creator_id").
+		Joins("LEFT JOIN users a ON a.id = t.assignee_id").
+		Joins("LEFT JOIN departments d ON d.id = t.department_id").
+		Joins("LEFT JOIN tasks p ON p.id = t.parent_id")
+}
+
+func (r *taskRepo) GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.TaskWithNames, error) {
+	var row model.TaskWithNames
+	err := r.namedQuery(ctx).Where("t.id = ?", id).First(&row).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *taskRepo) List(ctx context.Context, req *dto.ListTaskRequest, scope *rbacModel.DataScopeCondition) ([]model.TaskWithNames, int64, error) {
+	q := applyScope(r.namedQuery(ctx), scope)
+	q = applyListFilters(q, req)
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	page, size := normalizePage(req.Page, req.PageSize)
+	col, order := allowedSort(req.SortBy, req.SortOrder)
+	var rows []model.TaskWithNames
+	err := q.Order(col + " " + order).Offset((page - 1) * size).Limit(size).Find(&rows).Error
+	return rows, total, err
+}
+
+func applyListFilters(q *gorm.DB, req *dto.ListTaskRequest) *gorm.DB {
+	if req.Status != nil {
+		q = q.Where("t.status = ?", *req.Status)
+	}
+	if req.Priority != nil {
+		q = q.Where("t.priority = ?", *req.Priority)
+	}
+	if req.AssigneeID != "" {
+		q = q.Where("t.assignee_id = ?", req.AssigneeID)
+	}
+	if req.DepartmentID != "" {
+		q = q.Where("t.department_id = ?", req.DepartmentID)
+	}
+	if kw := strings.TrimSpace(req.Keyword); kw != "" {
+		like := "%" + kw + "%"
+		q = q.Where("t.title ILIKE ? OR t.description ILIKE ?", like, like)
+	}
+	if tag := strings.TrimSpace(req.Tags); tag != "" {
+		q = q.Where("t.tags ILIKE ?", "%"+tag+"%")
+	}
+	if req.ParentID != "" {
+		q = q.Where("t.parent_id = ?", req.ParentID)
+	}
+	return q
+}

--- a/backend/internal/task/service/attachment.go
+++ b/backend/internal/task/service/attachment.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *taskService) UploadAttachment(ctx context.Context, taskID, operator uuid.UUID, header *multipart.FileHeader) (*dto.AttachmentResponse, error) {
+	t, err := s.mustTask(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.ensureMutable(t, operator); err != nil {
+		return nil, err
+	}
+	if s.bridge == nil {
+		return nil, response.NewError(response.CodeTaskUploadFail, "文件上传失败")
+	}
+	uploaded, err := s.bridge.Upload(ctx, operator, header, "document", false)
+	if err != nil {
+		return nil, response.NewError(response.CodeTaskUploadFail, "文件上传失败")
+	}
+	fileID, err := uuid.Parse(uploaded.ID)
+	if err != nil {
+		return nil, response.NewError(response.CodeTaskUploadFail, "文件上传失败")
+	}
+	row := &model.TaskAttachment{
+		ID:         uuid.New(),
+		TaskID:     taskID,
+		FileID:     fileID,
+		UploadedBy: &operator,
+		CreatedAt:  time.Now(),
+	}
+	if err := s.files.Create(ctx, row); err != nil {
+		return nil, fmt.Errorf("create attachment: %w", err)
+	}
+	named, err := s.files.GetNamed(ctx, row.ID)
+	if err != nil || named == nil {
+		return &dto.AttachmentResponse{
+			ID: row.ID.String(), TaskID: taskID.String(), FileID: fileID.String(),
+			FileName: uploaded.OriginalName, FileSize: uploaded.FileSize, FileType: uploaded.MimeType,
+			UploadedBy: operator.String(), CreatedAt: row.CreatedAt,
+		}, nil
+	}
+	out := mapAttachment(*named)
+	return &out, nil
+}
+
+func (s *taskService) ListAttachments(ctx context.Context, taskID uuid.UUID) ([]dto.AttachmentResponse, error) {
+	if _, err := s.mustTask(ctx, taskID); err != nil {
+		return nil, err
+	}
+	rows, err := s.files.ListByTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("list attachments: %w", err)
+	}
+	out := make([]dto.AttachmentResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, mapAttachment(row))
+	}
+	return out, nil
+}
+
+func (s *taskService) DownloadAttachment(ctx context.Context, taskID, attachID uuid.UUID) (io.ReadCloser, string, string, error) {
+	if _, err := s.mustTask(ctx, taskID); err != nil {
+		return nil, "", "", err
+	}
+	named, err := s.mustAttachment(ctx, attachID, taskID)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if s.store == nil || named.FilePath == "" {
+		return nil, "", "", response.NewError(response.CodeTaskAttachGone, "附件不存在")
+	}
+	rc, contentType, err := s.store.Download(ctx, named.FilePath)
+	if err != nil {
+		return nil, "", "", response.NewError(response.CodeTaskAttachGone, "附件不存在")
+	}
+	if contentType == "" {
+		contentType = named.FileType
+	}
+	name := named.FileName
+	if name == "" {
+		name = "attachment"
+	}
+	return rc, name, contentType, nil
+}
+
+func (s *taskService) DeleteAttachment(ctx context.Context, taskID, attachID, operator uuid.UUID) error {
+	t, err := s.mustTask(ctx, taskID)
+	if err != nil {
+		return err
+	}
+	if err := s.ensureMutable(t, operator); err != nil {
+		return err
+	}
+	named, err := s.mustAttachment(ctx, attachID, taskID)
+	if err != nil {
+		return err
+	}
+	if err := s.files.Delete(ctx, attachID); err != nil {
+		return fmt.Errorf("delete attachment: %w", err)
+	}
+	if s.bridge != nil {
+		_ = s.bridge.Delete(ctx, named.FileID, operator)
+	}
+	return nil
+}
+
+func (s *taskService) mustAttachment(ctx context.Context, id, taskID uuid.UUID) (*model.TaskAttachmentNamed, error) {
+	row, err := s.files.GetNamed(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get attachment: %w", err)
+	}
+	if row == nil || row.TaskID != taskID {
+		return nil, response.NewError(response.CodeTaskAttachGone, "附件不存在")
+	}
+	return row, nil
+}

--- a/backend/internal/task/service/comment.go
+++ b/backend/internal/task/service/comment.go
@@ -1,0 +1,157 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *taskService) ListComments(ctx context.Context, taskID uuid.UUID) ([]dto.CommentResponse, error) {
+	if _, err := s.mustTask(ctx, taskID); err != nil {
+		return nil, err
+	}
+	rows, err := s.comments.ListByTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("list comments: %w", err)
+	}
+	out := make([]dto.CommentResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, mapComment(row))
+	}
+	return out, nil
+}
+
+func (s *taskService) AddComment(ctx context.Context, taskID, operator uuid.UUID, req *dto.CommentRequest) (*dto.CommentResponse, error) {
+	t, err := s.mustTask(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if model.IsClosed(t.Status) {
+		return nil, response.NewError(response.CodeTaskClosed, "任务已关闭，无法操作")
+	}
+	ids := s.resolveMentions(ctx, req.Content, req.Mentions)
+	now := time.Now()
+	c := &model.TaskComment{
+		ID:        uuid.New(),
+		TaskID:    taskID,
+		AuthorID:  operator,
+		Content:   req.Content,
+		Mentions:  encodeJSONList(ids),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.comments.Create(ctx, c); err != nil {
+		return nil, fmt.Errorf("create comment: %w", err)
+	}
+	s.addLog(ctx, taskID, operator, model.ActionComment, "", c.ID.String(), "")
+	mentionUUIDs := parseUUIDList(ids)
+	s.notifyUsers(ctx, mentionUUIDs, tplTaskMention, t, req.Content)
+	return s.getComment(ctx, c.ID)
+}
+
+func (s *taskService) UpdateComment(ctx context.Context, taskID, commentID, operator uuid.UUID, content string) (*dto.CommentResponse, error) {
+	if _, err := s.mustTask(ctx, taskID); err != nil {
+		return nil, err
+	}
+	c, err := s.mustComment(ctx, commentID, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if c.AuthorID != operator {
+		return nil, response.NewError(response.CodeTaskNoAccess, "无权操作该任务")
+	}
+	c.Content = content
+	c.Mentions = encodeJSONList(s.resolveMentions(ctx, content, nil))
+	c.UpdatedAt = time.Now()
+	if err := s.comments.Update(ctx, c); err != nil {
+		return nil, fmt.Errorf("update comment: %w", err)
+	}
+	return s.getComment(ctx, c.ID)
+}
+
+func (s *taskService) DeleteComment(ctx context.Context, taskID, commentID, operator uuid.UUID) error {
+	if _, err := s.mustTask(ctx, taskID); err != nil {
+		return err
+	}
+	c, err := s.mustComment(ctx, commentID, taskID)
+	if err != nil {
+		return err
+	}
+	if c.AuthorID != operator {
+		return response.NewError(response.CodeTaskNoAccess, "无权操作该任务")
+	}
+	if err := s.comments.Delete(ctx, commentID); err != nil {
+		return fmt.Errorf("delete comment: %w", err)
+	}
+	return nil
+}
+
+func (s *taskService) mustComment(ctx context.Context, id, taskID uuid.UUID) (*model.TaskComment, error) {
+	c, err := s.comments.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get comment: %w", err)
+	}
+	if c == nil || c.TaskID != taskID {
+		return nil, response.NewError(response.CodeTaskCommentGone, "评论不存在")
+	}
+	return c, nil
+}
+
+func (s *taskService) getComment(ctx context.Context, id uuid.UUID) (*dto.CommentResponse, error) {
+	c, err := s.comments.GetByID(ctx, id)
+	if err != nil || c == nil {
+		return nil, response.NewError(response.CodeTaskCommentGone, "评论不存在")
+	}
+	u, _ := s.tasks.GetUser(ctx, c.AuthorID)
+	named := model.TaskCommentNamed{TaskComment: *c, AuthorName: displayName(u)}
+	out := mapComment(named)
+	return &out, nil
+}
+
+func (s *taskService) resolveMentions(ctx context.Context, content string, extra []string) []string {
+	names := parseMentionNames(content)
+	users, err := s.tasks.FindUsersByUsername(ctx, names)
+	if err != nil {
+		users = nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(users)+len(extra))
+	for _, u := range users {
+		id := u.ID.String()
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	for _, raw := range extra {
+		id := parseUUIDPtr(raw)
+		if id == nil {
+			continue
+		}
+		key := id.String()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		if u, _ := s.tasks.GetUser(ctx, *id); u != nil {
+			seen[key] = struct{}{}
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+func parseUUIDList(raw []string) []uuid.UUID {
+	out := make([]uuid.UUID, 0, len(raw))
+	for _, s := range raw {
+		if id := parseUUIDPtr(s); id != nil {
+			out = append(out, *id)
+		}
+	}
+	return out
+}

--- a/backend/internal/task/service/extra_test.go
+++ b/backend/internal/task/service/extra_test.go
@@ -1,0 +1,207 @@
+package service
+
+import (
+	"context"
+	"io"
+	"mime/multipart"
+	"strings"
+	"testing"
+	"time"
+
+	filedto "github.com/Yogdunana/StarByte/backend/internal/file/dto"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/google/uuid"
+)
+
+type mockBridge struct{}
+
+func (m *mockBridge) Upload(_ context.Context, _ uuid.UUID, header *multipart.FileHeader, _ string, _ bool) (*filedto.FileUploadResponse, error) {
+	return &filedto.FileUploadResponse{
+		ID: uuid.New().String(), OriginalName: header.Filename, Filename: header.Filename,
+		FileSize: header.Size, MimeType: "text/plain",
+	}, nil
+}
+func (m *mockBridge) GetByID(_ context.Context, id uuid.UUID) (*filedto.FileDetailResponse, error) {
+	return &filedto.FileDetailResponse{ID: id.String(), Path: "obj/f.txt", OriginalName: "f.txt"}, nil
+}
+func (m *mockBridge) Delete(_ context.Context, _, _ uuid.UUID) error { return nil }
+
+type mockStore struct{}
+
+func (m *mockStore) Download(_ context.Context, _ string) (io.ReadCloser, string, error) {
+	return io.NopCloser(strings.NewReader("hi")), "text/plain", nil
+}
+
+func TestUpdateDeleteListParent(t *testing.T) {
+	svc, tasks, _, _ := newTestSvc()
+	ctx := context.Background()
+	creator := uuid.New()
+	parent, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "P", Tags: []string{"core"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid := uuid.MustParse(parent.ID)
+	title := "P2"
+	desc := "d"
+	prio := int16(3)
+	due := time.Now().Add(48 * time.Hour)
+	upd, err := svc.Update(ctx, pid, creator, &dto.UpdateTaskRequest{
+		Title: &title, Description: &desc, Priority: &prio, DueDate: &due, Tags: []string{"a"},
+	})
+	if err != nil || upd.Title != "P2" || upd.Priority != 3 || len(upd.Tags) != 1 {
+		t.Fatalf("update %+v %v", upd, err)
+	}
+	child, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "C", ParentID: parent.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := svc.Get(ctx, pid)
+	if err != nil || len(got.Children) != 1 || got.Children[0].ID != child.ID {
+		t.Fatalf("children %+v %v", got, err)
+	}
+	if _, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "bad", ParentID: child.ID}); err == nil {
+		t.Fatal("nested parent")
+	}
+	list, n, err := svc.List(ctx, creator, &dto.ListTaskRequest{Page: 1, PageSize: 10}, nil)
+	if err != nil || n < 2 || len(list) < 2 {
+		t.Fatalf("list %v %d", err, n)
+	}
+	scope := &rbacModel.DataScopeCondition{Query: "1 = 0"}
+	_, _, err = svc.List(ctx, creator, &dto.ListTaskRequest{}, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope2 := &rbacModel.DataScopeCondition{Query: "department_id = ?", Args: []interface{}{uuid.New()}}
+	rewritten := rewriteTaskScope(scope2, creator)
+	if !strings.Contains(rewritten.Query, "t.department_id") {
+		t.Fatalf("scope %s", rewritten.Query)
+	}
+	if err := svc.Delete(ctx, uuid.MustParse(child.ID), creator); err != nil {
+		t.Fatal(err)
+	}
+	doing, _ := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "doing"})
+	did := uuid.MustParse(doing.ID)
+	row, _ := tasks.GetByID(ctx, did)
+	row.Status = model.StatusDoing
+	_ = tasks.Update(ctx, row)
+	if err := svc.Delete(ctx, did, creator); err == nil {
+		t.Fatal("cannot delete doing")
+	}
+}
+
+func TestCommentUpdateDeleteAndLogs(t *testing.T) {
+	svc, _, _, _ := newTestSvc()
+	ctx := context.Background()
+	creator := uuid.New()
+	row, _ := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "X"})
+	id := uuid.MustParse(row.ID)
+	cmt, err := svc.AddComment(ctx, id, creator, &dto.CommentRequest{Content: "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	upd, err := svc.UpdateComment(ctx, id, uuid.MustParse(cmt.ID), creator, "hello @nobody")
+	if err != nil || upd.Content != "hello @nobody" {
+		t.Fatalf("upd %+v %v", upd, err)
+	}
+	other := uuid.New()
+	if _, err := svc.UpdateComment(ctx, id, uuid.MustParse(cmt.ID), other, "x"); err == nil {
+		t.Fatal("other cannot edit")
+	}
+	if err := svc.DeleteComment(ctx, id, uuid.MustParse(cmt.ID), other); err == nil {
+		t.Fatal("other cannot delete")
+	}
+	if err := svc.DeleteComment(ctx, id, uuid.MustParse(cmt.ID), creator); err != nil {
+		t.Fatal(err)
+	}
+	logs, err := svc.ListLogs(ctx, id)
+	if err != nil || len(logs) == 0 {
+		t.Fatalf("logs %v %d", err, len(logs))
+	}
+}
+
+func TestAttachments(t *testing.T) {
+	tasks := newMemTasks()
+	files := newMemFiles()
+	svc := NewTaskService(tasks, newMemLogs(), newMemComments(), files, &memNotify{}, &mockBridge{}, &mockStore{}).(*taskService)
+	ctx := context.Background()
+	creator := uuid.New()
+	row, _ := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "F"})
+	id := uuid.MustParse(row.ID)
+	header := &multipart.FileHeader{Filename: "a.txt", Size: 2}
+	att, err := svc.UploadAttachment(ctx, id, creator, header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mem store needs a path for download
+	named, _ := files.GetNamed(ctx, uuid.MustParse(att.ID))
+	named.FilePath = "obj/f.txt"
+	named.FileName = "a.txt"
+	list, err := svc.ListAttachments(ctx, id)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list att %v %d", err, len(list))
+	}
+	rc, name, _, err := svc.DownloadAttachment(ctx, id, uuid.MustParse(att.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = rc.Close()
+	if name == "" {
+		t.Fatal("empty name")
+	}
+	if err := svc.DeleteAttachment(ctx, id, uuid.MustParse(att.ID), creator); err != nil {
+		t.Fatal(err)
+	}
+	bare := NewTaskService(tasks, newMemLogs(), newMemComments(), files, nil, nil, nil).(*taskService)
+	if _, err := bare.UploadAttachment(ctx, id, creator, header); err == nil {
+		t.Fatal("nil bridge")
+	}
+}
+
+func TestAssignClosedAndHelpers(t *testing.T) {
+	svc, tasks, _, _ := newTestSvc()
+	ctx := context.Background()
+	creator := uuid.New()
+	u := uuid.New()
+	tasks.users[u] = &model.NamedUser{ID: u, Username: "z", RealName: "张"}
+	row, _ := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "A"})
+	id := uuid.MustParse(row.ID)
+	if _, err := svc.Assign(ctx, id, creator, u.String()); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Urge(ctx, id, creator, "go"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ChangeStatus(ctx, id, creator, &dto.StatusRequest{Status: 3}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Assign(ctx, id, creator, u.String()); err == nil {
+		t.Fatal("closed assign")
+	}
+	if displayName(&model.NamedUser{Username: "u"}) != "u" {
+		t.Fatal("display")
+	}
+	if displayName(&model.NamedUser{RealName: "R", Username: "u"}) != "R" {
+		t.Fatal("real")
+	}
+	if parseUUIDPtr("bad") != nil || parseUUIDPtr(u.String()) == nil {
+		t.Fatal("parse")
+	}
+	if uuidPtrString(nil) != "" {
+		t.Fatal("ptr")
+	}
+	if encodeTags(nil) != "[]" {
+		t.Fatal("tags")
+	}
+}
+
+func TestNotifyAdapterNil(t *testing.T) {
+	if NewNotifier(nil) != nil {
+		t.Fatal("nil notify")
+	}
+	n := reminderTargets(&model.Task{CreatorID: uuid.New()})
+	if len(n) != 1 {
+		t.Fatalf("targets %d", n)
+	}
+}

--- a/backend/internal/task/service/flow.go
+++ b/backend/internal/task/service/flow.go
@@ -1,0 +1,172 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *taskService) Assign(ctx context.Context, id, operator uuid.UUID, assigneeRaw string) (*dto.TaskResponse, error) {
+	t, err := s.mustTask(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canMutate(t.Status) {
+		return nil, response.NewError(response.CodeTaskClosed, "任务已关闭，无法操作")
+	}
+	assignee, err := s.mustUser(ctx, assigneeRaw)
+	if err != nil {
+		return nil, err
+	}
+	old := uuidPtrString(t.AssigneeID)
+	t.AssigneeID = &assignee.ID
+	t.UpdatedAt = time.Now()
+	if err := s.tasks.Update(ctx, t); err != nil {
+		return nil, fmt.Errorf("assign task: %w", err)
+	}
+	s.addLog(ctx, t.ID, operator, model.ActionAssign, old, assignee.ID.String(), "")
+	s.notifyUsers(ctx, []uuid.UUID{assignee.ID}, tplTaskAssigned, t, "")
+	return s.Get(ctx, id)
+}
+
+func (s *taskService) Transfer(ctx context.Context, id, operator uuid.UUID, req *dto.TransferRequest) (*dto.TaskResponse, error) {
+	t, err := s.mustTask(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.ensureMutable(t, operator); err != nil {
+		return nil, err
+	}
+	target, err := s.mustUser(ctx, req.NewAssigneeID)
+	if err != nil {
+		return nil, err
+	}
+	old := uuidPtrString(t.AssigneeID)
+	t.AssigneeID = &target.ID
+	t.UpdatedAt = time.Now()
+	if err := s.tasks.Update(ctx, t); err != nil {
+		return nil, fmt.Errorf("transfer task: %w", err)
+	}
+	s.addLog(ctx, t.ID, operator, model.ActionTransfer, old, target.ID.String(), req.Reason)
+	s.notifyUsers(ctx, []uuid.UUID{target.ID}, tplTaskTransferred, t, req.Reason)
+	return s.Get(ctx, id)
+}
+
+func (s *taskService) ChangeStatus(ctx context.Context, id, operator uuid.UUID, req *dto.StatusRequest) (*dto.TaskResponse, error) {
+	t, err := s.mustTask(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if model.IsClosed(t.Status) && t.Status != req.Status {
+		return nil, response.NewError(response.CodeTaskClosed, "任务已关闭，无法操作")
+	}
+	if t.CreatorID != operator && (t.AssigneeID == nil || *t.AssigneeID != operator) {
+		return nil, response.NewError(response.CodeTaskNoAccess, "无权操作该任务")
+	}
+	if !CanTransit(t.Status, req.Status) {
+		return nil, response.NewError(response.CodeTaskInvalidState, "任务状态不允许该操作")
+	}
+	old := strconv.Itoa(int(t.Status))
+	now := time.Now()
+	t.Status = req.Status
+	if req.Status == model.StatusDone {
+		t.CompletedAt = &now
+		t.Progress = 100
+	} else {
+		t.CompletedAt = nil
+	}
+	t.UpdatedAt = now
+	if err := s.tasks.Update(ctx, t); err != nil {
+		return nil, fmt.Errorf("change status: %w", err)
+	}
+	s.addLog(ctx, t.ID, operator, model.ActionStatusChange, old, strconv.Itoa(int(req.Status)), req.Comment)
+	return s.Get(ctx, id)
+}
+
+func (s *taskService) Urge(ctx context.Context, id, operator uuid.UUID, message string) error {
+	t, err := s.mustTask(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !canMutate(t.Status) {
+		return response.NewError(response.CodeTaskClosed, "任务已关闭，无法操作")
+	}
+	if t.CreatorID != operator {
+		return response.NewError(response.CodeTaskNoAccess, "无权操作该任务")
+	}
+	if t.AssigneeID == nil {
+		return response.NewError(response.CodeTaskInvalidState, "任务尚未分配负责人")
+	}
+	s.addLog(ctx, t.ID, operator, model.ActionUrge, "", t.AssigneeID.String(), message)
+	s.notifyUsers(ctx, []uuid.UUID{*t.AssigneeID}, tplTaskUrged, t, message)
+	return nil
+}
+
+func (s *taskService) ListLogs(ctx context.Context, id uuid.UUID) ([]dto.LogResponse, error) {
+	if _, err := s.mustTask(ctx, id); err != nil {
+		return nil, err
+	}
+	rows, err := s.logs.ListByTask(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("list logs: %w", err)
+	}
+	out := make([]dto.LogResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, mapLog(row))
+	}
+	return out, nil
+}
+
+func (s *taskService) ListMy(ctx context.Context, userID uuid.UUID, kind string, req *dto.MyTaskRequest) ([]*dto.TaskResponse, int64, error) {
+	rows, total, err := s.tasks.ListMine(ctx, userID, kind, req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list my tasks: %w", err)
+	}
+	out := make([]*dto.TaskResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, mapTask(&rows[i], nil))
+	}
+	return out, total, nil
+}
+
+func (s *taskService) Stats(ctx context.Context, req *dto.StatsRequest) (*dto.StatsResponse, error) {
+	out, err := s.tasks.Stats(ctx, req, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("task stats: %w", err)
+	}
+	return out, nil
+}
+
+func (s *taskService) mustUser(ctx context.Context, raw string) (*model.NamedUser, error) {
+	id := parseUUIDPtr(raw)
+	if id == nil {
+		return nil, response.NewError(response.CodeTaskTargetGone, "转办目标用户不存在")
+	}
+	u, err := s.tasks.GetUser(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("lookup user: %w", err)
+	}
+	if u == nil {
+		return nil, response.NewError(response.CodeTaskTargetGone, "转办目标用户不存在")
+	}
+	return u, nil
+}
+
+func (s *taskService) addLog(ctx context.Context, taskID, operator uuid.UUID, action, oldV, newV, comment string) {
+	_ = s.logs.Create(ctx, &model.TaskLog{
+		ID:         uuid.New(),
+		TaskID:     taskID,
+		ActionType: action,
+		OldValue:   oldV,
+		NewValue:   newV,
+		OperatorID: operator,
+		Comment:    comment,
+		CreatedAt:  time.Now(),
+	})
+}

--- a/backend/internal/task/service/mapper.go
+++ b/backend/internal/task/service/mapper.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+)
+
+func mapTask(row *model.TaskWithNames, children []model.Task) *dto.TaskResponse {
+	out := &dto.TaskResponse{
+		ID:              row.ID.String(),
+		Title:           row.Title,
+		Description:     row.Description,
+		Priority:        row.Priority,
+		Status:          row.Status,
+		Creator:         dto.Person{ID: row.CreatorID.String(), Name: row.CreatorName},
+		Children:        mapChildren(children),
+		DueDate:         row.DueDate,
+		CompletedAt:     row.CompletedAt,
+		Tags:            decodeJSONList(row.Tags),
+		CommentCount:    row.CommentCount,
+		AttachmentCount: row.AttachmentCount,
+		Progress:        row.Progress,
+		CreatedAt:       row.CreatedAt,
+		UpdatedAt:       row.UpdatedAt,
+	}
+	if row.AssigneeID != nil {
+		out.Assignee = &dto.Person{ID: row.AssigneeID.String(), Name: row.AssigneeName, Avatar: row.AssigneeAvatar}
+	}
+	if row.DepartmentID != nil && row.DepartmentName != "" {
+		out.Department = &dto.Person{ID: row.DepartmentID.String(), Name: row.DepartmentName}
+	}
+	if row.ParentID != nil {
+		out.Parent = &dto.ParentRef{ID: row.ParentID.String(), Title: row.ParentTitle}
+	}
+	return out
+}
+
+func mapChildren(rows []model.Task) []dto.TaskBrief {
+	out := make([]dto.TaskBrief, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, dto.TaskBrief{ID: r.ID.String(), Title: r.Title, Status: r.Status})
+	}
+	return out
+}
+
+func mapLog(row model.TaskLogNamed) dto.LogResponse {
+	return dto.LogResponse{
+		ID:         row.ID.String(),
+		ActionType: row.ActionType,
+		OldValue:   row.OldValue,
+		NewValue:   row.NewValue,
+		Operator:   dto.Person{ID: row.OperatorID.String(), Name: row.OperatorName},
+		Comment:    row.Comment,
+		CreatedAt:  row.CreatedAt,
+	}
+}
+
+func mapComment(row model.TaskCommentNamed) dto.CommentResponse {
+	return dto.CommentResponse{
+		ID:        row.ID.String(),
+		TaskID:    row.TaskID.String(),
+		UserID:    row.AuthorID.String(),
+		User:      dto.Person{ID: row.AuthorID.String(), Name: row.AuthorName},
+		Content:   row.Content,
+		Mentions:  decodeJSONList(row.Mentions),
+		CreatedAt: row.CreatedAt,
+		UpdatedAt: row.UpdatedAt,
+	}
+}
+
+func mapAttachment(row model.TaskAttachmentNamed) dto.AttachmentResponse {
+	return dto.AttachmentResponse{
+		ID:         row.ID.String(),
+		TaskID:     row.TaskID.String(),
+		FileID:     row.FileID.String(),
+		FileName:   row.FileName,
+		FilePath:   row.FilePath,
+		FileSize:   row.FileSize,
+		FileType:   row.FileType,
+		UploadedBy: row.UploaderID,
+		CreatedAt:  row.CreatedAt,
+	}
+}
+
+func displayName(u *model.NamedUser) string {
+	if u == nil {
+		return ""
+	}
+	if u.RealName != "" {
+		return u.RealName
+	}
+	return u.Username
+}

--- a/backend/internal/task/service/mem_test.go
+++ b/backend/internal/task/service/mem_test.go
@@ -1,0 +1,284 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/google/uuid"
+)
+
+type memTasks struct {
+	mu    sync.Mutex
+	items map[uuid.UUID]*model.Task
+	users map[uuid.UUID]*model.NamedUser
+}
+
+func newMemTasks() *memTasks {
+	return &memTasks{items: map[uuid.UUID]*model.Task{}, users: map[uuid.UUID]*model.NamedUser{}}
+}
+
+func (m *memTasks) Create(_ context.Context, t *model.Task) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *t
+	m.items[t.ID] = &cp
+	return nil
+}
+func (m *memTasks) Update(_ context.Context, t *model.Task) error {
+	return m.Create(context.Background(), t)
+}
+func (m *memTasks) Delete(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.items, id)
+	return nil
+}
+func (m *memTasks) GetByID(_ context.Context, id uuid.UUID) (*model.Task, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.items[id] == nil {
+		return nil, nil
+	}
+	cp := *m.items[id]
+	return &cp, nil
+}
+func (m *memTasks) GetByIDWithNames(ctx context.Context, id uuid.UUID) (*model.TaskWithNames, error) {
+	t, err := m.GetByID(ctx, id)
+	if err != nil || t == nil {
+		return nil, err
+	}
+	return &model.TaskWithNames{Task: *t, CreatorName: "创建人", AssigneeName: "负责人"}, nil
+}
+func (m *memTasks) List(_ context.Context, _ *dto.ListTaskRequest, _ *rbacModel.DataScopeCondition) ([]model.TaskWithNames, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]model.TaskWithNames, 0, len(m.items))
+	for _, t := range m.items {
+		out = append(out, model.TaskWithNames{Task: *t})
+	}
+	return out, int64(len(out)), nil
+}
+func (m *memTasks) ListMine(_ context.Context, userID uuid.UUID, kind string, _ *dto.MyTaskRequest) ([]model.TaskWithNames, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	out := make([]model.TaskWithNames, 0)
+	for _, t := range m.items {
+		ok := false
+		switch kind {
+		case "todo":
+			ok = t.AssigneeID != nil && *t.AssigneeID == userID && (t.Status == 0 || t.Status == 1 || t.Status == 4)
+		case "done":
+			ok = t.AssigneeID != nil && *t.AssigneeID == userID && t.Status == 2
+		case "created":
+			ok = t.CreatorID == userID
+		case "overdue":
+			ok = t.AssigneeID != nil && *t.AssigneeID == userID && t.DueDate != nil && t.DueDate.Before(now) && !model.IsClosed(t.Status)
+		}
+		if ok {
+			out = append(out, model.TaskWithNames{Task: *t})
+		}
+	}
+	return out, int64(len(out)), nil
+}
+func (m *memTasks) ListChildren(_ context.Context, parentID uuid.UUID) ([]model.Task, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.Task
+	for _, t := range m.items {
+		if t.ParentID != nil && *t.ParentID == parentID {
+			out = append(out, *t)
+		}
+	}
+	return out, nil
+}
+func (m *memTasks) ListDueSoon(_ context.Context, now, until time.Time) ([]model.Task, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.Task
+	for _, t := range m.items {
+		if t.DueDate != nil && t.DueDate.After(now) && !t.DueDate.After(until) && t.DueRemindedAt == nil && !model.IsClosed(t.Status) {
+			out = append(out, *t)
+		}
+	}
+	return out, nil
+}
+func (m *memTasks) ListOverdue(_ context.Context, now time.Time) ([]model.Task, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.Task
+	for _, t := range m.items {
+		if t.DueDate != nil && t.DueDate.Before(now) && t.OverdueRemindedAt == nil && !model.IsClosed(t.Status) {
+			out = append(out, *t)
+		}
+	}
+	return out, nil
+}
+func (m *memTasks) Stats(_ context.Context, _ *dto.StatsRequest, now time.Time) (*dto.StatsResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := &dto.StatsResponse{
+		ByStatus:   map[string]int64{"pending": 0, "doing": 0, "done": 0, "cancelled": 0, "held": 0},
+		ByPriority: map[string]int64{"low": 0, "medium": 0, "high": 0, "urgent": 0},
+	}
+	keys := map[int16]string{0: "pending", 1: "doing", 2: "done", 3: "cancelled", 4: "held"}
+	prios := map[int16]string{0: "low", 1: "medium", 2: "high", 3: "urgent"}
+	for _, t := range m.items {
+		out.Total++
+		out.ByStatus[keys[t.Status]]++
+		out.ByPriority[prios[t.Priority]]++
+		if t.DueDate != nil && t.DueDate.Before(now) && !model.IsClosed(t.Status) {
+			out.Overdue++
+		}
+	}
+	return out, nil
+}
+func (m *memTasks) GetUser(_ context.Context, id uuid.UUID) (*model.NamedUser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.users[id], nil
+}
+func (m *memTasks) FindUsersByUsername(_ context.Context, names []string) ([]model.NamedUser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	want := map[string]struct{}{}
+	for _, n := range names {
+		want[n] = struct{}{}
+	}
+	var out []model.NamedUser
+	for _, u := range m.users {
+		if _, ok := want[u.Username]; ok {
+			out = append(out, *u)
+		}
+	}
+	return out, nil
+}
+
+type memLogs struct {
+	mu    sync.Mutex
+	items []model.TaskLog
+}
+
+func newMemLogs() *memLogs { return &memLogs{} }
+func (m *memLogs) Create(_ context.Context, log *model.TaskLog) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items = append(m.items, *log)
+	return nil
+}
+func (m *memLogs) ListByTask(_ context.Context, taskID uuid.UUID) ([]model.TaskLogNamed, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.TaskLogNamed
+	for _, l := range m.items {
+		if l.TaskID == taskID {
+			out = append(out, model.TaskLogNamed{TaskLog: l, OperatorName: "操作者"})
+		}
+	}
+	return out, nil
+}
+
+type memComments struct {
+	mu    sync.Mutex
+	items map[uuid.UUID]*model.TaskComment
+}
+
+func newMemComments() *memComments { return &memComments{items: map[uuid.UUID]*model.TaskComment{}} }
+func (m *memComments) Create(_ context.Context, c *model.TaskComment) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *c
+	m.items[c.ID] = &cp
+	return nil
+}
+func (m *memComments) Update(_ context.Context, c *model.TaskComment) error {
+	return m.Create(context.Background(), c)
+}
+func (m *memComments) Delete(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.items, id)
+	return nil
+}
+func (m *memComments) GetByID(_ context.Context, id uuid.UUID) (*model.TaskComment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.items[id] == nil {
+		return nil, nil
+	}
+	cp := *m.items[id]
+	return &cp, nil
+}
+func (m *memComments) ListByTask(_ context.Context, taskID uuid.UUID) ([]model.TaskCommentNamed, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.TaskCommentNamed
+	for _, c := range m.items {
+		if c.TaskID == taskID {
+			out = append(out, model.TaskCommentNamed{TaskComment: *c, AuthorName: "作者"})
+		}
+	}
+	return out, nil
+}
+
+type memFiles struct {
+	mu    sync.Mutex
+	items map[uuid.UUID]*model.TaskAttachmentNamed
+}
+
+func newMemFiles() *memFiles {
+	return &memFiles{items: map[uuid.UUID]*model.TaskAttachmentNamed{}}
+}
+func (m *memFiles) Create(_ context.Context, a *model.TaskAttachment) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items[a.ID] = &model.TaskAttachmentNamed{TaskAttachment: *a, FileName: "f.txt"}
+	return nil
+}
+func (m *memFiles) Delete(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.items, id)
+	return nil
+}
+func (m *memFiles) GetByID(_ context.Context, id uuid.UUID) (*model.TaskAttachment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.items[id] == nil {
+		return nil, nil
+	}
+	cp := m.items[id].TaskAttachment
+	return &cp, nil
+}
+func (m *memFiles) GetNamed(_ context.Context, id uuid.UUID) (*model.TaskAttachmentNamed, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.items[id], nil
+}
+func (m *memFiles) ListByTask(_ context.Context, taskID uuid.UUID) ([]model.TaskAttachmentNamed, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []model.TaskAttachmentNamed
+	for _, a := range m.items {
+		if a.TaskID == taskID {
+			out = append(out, *a)
+		}
+	}
+	return out, nil
+}
+
+type memNotify struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (m *memNotify) Send(_ context.Context, _ []uuid.UUID, _ string, _ map[string]interface{}) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	return nil
+}

--- a/backend/internal/task/service/mention.go
+++ b/backend/internal/task/service/mention.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+var mentionRe = regexp.MustCompile(`@([A-Za-z0-9_\-\.]{2,64})`)
+
+func parseMentionNames(content string) []string {
+	matches := mentionRe.FindAllStringSubmatch(content, -1)
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		name := strings.TrimSpace(m[1])
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+func encodeJSONList(ids []string) string {
+	if len(ids) == 0 {
+		return "[]"
+	}
+	b, err := json.Marshal(ids)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
+func decodeJSONList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "[]" {
+		return []string{}
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		parts := strings.Split(raw, ",")
+		out = make([]string, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+	}
+	if out == nil {
+		return []string{}
+	}
+	return out
+}
+
+func encodeTags(tags []string) string {
+	clean := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			clean = append(clean, t)
+		}
+	}
+	s := encodeJSONList(clean)
+	if len(s) > 500 {
+		s = s[:500]
+	}
+	return s
+}
+
+func parseUUIDPtr(raw string) *uuid.UUID {
+	id, err := uuid.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil
+	}
+	return &id
+}
+
+func uuidPtrString(id *uuid.UUID) string {
+	if id == nil {
+		return ""
+	}
+	return id.String()
+}

--- a/backend/internal/task/service/mention_test.go
+++ b/backend/internal/task/service/mention_test.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseMentionNames(t *testing.T) {
+	got := parseMentionNames("请看 @alice 和 @bob，以及重复 @alice")
+	want := []string{"alice", "bob"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestEncodeDecodeJSONList(t *testing.T) {
+	raw := encodeJSONList([]string{"a", "b"})
+	got := decodeJSONList(raw)
+	if !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("roundtrip %v", got)
+	}
+	if len(decodeJSONList("")) != 0 {
+		t.Fatal("empty")
+	}
+	if !reflect.DeepEqual(decodeJSONList("x,y"), []string{"x", "y"}) {
+		t.Fatal("csv fallback")
+	}
+}
+
+func TestEncodeTagsTruncates(t *testing.T) {
+	tags := make([]string, 80)
+	for i := range tags {
+		tags[i] = "tag-name-xxxxxxxx"
+	}
+	s := encodeTags(tags)
+	if len(s) > 500 {
+		t.Fatalf("len=%d", len(s))
+	}
+}

--- a/backend/internal/task/service/notify.go
+++ b/backend/internal/task/service/notify.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+
+	notifdto "github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	notifsvc "github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+const (
+	tplTaskAssigned    = "task_assigned"
+	tplTaskTransferred = "task_transferred"
+	tplTaskUrged       = "task_urged"
+	tplTaskMention     = "task_mention"
+	tplTaskDueSoon     = "task_due_soon"
+	tplTaskOverdue     = "task_overdue"
+)
+
+type notificationAdapter struct {
+	inner notifsvc.NotificationService
+}
+
+func NewNotifier(inner notifsvc.NotificationService) Notifier {
+	if inner == nil {
+		return nil
+	}
+	return &notificationAdapter{inner: inner}
+}
+
+func (a *notificationAdapter) Send(ctx context.Context, userIDs []uuid.UUID, template string, vars map[string]interface{}) error {
+	if len(userIDs) == 0 {
+		return nil
+	}
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      userIDs,
+		TemplateCode: template,
+		Variables:    vars,
+		Channels:     []string{"in_app", "websocket"},
+	})
+}
+
+func (s *taskService) notifyUsers(ctx context.Context, userIDs []uuid.UUID, template string, t *model.Task, extra string) {
+	if s.notify == nil || len(userIDs) == 0 || t == nil {
+		return
+	}
+	vars := map[string]interface{}{
+		"title":     t.Title,
+		"real_name": "",
+		"message":   extra,
+		"due_date":  "",
+	}
+	if t.DueDate != nil {
+		vars["due_date"] = t.DueDate.Format("2006-01-02 15:04")
+	}
+	if err := s.notify.Send(ctx, userIDs, template, vars); err != nil {
+		logger.Warn("send task notify failed", zap.Error(err), zap.String("tpl", template))
+	}
+}

--- a/backend/internal/task/service/scheduler.go
+++ b/backend/internal/task/service/scheduler.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+type ReminderScheduler struct {
+	svc    TaskService
+	stopCh chan struct{}
+	done   chan struct{}
+}
+
+func NewReminderScheduler(svc TaskService) *ReminderScheduler {
+	return &ReminderScheduler{svc: svc, stopCh: make(chan struct{}), done: make(chan struct{})}
+}
+
+func (s *ReminderScheduler) Start() {
+	go s.run()
+	logger.Info("task due reminder scheduler started")
+}
+
+func (s *ReminderScheduler) Stop() {
+	close(s.stopCh)
+	<-s.done
+	logger.Info("task due reminder scheduler stopped")
+}
+
+func (s *ReminderScheduler) run() {
+	defer close(s.done)
+	ticker := time.NewTicker(15 * time.Minute)
+	defer ticker.Stop()
+	s.tick()
+	for {
+		select {
+		case <-ticker.C:
+			s.tick()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+func (s *ReminderScheduler) tick() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	n, err := s.svc.RemindDueAndOverdue(ctx)
+	if err != nil {
+		logger.Warn("task reminder job failed", zap.Error(err))
+		return
+	}
+	if n > 0 {
+		logger.Info("task reminder job sent", zap.Int("count", n))
+	}
+}
+
+func (s *taskService) RemindDueAndOverdue(ctx context.Context) (int, error) {
+	now := time.Now()
+	sent := 0
+	soon, err := s.tasks.ListDueSoon(ctx, now, now.Add(24*time.Hour))
+	if err != nil {
+		return 0, err
+	}
+	for i := range soon {
+		t := &soon[i]
+		s.notifyUsers(ctx, reminderTargets(t), tplTaskDueSoon, t, "")
+		mark := now
+		t.DueRemindedAt = &mark
+		t.UpdatedAt = now
+		if err := s.tasks.Update(ctx, t); err != nil {
+			logger.Warn("mark due reminder failed", zap.Error(err), zap.String("id", t.ID.String()))
+			continue
+		}
+		sent++
+	}
+	overdue, err := s.tasks.ListOverdue(ctx, now)
+	if err != nil {
+		return sent, err
+	}
+	for i := range overdue {
+		t := &overdue[i]
+		s.notifyUsers(ctx, reminderTargets(t), tplTaskOverdue, t, "")
+		mark := now
+		t.OverdueRemindedAt = &mark
+		t.UpdatedAt = now
+		if err := s.tasks.Update(ctx, t); err != nil {
+			logger.Warn("mark overdue reminder failed", zap.Error(err), zap.String("id", t.ID.String()))
+			continue
+		}
+		sent++
+	}
+	return sent, nil
+}
+
+func reminderTargets(t *model.Task) []uuid.UUID {
+	seen := map[uuid.UUID]struct{}{}
+	out := make([]uuid.UUID, 0, 2)
+	add := func(id uuid.UUID) {
+		if id == uuid.Nil {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	add(t.CreatorID)
+	if t.AssigneeID != nil {
+		add(*t.AssigneeID)
+	}
+	return out
+}

--- a/backend/internal/task/service/service.go
+++ b/backend/internal/task/service/service.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"io"
+	"mime/multipart"
+
+	filedto "github.com/Yogdunana/StarByte/backend/internal/file/dto"
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/repo"
+	"github.com/google/uuid"
+)
+
+type Notifier interface {
+	Send(ctx context.Context, userIDs []uuid.UUID, template string, vars map[string]interface{}) error
+}
+
+type FileBridge interface {
+	Upload(ctx context.Context, userID uuid.UUID, header *multipart.FileHeader, category string, isPublic bool) (*filedto.FileUploadResponse, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*filedto.FileDetailResponse, error)
+	Delete(ctx context.Context, id, userID uuid.UUID) error
+}
+
+type ObjectDownloader interface {
+	Download(ctx context.Context, objectName string) (io.ReadCloser, string, error)
+}
+
+type TaskService interface {
+	Create(ctx context.Context, operator uuid.UUID, req *dto.CreateTaskRequest) (*dto.TaskResponse, error)
+	List(ctx context.Context, viewer uuid.UUID, req *dto.ListTaskRequest, scope *rbacModel.DataScopeCondition) ([]*dto.TaskResponse, int64, error)
+	Get(ctx context.Context, id uuid.UUID) (*dto.TaskResponse, error)
+	Update(ctx context.Context, id, operator uuid.UUID, req *dto.UpdateTaskRequest) (*dto.TaskResponse, error)
+	Delete(ctx context.Context, id, operator uuid.UUID) error
+
+	Assign(ctx context.Context, id, operator uuid.UUID, assigneeID string) (*dto.TaskResponse, error)
+	Transfer(ctx context.Context, id, operator uuid.UUID, req *dto.TransferRequest) (*dto.TaskResponse, error)
+	ChangeStatus(ctx context.Context, id, operator uuid.UUID, req *dto.StatusRequest) (*dto.TaskResponse, error)
+	Urge(ctx context.Context, id, operator uuid.UUID, message string) error
+	ListLogs(ctx context.Context, id uuid.UUID) ([]dto.LogResponse, error)
+
+	ListComments(ctx context.Context, taskID uuid.UUID) ([]dto.CommentResponse, error)
+	AddComment(ctx context.Context, taskID, operator uuid.UUID, req *dto.CommentRequest) (*dto.CommentResponse, error)
+	UpdateComment(ctx context.Context, taskID, commentID, operator uuid.UUID, content string) (*dto.CommentResponse, error)
+	DeleteComment(ctx context.Context, taskID, commentID, operator uuid.UUID) error
+
+	UploadAttachment(ctx context.Context, taskID, operator uuid.UUID, header *multipart.FileHeader) (*dto.AttachmentResponse, error)
+	ListAttachments(ctx context.Context, taskID uuid.UUID) ([]dto.AttachmentResponse, error)
+	DownloadAttachment(ctx context.Context, taskID, attachID uuid.UUID) (io.ReadCloser, string, string, error)
+	DeleteAttachment(ctx context.Context, taskID, attachID, operator uuid.UUID) error
+
+	ListMy(ctx context.Context, userID uuid.UUID, kind string, req *dto.MyTaskRequest) ([]*dto.TaskResponse, int64, error)
+	Stats(ctx context.Context, req *dto.StatsRequest) (*dto.StatsResponse, error)
+	RemindDueAndOverdue(ctx context.Context) (int, error)
+}
+
+type taskService struct {
+	tasks    repo.TaskRepo
+	logs     repo.LogRepo
+	comments repo.CommentRepo
+	files    repo.AttachmentRepo
+	notify   Notifier
+	bridge   FileBridge
+	store    ObjectDownloader
+}
+
+func NewTaskService(
+	tasks repo.TaskRepo,
+	logs repo.LogRepo,
+	comments repo.CommentRepo,
+	files repo.AttachmentRepo,
+	notify Notifier,
+	bridge FileBridge,
+	store ObjectDownloader,
+) TaskService {
+	return &taskService{
+		tasks: tasks, logs: logs, comments: comments, files: files,
+		notify: notify, bridge: bridge, store: store,
+	}
+}

--- a/backend/internal/task/service/state.go
+++ b/backend/internal/task/service/state.go
@@ -1,0 +1,24 @@
+package service
+
+import "github.com/Yogdunana/StarByte/backend/internal/task/model"
+
+// CanTransit reports whether status may move from -> to per Issue #9.
+func CanTransit(from, to int16) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case model.StatusPending:
+		return to == model.StatusDoing || to == model.StatusCancelled
+	case model.StatusDoing:
+		return to == model.StatusDone || to == model.StatusHeld || to == model.StatusCancelled
+	case model.StatusHeld:
+		return to == model.StatusDoing
+	default:
+		return false
+	}
+}
+
+func canMutate(status int16) bool {
+	return !model.IsClosed(status)
+}

--- a/backend/internal/task/service/state_test.go
+++ b/backend/internal/task/service/state_test.go
@@ -1,0 +1,30 @@
+package service
+
+import "testing"
+
+func TestCanTransit(t *testing.T) {
+	cases := []struct {
+		from, to int16
+		ok       bool
+	}{
+		{0, 1, true},
+		{0, 3, true},
+		{0, 2, false},
+		{0, 4, false},
+		{1, 2, true},
+		{1, 4, true},
+		{1, 3, true},
+		{1, 0, false},
+		{4, 1, true},
+		{4, 2, false},
+		{4, 3, false},
+		{2, 1, false},
+		{3, 0, false},
+		{1, 1, true},
+	}
+	for _, c := range cases {
+		if got := CanTransit(c.from, c.to); got != c.ok {
+			t.Fatalf("CanTransit(%d,%d)=%v want %v", c.from, c.to, got, c.ok)
+		}
+	}
+}

--- a/backend/internal/task/service/task.go
+++ b/backend/internal/task/service/task.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *taskService) Create(ctx context.Context, operator uuid.UUID, req *dto.CreateTaskRequest) (*dto.TaskResponse, error) {
+	now := time.Now()
+	t := &model.Task{
+		ID:          uuid.New(),
+		Title:       req.Title,
+		Description: req.Description,
+		Status:      model.StatusPending,
+		Priority:    req.Priority,
+		CreatorID:   operator,
+		DueDate:     req.DueDate,
+		Tags:        encodeTags(req.Tags),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if t.Priority < 0 || t.Priority > 3 {
+		t.Priority = model.PriorityMedium
+	}
+	if id := parseUUIDPtr(req.AssigneeID); id != nil {
+		if u, err := s.tasks.GetUser(ctx, *id); err != nil {
+			return nil, fmt.Errorf("lookup assignee: %w", err)
+		} else if u == nil {
+			return nil, response.NewError(response.CodeTaskTargetGone, "转办目标用户不存在")
+		}
+		t.AssigneeID = id
+	}
+	if id := parseUUIDPtr(req.DepartmentID); id != nil {
+		t.DepartmentID = id
+	}
+	if id := parseUUIDPtr(req.ParentID); id != nil {
+		parent, err := s.mustTask(ctx, *id)
+		if err != nil {
+			return nil, err
+		}
+		if parent.ParentID != nil {
+			return nil, response.NewError(response.CodeBadRequest, "仅支持一层子任务")
+		}
+		t.ParentID = id
+	}
+	if err := s.tasks.Create(ctx, t); err != nil {
+		return nil, fmt.Errorf("create task: %w", err)
+	}
+	s.addLog(ctx, t.ID, operator, model.ActionCreate, "", t.Title, "")
+	if t.AssigneeID != nil {
+		s.notifyUsers(ctx, []uuid.UUID{*t.AssigneeID}, tplTaskAssigned, t, "")
+		s.addLog(ctx, t.ID, operator, model.ActionAssign, "", t.AssigneeID.String(), "")
+	}
+	return s.Get(ctx, t.ID)
+}
+
+func (s *taskService) List(ctx context.Context, viewer uuid.UUID, req *dto.ListTaskRequest, scope *rbacModel.DataScopeCondition) ([]*dto.TaskResponse, int64, error) {
+	rows, total, err := s.tasks.List(ctx, req, rewriteTaskScope(scope, viewer))
+	if err != nil {
+		return nil, 0, fmt.Errorf("list tasks: %w", err)
+	}
+	out := make([]*dto.TaskResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, mapTask(&rows[i], nil))
+	}
+	return out, total, nil
+}
+
+func (s *taskService) Get(ctx context.Context, id uuid.UUID) (*dto.TaskResponse, error) {
+	row, err := s.tasks.GetByIDWithNames(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get task: %w", err)
+	}
+	if row == nil {
+		return nil, response.NewError(response.CodeTaskNotFound, "任务不存在")
+	}
+	children, err := s.tasks.ListChildren(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("list children: %w", err)
+	}
+	return mapTask(row, children), nil
+}
+
+func (s *taskService) Update(ctx context.Context, id, operator uuid.UUID, req *dto.UpdateTaskRequest) (*dto.TaskResponse, error) {
+	t, err := s.mustTask(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.ensureMutable(t, operator); err != nil {
+		return nil, err
+	}
+	if req.Title != nil {
+		t.Title = strings.TrimSpace(*req.Title)
+	}
+	if req.Description != nil {
+		t.Description = *req.Description
+	}
+	if req.Priority != nil {
+		if *req.Priority < 0 || *req.Priority > 3 {
+			return nil, response.NewError(response.CodeBadRequest, "无效优先级")
+		}
+		t.Priority = *req.Priority
+	}
+	if req.DueDate != nil {
+		t.DueDate = req.DueDate
+		t.DueRemindedAt = nil
+		t.OverdueRemindedAt = nil
+	}
+	if req.Tags != nil {
+		t.Tags = encodeTags(req.Tags)
+	}
+	t.UpdatedAt = time.Now()
+	if err := s.tasks.Update(ctx, t); err != nil {
+		return nil, fmt.Errorf("update task: %w", err)
+	}
+	return s.Get(ctx, id)
+}
+
+func (s *taskService) Delete(ctx context.Context, id, operator uuid.UUID) error {
+	t, err := s.mustTask(ctx, id)
+	if err != nil {
+		return err
+	}
+	if t.Status == model.StatusDoing {
+		return response.NewError(response.CodeTaskInvalidState, "进行中任务不可删除")
+	}
+	if t.CreatorID != operator && (t.AssigneeID == nil || *t.AssigneeID != operator) {
+		return response.NewError(response.CodeTaskNoAccess, "无权操作该任务")
+	}
+	if err := s.tasks.Delete(ctx, id); err != nil {
+		return fmt.Errorf("delete task: %w", err)
+	}
+	return nil
+}
+
+func (s *taskService) mustTask(ctx context.Context, id uuid.UUID) (*model.Task, error) {
+	t, err := s.tasks.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get task: %w", err)
+	}
+	if t == nil {
+		return nil, response.NewError(response.CodeTaskNotFound, "任务不存在")
+	}
+	return t, nil
+}
+
+func (s *taskService) ensureMutable(t *model.Task, operator uuid.UUID) error {
+	if model.IsClosed(t.Status) {
+		return response.NewError(response.CodeTaskClosed, "任务已关闭，无法操作")
+	}
+	if t.CreatorID != operator && (t.AssigneeID == nil || *t.AssigneeID != operator) {
+		return response.NewError(response.CodeTaskNoAccess, "无权操作该任务")
+	}
+	return nil
+}
+
+func rewriteTaskScope(scope *rbacModel.DataScopeCondition, userID uuid.UUID) *rbacModel.DataScopeCondition {
+	if scope == nil || scope.IsEmpty() {
+		return scope
+	}
+	if scope.Query == "1 = 0" {
+		return &rbacModel.DataScopeCondition{
+			Query: "t.creator_id = ? OR t.assignee_id = ?",
+			Args:  []interface{}{userID, userID},
+		}
+	}
+	q := strings.ReplaceAll(scope.Query, "department_id", "t.department_id")
+	return &rbacModel.DataScopeCondition{Query: q, Args: scope.Args}
+}

--- a/backend/internal/task/service/task_test.go
+++ b/backend/internal/task/service/task_test.go
@@ -1,0 +1,193 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func newTestSvc() (*taskService, *memTasks, *memLogs, *memNotify) {
+	tasks := newMemTasks()
+	logs := newMemLogs()
+	notify := &memNotify{}
+	svc := NewTaskService(tasks, logs, newMemComments(), newMemFiles(), notify, nil, nil).(*taskService)
+	return svc, tasks, logs, notify
+}
+
+func TestCreateAssignStatusUrgeComment(t *testing.T) {
+	svc, tasks, logs, notify := newTestSvc()
+	ctx := context.Background()
+	creator := uuid.New()
+	assignee := uuid.New()
+	tasks.users[assignee] = &model.NamedUser{ID: assignee, Username: "alice", RealName: "爱丽丝"}
+
+	created, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{
+		Title: "实现登录", Priority: 2, AssigneeID: assignee.String(), Tags: []string{"frontend", "auth"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Status != 0 || created.Assignee == nil || created.Assignee.ID != assignee.String() {
+		t.Fatalf("create %+v", created)
+	}
+	id := uuid.MustParse(created.ID)
+
+	if _, err := svc.ChangeStatus(ctx, id, creator, &dto.StatusRequest{Status: 1, Comment: "开工"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ChangeStatus(ctx, id, creator, &dto.StatusRequest{Status: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ChangeStatus(ctx, id, creator, &dto.StatusRequest{Status: 1}); err == nil {
+		t.Fatal("expected closed")
+	} else if ae, ok := err.(*response.AppError); !ok || ae.Code != response.CodeTaskClosed {
+		t.Fatalf("want 9007 got %v", err)
+	}
+
+	other := uuid.New()
+	tasks.users[other] = &model.NamedUser{ID: other, Username: "bob"}
+	if _, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "B", AssigneeID: assignee.String()}); err != nil {
+		t.Fatal(err)
+	}
+	_ = logs
+	_ = notify
+}
+
+func TestStateMachineAndTransfer(t *testing.T) {
+	svc, tasks, _, notify := newTestSvc()
+	ctx := context.Background()
+	creator := uuid.New()
+	a1 := uuid.New()
+	a2 := uuid.New()
+	tasks.users[a1] = &model.NamedUser{ID: a1, Username: "u1"}
+	tasks.users[a2] = &model.NamedUser{ID: a2, Username: "u2"}
+
+	row, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "T", AssigneeID: a1.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(row.ID)
+	if _, err := svc.ChangeStatus(ctx, id, creator, &dto.StatusRequest{Status: 4}); err == nil {
+		t.Fatal("pending cannot hold")
+	}
+	if _, err := svc.ChangeStatus(ctx, id, creator, &dto.StatusRequest{Status: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ChangeStatus(ctx, id, creator, &dto.StatusRequest{Status: 4}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ChangeStatus(ctx, id, creator, &dto.StatusRequest{Status: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Transfer(ctx, id, creator, &dto.TransferRequest{NewAssigneeID: a2.String(), Reason: "忙不过来"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := svc.Get(ctx, id)
+	if got.Assignee == nil || got.Assignee.ID != a2.String() {
+		t.Fatalf("transfer %+v", got.Assignee)
+	}
+	if err := svc.Urge(ctx, id, creator, "尽快"); err != nil {
+		t.Fatal(err)
+	}
+	if notify.calls < 2 {
+		t.Fatalf("notify calls=%d", notify.calls)
+	}
+	if _, err := svc.Assign(ctx, id, creator, uuid.New().String()); err == nil {
+		t.Fatal("missing user")
+	}
+}
+
+func TestCommentMentionAndMyLists(t *testing.T) {
+	svc, tasks, _, _ := newTestSvc()
+	ctx := context.Background()
+	creator := uuid.New()
+	assignee := uuid.New()
+	tasks.users[assignee] = &model.NamedUser{ID: assignee, Username: "alice"}
+	row, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "C", AssigneeID: assignee.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(row.ID)
+	cmt, err := svc.AddComment(ctx, id, creator, &dto.CommentRequest{Content: "hello @alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cmt.Mentions) != 1 || cmt.Mentions[0] != assignee.String() {
+		t.Fatalf("mentions %+v", cmt.Mentions)
+	}
+	list, err := svc.ListComments(ctx, id)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list comments %v %d", err, len(list))
+	}
+	todo, n, err := svc.ListMy(ctx, assignee, "todo", &dto.MyTaskRequest{})
+	if err != nil || n != 1 || len(todo) != 1 {
+		t.Fatalf("todo %v %d", err, n)
+	}
+	created, n, err := svc.ListMy(ctx, creator, "created", &dto.MyTaskRequest{})
+	if err != nil || n != 1 || created[0].ID != row.ID {
+		t.Fatalf("created %v %d", err, n)
+	}
+	past := time.Now().Add(-2 * time.Hour)
+	_, err = svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "late", AssigneeID: assignee.String(), DueDate: &past})
+	if err != nil {
+		t.Fatal(err)
+	}
+	over, n, err := svc.ListMy(ctx, assignee, "overdue", &dto.MyTaskRequest{})
+	if err != nil || n != 1 || over[0].Title != "late" {
+		t.Fatalf("overdue %v %d %+v", err, n, over)
+	}
+	stats, err := svc.Stats(ctx, &dto.StatsRequest{})
+	if err != nil || stats.Total < 2 || stats.Overdue < 1 {
+		t.Fatalf("stats %+v %v", stats, err)
+	}
+}
+
+func TestRemindDueAndOverdue(t *testing.T) {
+	svc, tasks, _, notify := newTestSvc()
+	ctx := context.Background()
+	creator := uuid.New()
+	assignee := uuid.New()
+	soon := time.Now().Add(2 * time.Hour)
+	past := time.Now().Add(-time.Hour)
+	t1 := &model.Task{ID: uuid.New(), Title: "soon", CreatorID: creator, AssigneeID: &assignee, DueDate: &soon, Status: 1, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	t2 := &model.Task{ID: uuid.New(), Title: "late", CreatorID: creator, AssigneeID: &assignee, DueDate: &past, Status: 0, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	_ = tasks.Create(ctx, t1)
+	_ = tasks.Create(ctx, t2)
+	n, err := svc.RemindDueAndOverdue(ctx)
+	if err != nil || n != 2 {
+		t.Fatalf("remind n=%d err=%v", n, err)
+	}
+	if notify.calls != 2 {
+		t.Fatalf("notify=%d", notify.calls)
+	}
+	n, err = svc.RemindDueAndOverdue(ctx)
+	if err != nil || n != 0 {
+		t.Fatalf("second remind n=%d err=%v", n, err)
+	}
+}
+
+func TestNoAccessAndNotFound(t *testing.T) {
+	svc, _, _, _ := newTestSvc()
+	ctx := context.Background()
+	if _, err := svc.Get(ctx, uuid.New()); err == nil {
+		t.Fatal("expected not found")
+	}
+	creator := uuid.New()
+	row, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{Title: "X"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(row.ID)
+	other := uuid.New()
+	if _, err := svc.Update(ctx, id, other, &dto.UpdateTaskRequest{}); err == nil {
+		t.Fatal("expected no access")
+	}
+	if err := svc.Urge(ctx, id, other, "x"); err == nil {
+		t.Fatal("urge no access")
+	}
+}

--- a/backend/migrations/000023_task_workflow.down.sql
+++ b/backend/migrations/000023_task_workflow.down.sql
@@ -1,0 +1,21 @@
+DROP INDEX IF EXISTS idx_task_logs_created_at;
+DROP INDEX IF EXISTS idx_task_logs_task_id;
+DROP TABLE IF EXISTS task_logs;
+
+ALTER TABLE task_attachments
+    DROP COLUMN IF EXISTS uploaded_by;
+
+ALTER TABLE task_comments
+    DROP COLUMN IF EXISTS mentions,
+    DROP COLUMN IF EXISTS updated_at;
+
+DROP INDEX IF EXISTS idx_tasks_due_date;
+DROP INDEX IF EXISTS idx_tasks_parent_id;
+
+ALTER TABLE tasks
+    DROP COLUMN IF EXISTS parent_id,
+    DROP COLUMN IF EXISTS sort_order,
+    DROP COLUMN IF EXISTS due_reminded_at,
+    DROP COLUMN IF EXISTS overdue_reminded_at;
+
+DELETE FROM permissions WHERE code IN ('task:assign', 'task:transfer', 'task:comment');

--- a/backend/migrations/000023_task_workflow.up.sql
+++ b/backend/migrations/000023_task_workflow.up.sql
@@ -1,0 +1,46 @@
+-- ============================================================
+-- 000023_task_workflow.up.sql
+-- Issue #9：复用 000013 表，不改已有列名
+-- tasks.status 对齐 Issue：0待处理 1进行中 2已完成 3已取消 4已挂起
+--   （覆盖 000013 注释：2待审核 3已完成 4已取消；表尚无业务数据）
+-- task_comments.author_id 对外映射 user_id
+-- task_attachments.file_id 复用 files/MinIO，不另存路径列
+-- tags 仍为 VARCHAR，存 JSON 数组字符串
+-- ============================================================
+
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS parent_id UUID REFERENCES tasks(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS sort_order INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS due_reminded_at TIMESTAMP,
+    ADD COLUMN IF NOT EXISTS overdue_reminded_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON tasks(parent_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_due_date ON tasks(due_date);
+
+ALTER TABLE task_comments
+    ADD COLUMN IF NOT EXISTS mentions TEXT NOT NULL DEFAULT '[]',
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE task_attachments
+    ADD COLUMN IF NOT EXISTS uploaded_by UUID REFERENCES users(id) ON DELETE SET NULL;
+
+CREATE TABLE IF NOT EXISTS task_logs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    action_type VARCHAR(32) NOT NULL,
+    old_value VARCHAR(500) NOT NULL DEFAULT '',
+    new_value VARCHAR(500) NOT NULL DEFAULT '',
+    operator_id UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    comment TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_logs_task_id ON task_logs(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_logs_created_at ON task_logs(created_at);
+
+INSERT INTO permissions (id, name, code, resource, action, description, type, is_system, status)
+VALUES
+    (uuid_generate_v4(), '任务分配', 'task:assign', 'task', 'assign', '分配任务负责人', 2, true, 0),
+    (uuid_generate_v4(), '任务转办', 'task:transfer', 'task', 'transfer', '转办任务', 2, true, 0),
+    (uuid_generate_v4(), '任务评论', 'task:comment', 'task', 'comment', '任务评论与提及', 2, true, 0)
+ON CONFLICT (code) DO NOTHING;

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -109,8 +109,14 @@ const (
 	CodeVoteAnonymousHidden = 8010 // 匿名投票无法查看个人记录
 
 	// ===== Task module (9000-9999) =====
-	CodeTaskNotFound = 9001 // 任务不存在
-	CodeTaskNoAccess = 9002 // 无权操作任务
+	CodeTaskNotFound     = 9001 // 任务不存在
+	CodeTaskInvalidState = 9002 // 任务状态不允许该操作
+	CodeTaskNoAccess     = 9003 // 无权操作该任务
+	CodeTaskCommentGone  = 9004 // 评论不存在
+	CodeTaskAttachGone   = 9005 // 附件不存在
+	CodeTaskUploadFail   = 9006 // 文件上传失败
+	CodeTaskClosed       = 9007 // 任务已关闭，无法操作
+	CodeTaskTargetGone   = 9008 // 转办目标用户不存在
 
 	// ===== Internship module (10000-10999) =====
 	CodeInternshipNotFound = 10001 // 实习记录不存在

--- a/backend/scripts/seed_rbac.go
+++ b/backend/scripts/seed_rbac.go
@@ -75,6 +75,11 @@ func allSeedPermissions() []seedPerm {
 	perms = append(perms, moduleCRUD("meeting", "会议")...)
 	perms = append(perms, seedPerm{Name: "会议管理", Code: "meeting:manage", Resource: "meeting", Action: "manage"})
 	perms = append(perms, moduleCRUD("task", "任务")...)
+	perms = append(perms,
+		seedPerm{Name: "任务分配", Code: "task:assign", Resource: "task", Action: "assign"},
+		seedPerm{Name: "任务转办", Code: "task:transfer", Resource: "task", Action: "transfer"},
+		seedPerm{Name: "任务评论", Code: "task:comment", Resource: "task", Action: "comment"},
+	)
 	perms = append(perms, moduleCRUD("internship", "实习")...)
 	perms = append(perms, moduleCRUD("workflow", "流程")...)
 	perms = append(perms,
@@ -182,6 +187,7 @@ func seedRolePermissions(db *gorm.DB) error {
 			OR (p.resource = 'member' AND p.action IN ('approve','export','manage'))
 			OR (p.resource = 'interview' AND p.action IN ('manage','evaluate'))
 			OR (p.resource = 'meeting' AND p.action = 'manage')
+			OR (p.resource = 'task' AND p.action IN ('assign','transfer','comment'))
 		)
 		ON CONFLICT (role_id, permission_id) DO NOTHING
 	`).Error; err != nil {
@@ -197,6 +203,7 @@ func seedRolePermissions(db *gorm.DB) error {
 			p.action = 'read'
 			OR (p.resource IN ('member','interview','meeting','task','internship','file')
 			    AND p.action = 'create')
+			OR (p.resource = 'task' AND p.action IN ('update','comment'))
 		)
 		ON CONFLICT (role_id, permission_id) DO NOTHING
 	`).Error; err != nil {
@@ -213,7 +220,7 @@ func officerPermCodes() []string {
 	return []string{
 		"user:read", "member:read", "member:create",
 		"interview:read", "interview:evaluate", "meeting:read",
-		"task:read", "task:create",
+		"task:read", "task:create", "task:update", "task:comment",
 		"file:read", "file:create",
 		"internship:read", "internship:create",
 	}

--- a/backend/scripts/seed_templates.go
+++ b/backend/scripts/seed_templates.go
@@ -66,6 +66,36 @@ var seedTemplatesData = []seedTemplate{
 		Body:   "{{.real_name}}，你被分配了任务「{{.title}}」。",
 		Schema: `{"real_name":"string","title":"string"}`,
 	},
+	{
+		Code: "task_transferred", Name: "任务转办", Category: "task",
+		Title:  "任务转办：{{.title}}",
+		Body:   "任务「{{.title}}」已转办给你。{{.message}}",
+		Schema: `{"title":"string","message":"string"}`,
+	},
+	{
+		Code: "task_urged", Name: "任务催办", Category: "task",
+		Title:  "催办：{{.title}}",
+		Body:   "任务「{{.title}}」被催办。{{.message}}",
+		Schema: `{"title":"string","message":"string"}`,
+	},
+	{
+		Code: "task_mention", Name: "任务评论提及", Category: "task",
+		Title:  "有人在任务中提到你：{{.title}}",
+		Body:   "任务「{{.title}}」的评论提到了你：{{.message}}",
+		Schema: `{"title":"string","message":"string"}`,
+	},
+	{
+		Code: "task_due_soon", Name: "任务即将到期", Category: "task",
+		Title:  "任务即将到期：{{.title}}",
+		Body:   "任务「{{.title}}」将于 {{.due_date}} 到期。",
+		Schema: `{"title":"string","due_date":"string"}`,
+	},
+	{
+		Code: "task_overdue", Name: "任务已超期", Category: "task",
+		Title:  "任务已超期：{{.title}}",
+		Body:   "任务「{{.title}}」已超过截止时间 {{.due_date}}。",
+		Schema: `{"title":"string","due_date":"string"}`,
+	},
 }
 
 func seedTemplates(db *gorm.DB) error {

--- a/frontend/src/api/task.ts
+++ b/frontend/src/api/task.ts
@@ -2,63 +2,114 @@ import request from './request';
 import type {
   Task,
   TaskComment,
+  TaskLog,
+  TaskAttachment,
+  TaskStats,
   CreateTaskParams,
   UpdateTaskParams,
   ListTaskParams,
   PageResponse,
 } from '@/types/api';
 
-// 获取任务列表
 export function getTaskList(params: ListTaskParams): Promise<PageResponse<Task>> {
   return request.get('/tasks', { params });
 }
 
-// 获取我的任务
-export function getMyTasks(params: ListTaskParams): Promise<PageResponse<Task>> {
-  return request.get('/tasks/my', { params });
-}
-
-// 获取我创建的任务
-export function getCreatedTasks(params: ListTaskParams): Promise<PageResponse<Task>> {
-  return request.get('/tasks/created', { params });
-}
-
-// 获取任务详情
 export function getTaskDetail(id: string): Promise<Task> {
   return request.get(`/tasks/${id}`);
 }
 
-// 创建任务
 export function createTask(data: CreateTaskParams): Promise<Task> {
   return request.post('/tasks', data);
 }
 
-// 更新任务
 export function updateTask(id: string, data: UpdateTaskParams): Promise<Task> {
   return request.put(`/tasks/${id}`, data);
 }
 
-// 删除任务
 export function deleteTask(id: string): Promise<void> {
   return request.delete(`/tasks/${id}`);
 }
 
-// 更新任务状态
-export function updateTaskStatus(id: string, status: number): Promise<Task> {
-  return request.patch(`/tasks/${id}/status`, { status });
+export function updateTaskStatus(id: string, status: number, comment?: string): Promise<Task> {
+  return request.post(`/tasks/${id}/status`, { status, comment });
 }
 
-// 分配任务
 export function assignTask(id: string, assigneeId: string): Promise<Task> {
   return request.post(`/tasks/${id}/assign`, { assignee_id: assigneeId });
 }
 
-// 获取任务评论
+export function transferTask(id: string, newAssigneeId: string, reason: string): Promise<Task> {
+  return request.post(`/tasks/${id}/transfer`, { new_assignee_id: newAssigneeId, reason });
+}
+
+export function urgeTask(id: string, message?: string): Promise<void> {
+  return request.post(`/tasks/${id}/urge`, { message });
+}
+
+export function getTaskLogs(id: string): Promise<TaskLog[]> {
+  return request.get(`/tasks/${id}/logs`);
+}
+
 export function getTaskComments(taskId: string): Promise<TaskComment[]> {
   return request.get(`/tasks/${taskId}/comments`);
 }
 
-// 添加任务评论
-export function addTaskComment(taskId: string, content: string): Promise<TaskComment> {
-  return request.post(`/tasks/${taskId}/comments`, { content });
+export function addTaskComment(taskId: string, content: string, mentions?: string[]): Promise<TaskComment> {
+  return request.post(`/tasks/${taskId}/comments`, { content, mentions });
+}
+
+export function updateTaskComment(taskId: string, cid: string, content: string): Promise<TaskComment> {
+  return request.put(`/tasks/${taskId}/comments/${cid}`, { content });
+}
+
+export function deleteTaskComment(taskId: string, cid: string): Promise<void> {
+  return request.delete(`/tasks/${taskId}/comments/${cid}`);
+}
+
+export function getTaskAttachments(taskId: string): Promise<TaskAttachment[]> {
+  return request.get(`/tasks/${taskId}/attachments`);
+}
+
+export function uploadTaskAttachment(taskId: string, file: File): Promise<TaskAttachment> {
+  const form = new FormData();
+  form.append('file', file);
+  return request.post(`/tasks/${taskId}/attachments`, form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+}
+
+export async function downloadTaskAttachment(taskId: string, aid: string, filename: string): Promise<void> {
+  const res = await request.get(`/tasks/${taskId}/attachments/${aid}`, { responseType: 'blob' });
+  const blob = (res as { data: Blob }).data;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename || 'attachment';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function deleteTaskAttachment(taskId: string, aid: string): Promise<void> {
+  return request.delete(`/tasks/${taskId}/attachments/${aid}`);
+}
+
+export function getMyTodo(params: ListTaskParams): Promise<PageResponse<Task>> {
+  return request.get('/tasks/my/todo', { params });
+}
+
+export function getMyDone(params: ListTaskParams): Promise<PageResponse<Task>> {
+  return request.get('/tasks/my/done', { params });
+}
+
+export function getMyCreated(params: ListTaskParams): Promise<PageResponse<Task>> {
+  return request.get('/tasks/my/created', { params });
+}
+
+export function getMyOverdue(params: ListTaskParams): Promise<PageResponse<Task>> {
+  return request.get('/tasks/my/overdue', { params });
+}
+
+export function getTaskStats(params?: { department_id?: string; start_date?: string; end_date?: string }): Promise<TaskStats> {
+  return request.get('/tasks/stats', { params });
 }

--- a/frontend/src/pages/task/BoardPage.tsx
+++ b/frontend/src/pages/task/BoardPage.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Card, Tag, message } from 'antd';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { getTaskList, updateTaskStatus } from '@/api/task';
+import type { Task } from '@/types/api';
+import { BOARD_COLUMNS, TaskPriorityMap } from './meta';
+import DetailDrawer from './DetailDrawer';
+
+const BoardPage: React.FC = () => {
+  const [list, setList] = useState<Task[]>([]);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [detailId, setDetailId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const res = await getTaskList({ page: 1, page_size: 100, sort_by: 'sort_order', sort_order: 'asc' });
+    setList(res.list || []);
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const dropTo = async (status: number) => {
+    if (!dragId) return;
+    try {
+      await updateTaskStatus(dragId, status);
+      message.success('已更新状态');
+      await load();
+    } catch {
+      /* interceptor already toasts */
+    } finally {
+      setDragId(null);
+    }
+  };
+
+  return (
+    <Card title="任务看板">
+      <div style={{ display: 'flex', gap: 12, overflowX: 'auto', minHeight: 480 }}>
+        {BOARD_COLUMNS.map((col) => {
+          const cards = list.filter((t) => t.status === col.status);
+          return (
+            <div
+              key={col.status}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => { void dropTo(col.status); }}
+              style={{
+                width: 240, flexShrink: 0, background: '#f5f5f5', borderRadius: 8, padding: 8,
+              }}
+            >
+              <div style={{ fontWeight: 600, marginBottom: 8 }}>{col.title} ({cards.length})</div>
+              {cards.map((t) => (
+                <div
+                  key={t.id}
+                  draggable
+                  onDragStart={() => setDragId(t.id)}
+                  onClick={() => setDetailId(t.id)}
+                  style={{
+                    background: '#fff', borderRadius: 6, padding: 10, marginBottom: 8,
+                    cursor: 'grab', boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+                  }}
+                >
+                  <div style={{ fontWeight: 500 }}>{t.title}</div>
+                  <div style={{ marginTop: 6 }}>
+                    <StatusTag status={t.priority} mapping={TaskPriorityMap} />
+                  </div>
+                  <div style={{ color: '#888', fontSize: 12, marginTop: 6 }}>
+                    {t.assignee?.name || '未分配'}
+                    {t.due_date ? ` · ${t.due_date.slice(0, 10)}` : ''}
+                  </div>
+                  {(t.tags || []).slice(0, 3).map((tag) => <Tag key={tag} style={{ marginTop: 4 }}>{tag}</Tag>)}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+      <DetailDrawer taskId={detailId} open={!!detailId} onClose={() => setDetailId(null)} onChanged={() => { void load(); }} />
+    </Card>
+  );
+};
+
+export default BoardPage;

--- a/frontend/src/pages/task/DetailDrawer.tsx
+++ b/frontend/src/pages/task/DetailDrawer.tsx
@@ -1,0 +1,194 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Descriptions, Drawer, Input, List, Space, Tabs, Tag, Upload, message } from 'antd';
+import { UploadOutlined } from '@ant-design/icons';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { usePermission } from '@/hooks/usePermission';
+import { useSelector } from 'react-redux';
+import { selectCurrentUser } from '@/store/slices/userSlice';
+import {
+  addTaskComment, deleteTaskAttachment, deleteTaskComment, downloadTaskAttachment,
+  getTaskAttachments, getTaskComments, getTaskDetail, getTaskLogs, updateTaskStatus,
+  uploadTaskAttachment, urgeTask,
+} from '@/api/task';
+import type { Task, TaskAttachment, TaskComment, TaskLog } from '@/types/api';
+import { TaskPriorityMap, TaskStatusMap } from './meta';
+
+interface Props {
+  taskId: string | null;
+  open: boolean;
+  onClose: () => void;
+  onChanged: () => void;
+}
+
+const DetailDrawer: React.FC<Props> = ({ taskId, open, onClose, onChanged }) => {
+  const canUpdate = usePermission('task:update');
+  const canComment = usePermission('task:comment');
+  const canCreate = usePermission('task:create');
+  const me = useSelector(selectCurrentUser);
+  const [task, setTask] = useState<Task | null>(null);
+  const [comments, setComments] = useState<TaskComment[]>([]);
+  const [logs, setLogs] = useState<TaskLog[]>([]);
+  const [files, setFiles] = useState<TaskAttachment[]>([]);
+  const [content, setContent] = useState('');
+
+  const load = async (id: string) => {
+    const [t, c, l, a] = await Promise.all([
+      getTaskDetail(id),
+      getTaskComments(id),
+      getTaskLogs(id),
+      getTaskAttachments(id),
+    ]);
+    setTask(t);
+    setComments(c || []);
+    setLogs(l || []);
+    setFiles(a || []);
+  };
+
+  useEffect(() => {
+    if (open && taskId) {
+      void load(taskId);
+    }
+  }, [open, taskId]);
+
+  const changeStatus = async (status: number) => {
+    if (!taskId) return;
+    await updateTaskStatus(taskId, status);
+    message.success('状态已更新');
+    await load(taskId);
+    onChanged();
+  };
+
+  return (
+    <Drawer title={task?.title || '任务详情'} width={640} open={open} onClose={onClose}>
+      {task && (
+        <>
+          <Descriptions column={2} size="small" style={{ marginBottom: 16 }}>
+            <Descriptions.Item label="状态"><StatusTag status={task.status} mapping={TaskStatusMap} /></Descriptions.Item>
+            <Descriptions.Item label="优先级"><StatusTag status={task.priority} mapping={TaskPriorityMap} /></Descriptions.Item>
+            <Descriptions.Item label="负责人">{task.assignee?.name || '-'}</Descriptions.Item>
+            <Descriptions.Item label="创建人">{task.creator?.name || '-'}</Descriptions.Item>
+            <Descriptions.Item label="部门">{task.department?.name || '-'}</Descriptions.Item>
+            <Descriptions.Item label="截止">{task.due_date?.replace('T', ' ').slice(0, 16) || '-'}</Descriptions.Item>
+            <Descriptions.Item label="标签" span={2}>
+              {(task.tags || []).map((tag) => <Tag key={tag}>{tag}</Tag>)}
+            </Descriptions.Item>
+            <Descriptions.Item label="说明" span={2}>{task.description || '-'}</Descriptions.Item>
+          </Descriptions>
+          <Space wrap style={{ marginBottom: 16 }}>
+            {canUpdate && task.status === 0 && <Button onClick={() => changeStatus(1)}>开始</Button>}
+            {canUpdate && task.status === 1 && <Button onClick={() => changeStatus(2)}>完成</Button>}
+            {canUpdate && task.status === 1 && <Button onClick={() => changeStatus(4)}>挂起</Button>}
+            {canUpdate && task.status === 4 && <Button onClick={() => changeStatus(1)}>恢复</Button>}
+            {canUpdate && (task.status === 0 || task.status === 1) && <Button danger onClick={() => changeStatus(3)}>取消</Button>}
+            {canCreate && task.creator?.id === me?.id && task.assignee && (
+              <Button onClick={() => urgeTask(task.id, '请尽快处理').then(() => message.success('已催办'))}>催办</Button>
+            )}
+          </Space>
+          <Tabs
+            items={[
+              {
+                key: 'comments',
+                label: `评论 (${task.comment_count})`,
+                children: (
+                  <>
+                    <List
+                      dataSource={comments}
+                      locale={{ emptyText: '暂无评论' }}
+                      renderItem={(item) => (
+                        <List.Item
+                          actions={item.user_id === me?.id ? [
+                            <Button key="d" type="link" size="small" danger onClick={() => deleteTaskComment(task.id, item.id).then(() => load(task.id))}>删除</Button>,
+                          ] : undefined}
+                        >
+                          <List.Item.Meta title={item.user?.name} description={item.content} />
+                        </List.Item>
+                      )}
+                    />
+                    {canComment && (
+                      <Space.Compact style={{ width: '100%', marginTop: 12 }}>
+                        <Input.TextArea
+                          rows={2}
+                          value={content}
+                          onChange={(e) => setContent(e.target.value)}
+                          placeholder="评论，可用 @username 提及"
+                        />
+                        <Button
+                          type="primary"
+                          onClick={async () => {
+                            if (!content.trim()) return;
+                            await addTaskComment(task.id, content.trim());
+                            setContent('');
+                            await load(task.id);
+                            onChanged();
+                          }}
+                        >
+                          发送
+                        </Button>
+                      </Space.Compact>
+                    )}
+                  </>
+                ),
+              },
+              {
+                key: 'files',
+                label: `附件 (${task.attachment_count})`,
+                children: (
+                  <>
+                    <List
+                      dataSource={files}
+                      locale={{ emptyText: '暂无附件' }}
+                      renderItem={(item) => (
+                        <List.Item
+                          actions={[
+                            <Button key="dl" type="link" size="small" onClick={() => downloadTaskAttachment(task.id, item.id, item.file_name)}>下载</Button>,
+                            canUpdate ? <Button key="rm" type="link" size="small" danger onClick={() => deleteTaskAttachment(task.id, item.id).then(() => load(task.id))}>删除</Button> : null,
+                          ]}
+                        >
+                          {item.file_name} ({Math.round(item.file_size / 1024)} KB)
+                        </List.Item>
+                      )}
+                    />
+                    {canUpdate && (
+                      <Upload
+                        showUploadList={false}
+                        beforeUpload={async (file) => {
+                          await uploadTaskAttachment(task.id, file);
+                          message.success('已上传');
+                          await load(task.id);
+                          onChanged();
+                          return false;
+                        }}
+                      >
+                        <Button icon={<UploadOutlined />} style={{ marginTop: 8 }}>上传附件</Button>
+                      </Upload>
+                    )}
+                  </>
+                ),
+              },
+              {
+                key: 'logs',
+                label: '流转历史',
+                children: (
+                  <List
+                    dataSource={logs}
+                    locale={{ emptyText: '暂无记录' }}
+                    renderItem={(item) => (
+                      <List.Item>
+                        <List.Item.Meta
+                          title={`${item.operator?.name} · ${item.action_type}`}
+                          description={`${item.old_value || '-'} → ${item.new_value || '-'} ${item.comment || ''} ${item.created_at?.replace('T', ' ').slice(0, 16)}`}
+                        />
+                      </List.Item>
+                    )}
+                  />
+                ),
+              },
+            ]}
+          />
+        </>
+      )}
+    </Drawer>
+  );
+};
+
+export default DetailDrawer;

--- a/frontend/src/pages/task/FormModal.tsx
+++ b/frontend/src/pages/task/FormModal.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import { DatePicker, Form, Input, Modal, Select } from 'antd';
+import dayjs from 'dayjs';
+import { getUserList } from '@/api/user';
+import { getMemberDepartments } from '@/api/member';
+import type { MemberDepartmentOption, Task } from '@/types/api';
+import type { UserListItem } from '@/api/user';
+
+interface Props {
+  open: boolean;
+  editing: Task | null;
+  onCancel: () => void;
+  onSubmit: (values: Record<string, unknown>) => Promise<void>;
+}
+
+const FormModal: React.FC<Props> = ({ open, editing, onCancel, onSubmit }) => {
+  const [form] = Form.useForm();
+  const [users, setUsers] = useState<UserListItem[]>([]);
+  const [depts, setDepts] = useState<MemberDepartmentOption[]>([]);
+
+  useEffect(() => {
+    void getUserList({ page: 1, page_size: 50 }).then((res) => setUsers(res.list || []));
+    void getMemberDepartments().then(setDepts).catch(() => setDepts([]));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    if (editing) {
+      form.setFieldsValue({
+        title: editing.title,
+        description: editing.description,
+        priority: editing.priority,
+        tags: editing.tags,
+        due_date: editing.due_date ? dayjs(editing.due_date) : undefined,
+      });
+    } else {
+      form.resetFields();
+      form.setFieldsValue({ priority: 1 });
+    }
+  }, [open, editing, form]);
+
+  return (
+    <Modal
+      title={editing ? '编辑任务' : '新建任务'}
+      open={open}
+      onCancel={onCancel}
+      onOk={() => form.submit()}
+      destroyOnClose
+    >
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={async (values) => {
+          await onSubmit({
+            title: values.title,
+            description: values.description,
+            priority: values.priority,
+            tags: values.tags,
+            assignee_id: values.assignee_id,
+            department_id: values.department_id,
+            parent_id: values.parent_id,
+            due_date: values.due_date ? (values.due_date as dayjs.Dayjs).toISOString() : undefined,
+          });
+        }}
+      >
+        <Form.Item name="title" label="标题" rules={[{ required: true }]}>
+          <Input maxLength={200} />
+        </Form.Item>
+        <Form.Item name="priority" label="优先级" rules={[{ required: true }]}>
+          <Select
+            options={[
+              { value: 0, label: '低' },
+              { value: 1, label: '中' },
+              { value: 2, label: '高' },
+              { value: 3, label: '紧急' },
+            ]}
+          />
+        </Form.Item>
+        {!editing && (
+          <Form.Item name="assignee_id" label="负责人">
+            <Select
+              allowClear
+              showSearch
+              optionFilterProp="label"
+              options={users.map((u) => ({ value: u.id, label: u.real_name || u.username }))}
+            />
+          </Form.Item>
+        )}
+        {!editing && (
+          <Form.Item name="department_id" label="部门">
+            <Select allowClear options={depts.map((d) => ({ value: d.id, label: d.name }))} />
+          </Form.Item>
+        )}
+        <Form.Item name="due_date" label="截止日期">
+          <DatePicker showTime style={{ width: '100%' }} />
+        </Form.Item>
+        <Form.Item name="tags" label="标签">
+          <Select mode="tags" placeholder="输入后回车" />
+        </Form.Item>
+        <Form.Item name="description" label="说明">
+          <Input.TextArea rows={3} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default FormModal;

--- a/frontend/src/pages/task/ListPage.tsx
+++ b/frontend/src/pages/task/ListPage.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, Card, Input, Select, Space, Table, Tag, message } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { usePermission } from '@/hooks/usePermission';
+import { createTask, deleteTask, getTaskList, getTaskStats, updateTask } from '@/api/task';
+import type { Task, TaskPriority, TaskStats, TaskStatus } from '@/types/api';
+import { TaskPriorityMap, TaskStatusMap } from './meta';
+import FormModal from './FormModal';
+import DetailDrawer from './DetailDrawer';
+
+const ListPage: React.FC = () => {
+  const canCreate = usePermission('task:create');
+  const canUpdate = usePermission('task:update');
+  const canDelete = usePermission('task:delete');
+  const [list, setList] = useState<Task[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState<TaskStatus | undefined>();
+  const [priority, setPriority] = useState<TaskPriority | undefined>();
+  const [keyword, setKeyword] = useState('');
+  const [sortBy, setSortBy] = useState('created_at');
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Task | null>(null);
+  const [detailId, setDetailId] = useState<string | null>(null);
+  const [stats, setStats] = useState<TaskStats | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getTaskList({
+        page, page_size: 10, status, priority, keyword, sort_by: sortBy, sort_order: 'desc',
+      });
+      setList(res.list || []);
+      setTotal(res.total);
+      setStats(await getTaskStats());
+    } finally {
+      setLoading(false);
+    }
+  }, [page, status, priority, keyword, sortBy]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const columns: ColumnsType<Task> = [
+    { title: '标题', dataIndex: 'title', render: (v: string, r) => <Button type="link" onClick={() => setDetailId(r.id)}>{v}</Button> },
+    { title: '优先级', dataIndex: 'priority', width: 80, render: (v: number) => <StatusTag status={v} mapping={TaskPriorityMap} /> },
+    { title: '负责人', key: 'a', width: 100, render: (_, r) => r.assignee?.name || '-' },
+    { title: '创建人', key: 'c', width: 100, render: (_, r) => r.creator?.name || '-' },
+    { title: '截止', dataIndex: 'due_date', width: 160, render: (v?: string) => v?.replace('T', ' ').slice(0, 16) || '-' },
+    { title: '标签', dataIndex: 'tags', width: 160, render: (tags: string[]) => (tags || []).map((t) => <Tag key={t}>{t}</Tag>) },
+    { title: '状态', dataIndex: 'status', width: 90, render: (v: number) => <StatusTag status={v} mapping={TaskStatusMap} /> },
+    {
+      title: '操作',
+      width: 160,
+      render: (_, record) => (
+        <Space>
+          {canUpdate && record.status !== 2 && record.status !== 3 && (
+            <Button type="link" size="small" onClick={() => { setEditing(record); setOpen(true); }}>编辑</Button>
+          )}
+          {canDelete && record.status !== 1 && (
+            <Button type="link" size="small" danger onClick={() => deleteTask(record.id).then(() => { message.success('已删除'); void load(); })}>删除</Button>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Card
+      title="任务列表"
+      extra={canCreate && (
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => { setEditing(null); setOpen(true); }}>
+          新建任务
+        </Button>
+      )}
+    >
+      {stats && (
+        <Space style={{ marginBottom: 12 }}>
+          <Tag>全部 {stats.total}</Tag>
+          <Tag color="red">超期 {stats.overdue}</Tag>
+          <Tag color="blue">进行中 {stats.by_status?.doing || 0}</Tag>
+          <Tag color="green">已完成 {stats.by_status?.done || 0}</Tag>
+        </Space>
+      )}
+      <Space style={{ marginBottom: 16 }} wrap>
+        <Input.Search allowClear placeholder="搜索标题" onSearch={(v) => { setKeyword(v); setPage(1); }} />
+        <Select
+          allowClear placeholder="状态" style={{ width: 120 }} value={status}
+          onChange={(v) => { setStatus(v); setPage(1); }}
+          options={Object.entries(TaskStatusMap).map(([k, v]) => ({ value: Number(k), label: v.text }))}
+        />
+        <Select
+          allowClear placeholder="优先级" style={{ width: 120 }} value={priority}
+          onChange={(v) => { setPriority(v); setPage(1); }}
+          options={Object.entries(TaskPriorityMap).map(([k, v]) => ({ value: Number(k), label: v.text }))}
+        />
+        <Select
+          value={sortBy} style={{ width: 140 }} onChange={setSortBy}
+          options={[
+            { value: 'created_at', label: '按创建时间' },
+            { value: 'due_date', label: '按截止日期' },
+            { value: 'priority', label: '按优先级' },
+            { value: 'status', label: '按状态' },
+          ]}
+        />
+      </Space>
+      <Table
+        rowKey="id"
+        loading={loading}
+        columns={columns}
+        dataSource={list}
+        pagination={{ current: page, total, pageSize: 10, onChange: setPage }}
+      />
+      <FormModal
+        open={open}
+        editing={editing}
+        onCancel={() => setOpen(false)}
+        onSubmit={async (values) => {
+          if (editing) {
+            await updateTask(editing.id, {
+              title: String(values.title),
+              description: values.description ? String(values.description) : undefined,
+              priority: Number(values.priority) as TaskPriority,
+              due_date: values.due_date ? String(values.due_date) : undefined,
+              tags: Array.isArray(values.tags) ? values.tags.map(String) : undefined,
+            });
+            message.success('已更新');
+          } else {
+            await createTask({
+              title: String(values.title),
+              description: values.description ? String(values.description) : undefined,
+              priority: Number(values.priority) as TaskPriority,
+              assignee_id: values.assignee_id ? String(values.assignee_id) : undefined,
+              department_id: values.department_id ? String(values.department_id) : undefined,
+              due_date: values.due_date ? String(values.due_date) : undefined,
+              tags: Array.isArray(values.tags) ? values.tags.map(String) : undefined,
+            });
+            message.success('已创建');
+          }
+          setOpen(false);
+          await load();
+        }}
+      />
+      <DetailDrawer taskId={detailId} open={!!detailId} onClose={() => setDetailId(null)} onChanged={() => { void load(); }} />
+    </Card>
+  );
+};
+
+export default ListPage;

--- a/frontend/src/pages/task/MyPage.tsx
+++ b/frontend/src/pages/task/MyPage.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Card, Input, Table, Tabs } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import StatusTag from '@/components/StatusTag/StatusTag';
+import { getMyCreated, getMyDone, getMyOverdue, getMyTodo } from '@/api/task';
+import type { PageResponse, Task } from '@/types/api';
+import { TaskPriorityMap, TaskStatusMap } from './meta';
+import DetailDrawer from './DetailDrawer';
+
+type TabKey = 'todo' | 'done' | 'created' | 'overdue';
+
+const fetchers: Record<TabKey, (p: { page: number; page_size: number; keyword?: string }) => Promise<PageResponse<Task>>> = {
+  todo: getMyTodo,
+  done: getMyDone,
+  created: getMyCreated,
+  overdue: getMyOverdue,
+};
+
+const MyPage: React.FC = () => {
+  const [tab, setTab] = useState<TabKey>('todo');
+  const [list, setList] = useState<Task[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [keyword, setKeyword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [detailId, setDetailId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchers[tab]({ page, page_size: 10, keyword });
+      setList(res.list || []);
+      setTotal(res.total);
+    } finally {
+      setLoading(false);
+    }
+  }, [tab, page, keyword]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const columns: ColumnsType<Task> = [
+    { title: '标题', dataIndex: 'title', render: (v: string, r) => <a onClick={() => setDetailId(r.id)}>{v}</a> },
+    { title: '优先级', dataIndex: 'priority', width: 80, render: (v: number) => <StatusTag status={v} mapping={TaskPriorityMap} /> },
+    { title: '状态', dataIndex: 'status', width: 90, render: (v: number) => <StatusTag status={v} mapping={TaskStatusMap} /> },
+    { title: '负责人', key: 'a', width: 100, render: (_, r) => r.assignee?.name || '-' },
+    { title: '截止', dataIndex: 'due_date', width: 160, render: (v?: string) => v?.replace('T', ' ').slice(0, 16) || '-' },
+  ];
+
+  return (
+    <Card title="我的任务">
+      <Input.Search
+        allowClear
+        placeholder="搜索标题"
+        style={{ width: 260, marginBottom: 12 }}
+        onSearch={(v) => { setKeyword(v); setPage(1); }}
+      />
+      <Tabs
+        activeKey={tab}
+        onChange={(k) => { setTab(k as TabKey); setPage(1); }}
+        items={[
+          { key: 'todo', label: '待办' },
+          { key: 'done', label: '已办' },
+          { key: 'created', label: '我创建的' },
+          { key: 'overdue', label: '超期' },
+        ]}
+      />
+      <Table
+        rowKey="id"
+        loading={loading}
+        columns={columns}
+        dataSource={list}
+        pagination={{ current: page, total, pageSize: 10, onChange: setPage }}
+      />
+      <DetailDrawer taskId={detailId} open={!!detailId} onClose={() => setDetailId(null)} onChanged={() => { void load(); }} />
+    </Card>
+  );
+};
+
+export default MyPage;

--- a/frontend/src/pages/task/meta.ts
+++ b/frontend/src/pages/task/meta.ts
@@ -1,0 +1,24 @@
+import type { StatusMap } from '@/types/common';
+
+export const TaskStatusMap: StatusMap = {
+  0: { color: 'default', text: '待处理' },
+  1: { color: 'processing', text: '进行中' },
+  2: { color: 'success', text: '已完成' },
+  3: { color: 'error', text: '已取消' },
+  4: { color: 'warning', text: '已挂起' },
+};
+
+export const TaskPriorityMap: StatusMap = {
+  0: { color: 'default', text: '低' },
+  1: { color: 'blue', text: '中' },
+  2: { color: 'orange', text: '高' },
+  3: { color: 'red', text: '紧急' },
+};
+
+export const BOARD_COLUMNS: Array<{ status: 0 | 1 | 4 | 2 | 3; title: string }> = [
+  { status: 0, title: '待处理' },
+  { status: 1, title: '进行中' },
+  { status: 4, title: '已挂起' },
+  { status: 2, title: '已完成' },
+  { status: 3, title: '已取消' },
+];

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -28,6 +28,9 @@ const MeetingListPage = lazy(() => import('@/pages/meeting/ListPage'));
 const MeetingDetailPage = lazy(() => import('@/pages/meeting/DetailPage'));
 const MeetingCheckinPage = lazy(() => import('@/pages/meeting/CheckinPage'));
 const MeetingWeightPage = lazy(() => import('@/pages/meeting/WeightPage'));
+const TaskListPage = lazy(() => import('@/pages/task/ListPage'));
+const TaskBoardPage = lazy(() => import('@/pages/task/BoardPage'));
+const TaskMyPage = lazy(() => import('@/pages/task/MyPage'));
 const WorkflowDesigner = lazy(() => import('@/pages/workflow/designer/DesignerPage'));
 const Forbidden = lazy(() => import('@/pages/error/Forbidden'));
 const NotFound = lazy(() => import('@/pages/error/NotFound'));
@@ -204,12 +207,17 @@ const routes: AppRouteObject[] = [
         children: [
           {
             path: 'list',
-            element: <div style={{ padding: 24 }}>任务列表（开发中）</div>,
-            meta: { title: '任务列表' },
+            element: lazyGuarded(TaskListPage, 'task:read'),
+            meta: { title: '任务列表', permission: 'task:read' },
+          },
+          {
+            path: 'board',
+            element: lazyGuarded(TaskBoardPage, 'task:read'),
+            meta: { title: '任务看板', permission: 'task:read' },
           },
           {
             path: 'my',
-            element: <div style={{ padding: 24 }}>我的任务（开发中）</div>,
+            element: lazyWrap(TaskMyPage),
             meta: { title: '我的任务' },
           },
         ],

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -648,10 +648,22 @@ export interface CreateVoteParams {
 // ============================================================
 
 export type TaskStatus = 0 | 1 | 2 | 3 | 4;
-// 0=待处理 1=进行中 2=待审核 3=已完成 4=已取消
+// 0=待处理 1=进行中 2=已完成 3=已取消 4=已挂起
 
 export type TaskPriority = 0 | 1 | 2 | 3;
 // 0=低 1=中 2=高 3=紧急
+
+export interface TaskPerson {
+  id: string;
+  name: string;
+  avatar?: string;
+}
+
+export interface TaskBrief {
+  id: string;
+  title: string;
+  status: TaskStatus;
+}
 
 export interface Task {
   id: string;
@@ -659,29 +671,59 @@ export interface Task {
   description?: string;
   status: TaskStatus;
   priority: TaskPriority;
-  creator_id: string;
-  creator_name: string;
-  assignee_id?: string;
-  assignee_name?: string;
-  department_id?: string;
-  department_name?: string;
+  assignee?: TaskPerson;
+  creator: TaskPerson;
+  department?: TaskPerson;
+  parent?: { id: string; title: string };
+  children: TaskBrief[];
   due_date?: string;
-  progress: number; // 0-100
-  tags?: string[];
-  related_type?: string;
-  related_id?: string;
+  completed_at?: string;
+  tags: string[];
+  comment_count: number;
+  attachment_count: number;
+  progress: number;
   created_at: string;
   updated_at: string;
-  completed_at?: string;
 }
 
 export interface TaskComment {
   id: string;
   task_id: string;
-  author_id: string;
-  author_name: string;
+  user_id: string;
+  user: TaskPerson;
   content: string;
+  mentions: string[];
   created_at: string;
+  updated_at: string;
+}
+
+export interface TaskLog {
+  id: string;
+  action_type: 'status_change' | 'assign' | 'transfer' | 'comment' | 'urge' | 'create' | string;
+  old_value: string;
+  new_value: string;
+  operator: TaskPerson;
+  comment: string;
+  created_at: string;
+}
+
+export interface TaskAttachment {
+  id: string;
+  task_id: string;
+  file_id: string;
+  file_name: string;
+  file_path: string;
+  file_size: number;
+  file_type: string;
+  uploaded_by: string;
+  created_at: string;
+}
+
+export interface TaskStats {
+  total: number;
+  overdue: number;
+  by_status: Record<string, number>;
+  by_priority: Record<string, number>;
 }
 
 export interface CreateTaskParams {
@@ -692,19 +734,14 @@ export interface CreateTaskParams {
   department_id?: string;
   due_date?: string;
   tags?: string[];
-  related_type?: string;
-  related_id?: string;
+  parent_id?: string;
 }
 
 export interface UpdateTaskParams {
   title?: string;
   description?: string;
-  status?: TaskStatus;
   priority?: TaskPriority;
-  assignee_id?: string;
-  department_id?: string;
   due_date?: string;
-  progress?: number;
   tags?: string[];
 }
 
@@ -712,8 +749,10 @@ export interface ListTaskParams extends ListParams {
   status?: TaskStatus;
   priority?: TaskPriority;
   assignee_id?: string;
-  creator_id?: string;
   department_id?: string;
+  tags?: string;
+  sort_by?: string;
+  sort_order?: string;
 }
 
 // ============================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 Issue #9 任务流转：创建/分配/跟踪/状态机、评论 @提及、MinIO 附件、我的待办/已办/超期，以及到期前 24h / 已超期定时提醒。

复用 `000013` 的 `tasks` / `task_comments` / `task_attachments`，**不改已有列名**。新迁移 `000023` 补 `parent_id`、`sort_order`、提醒时间戳、评论 `mentions`，并新增 `task_logs`。

`tasks.status` 对齐 Issue：0 待处理 / 1 进行中 / 2 已完成 / 3 已取消 / 4 已挂起（覆盖 000013「待审核」语义；表无业务数据）。`author_id` 对外映射 `user_id`；附件继续走 `file_id` + files/MinIO。

不冲突流程引擎 `/api/v1/workflow/tasks`。

## 关联 Issue

Closes #9

## 测试方式

1. 跑迁移 `000023`，再 `APP_ENV=dev make seed`
2. 登录 `admin/admin123`，打开「任务流转 → 任务列表」创建任务并分配
3. 详情抽屉：改状态、评论 `@username`、催办
4. 看板列展示与抽屉改状态；「我的任务」四个 Tab
5. 后端 `go test ./internal/task/service -cover`（75.7%）
6. 本环境 MinIO 未启动时附件上传返回 9006（对象存储未配置），属环境问题

## 截图 / GIF

| 页面/功能 | 截图 |
|----------|------|
| 任务列表 | [任务列表](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftask_list.webp) |
| 任务看板 | [任务看板](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftask_board.webp) |
| 我的任务 | [我的任务](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftask_my_created.webp) |

## 注意事项

- 必须跑 `000023`，再 seed，否则缺 `task:assign` / `task:transfer` / `task:comment` 与通知模板
- 开发库是 `starbyte_dev`（`APP_ENV=dev`）
- 附件依赖 MinIO（#18）；本环境未起 MinIO 时上传返回 9006
- 通知失败只打日志不回滚
- 看板 HTML5 拖拽改状态；自动化走查改用抽屉按钮（状态机一致）

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测
- [x] 已添加/更新必要的文档
- [x] CI 检查通过（4/4）
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

