### PR TITLE
fix(task): 详情/评论/附件/统计走数据范围

### DIFF
--- a/backend/internal/task/handler/extra_handler.go
+++ b/backend/internal/task/handler/extra_handler.go
@@ -15,12 +15,17 @@ import (
 // @Tags 任务
 // @Router /tasks/{id}/comments [get]
 func (h *TaskHandler) ListComments(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 	id, err := parseID(c)
 	if err != nil {
 		response.Error(c, err)
 		return
 	}
-	out, err := h.svc.ListComments(c.Request.Context(), id)
+	out, err := h.svc.ListComments(c.Request.Context(), userID, id, dataScope(c))
 	if err != nil {
 		response.Error(c, err)
 		return
@@ -121,12 +126,17 @@ func (h *TaskHandler) DeleteComment(c *gin.Context) {
 // @Tags 任务
 // @Router /tasks/{id}/attachments [get]
 func (h *TaskHandler) ListAttachments(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 	id, err := parseID(c)
 	if err != nil {
 		response.Error(c, err)
 		return
 	}
-	out, err := h.svc.ListAttachments(c.Request.Context(), id)
+	out, err := h.svc.ListAttachments(c.Request.Context(), userID, id, dataScope(c))
 	if err != nil {
 		response.Error(c, err)
 		return
@@ -177,7 +187,12 @@ func (h *TaskHandler) DownloadAttachment(c *gin.Context) {
 		response.Error(c, err)
 		return
 	}
-	rc, filename, contentType, err := h.svc.DownloadAttachment(c.Request.Context(), id, aid)
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	rc, filename, contentType, err := h.svc.DownloadAttachment(c.Request.Context(), userID, id, aid, dataScope(c))
 	if err != nil {
 		response.Error(c, err)
 		return
@@ -262,21 +277,3 @@ func (h *TaskHandler) MyCreated(c *gin.Context) { h.myKind(c, "created") }
 // @Tags 任务
 // @Router /tasks/my/overdue [get]
 func (h *TaskHandler) MyOverdue(c *gin.Context) { h.myKind(c, "overdue") }
-
-// Stats 任务统计
-// @Summary 任务统计
-// @Tags 任务
-// @Router /tasks/stats [get]
-func (h *TaskHandler) Stats(c *gin.Context) {
-	var req dto.StatsRequest
-	if err := c.ShouldBindQuery(&req); err != nil {
-		response.BadRequest(c, "参数错误: "+err.Error())
-		return
-	}
-	out, err := h.svc.Stats(c.Request.Context(), &req)
-	if err != nil {
-		response.Error(c, err)
-		return
-	}
-	response.OK(c, out)
-}

--- a/backend/internal/task/handler/flow_handler.go
+++ b/backend/internal/task/handler/flow_handler.go
@@ -119,12 +119,40 @@ func (h *TaskHandler) Urge(c *gin.Context) {
 // @Tags 任务
 // @Router /tasks/{id}/logs [get]
 func (h *TaskHandler) ListLogs(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 	id, err := parseID(c)
 	if err != nil {
 		response.Error(c, err)
 		return
 	}
-	out, err := h.svc.ListLogs(c.Request.Context(), id)
+	out, err := h.svc.ListLogs(c.Request.Context(), userID, id, dataScope(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+// Stats 任务统计
+// @Summary 任务统计
+// @Tags 任务
+// @Router /tasks/stats [get]
+func (h *TaskHandler) Stats(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.StatsRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Stats(c.Request.Context(), userID, &req, dataScope(c))
 	if err != nil {
 		response.Error(c, err)
 		return

--- a/backend/internal/task/handler/task_handler.go
+++ b/backend/internal/task/handler/task_handler.go
@@ -63,12 +63,17 @@ func (h *TaskHandler) ListTasks(c *gin.Context) {
 // @Tags 任务
 // @Router /tasks/{id} [get]
 func (h *TaskHandler) GetTask(c *gin.Context) {
+	userID, err := getUserID(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
 	id, err := parseID(c)
 	if err != nil {
 		response.Error(c, err)
 		return
 	}
-	out, err := h.svc.Get(c.Request.Context(), id)
+	out, err := h.svc.Get(c.Request.Context(), userID, id, dataScope(c))
 	if err != nil {
 		response.Error(c, err)
 		return

--- a/backend/internal/task/repo/query.go
+++ b/backend/internal/task/repo/query.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/task/model"
 	"github.com/google/uuid"
@@ -72,8 +73,8 @@ func (r *taskRepo) ListOverdue(ctx context.Context, now time.Time) ([]model.Task
 	return rows, err
 }
 
-func (r *taskRepo) Stats(ctx context.Context, req *dto.StatsRequest, now time.Time) (*dto.StatsResponse, error) {
-	q := r.db.WithContext(ctx).Model(&model.Task{})
+func (r *taskRepo) Stats(ctx context.Context, req *dto.StatsRequest, now time.Time, scope *rbacModel.DataScopeCondition) (*dto.StatsResponse, error) {
+	q := applyScope(r.db.WithContext(ctx).Model(&model.Task{}), scope)
 	if req.DepartmentID != "" {
 		q = q.Where("department_id = ?", req.DepartmentID)
 	}

--- a/backend/internal/task/repo/task_repo.go
+++ b/backend/internal/task/repo/task_repo.go
@@ -23,7 +23,7 @@ type TaskRepo interface {
 	ListChildren(ctx context.Context, parentID uuid.UUID) ([]model.Task, error)
 	ListDueSoon(ctx context.Context, now, until time.Time) ([]model.Task, error)
 	ListOverdue(ctx context.Context, now time.Time) ([]model.Task, error)
-	Stats(ctx context.Context, req *dto.StatsRequest, now time.Time) (*dto.StatsResponse, error)
+	Stats(ctx context.Context, req *dto.StatsRequest, now time.Time, scope *rbacModel.DataScopeCondition) (*dto.StatsResponse, error)
 	GetUser(ctx context.Context, id uuid.UUID) (*model.NamedUser, error)
 	FindUsersByUsername(ctx context.Context, names []string) ([]model.NamedUser, error)
 }

--- a/backend/internal/task/service/attachment.go
+++ b/backend/internal/task/service/attachment.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"time"
 
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/task/model"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
@@ -54,8 +55,8 @@ func (s *taskService) UploadAttachment(ctx context.Context, taskID, operator uui
 	return &out, nil
 }
 
-func (s *taskService) ListAttachments(ctx context.Context, taskID uuid.UUID) ([]dto.AttachmentResponse, error) {
-	if _, err := s.mustTask(ctx, taskID); err != nil {
+func (s *taskService) ListAttachments(ctx context.Context, viewer, taskID uuid.UUID, scope *rbacModel.DataScopeCondition) ([]dto.AttachmentResponse, error) {
+	if _, err := s.mustVisible(ctx, taskID, viewer, scope); err != nil {
 		return nil, err
 	}
 	rows, err := s.files.ListByTask(ctx, taskID)
@@ -69,8 +70,8 @@ func (s *taskService) ListAttachments(ctx context.Context, taskID uuid.UUID) ([]
 	return out, nil
 }
 
-func (s *taskService) DownloadAttachment(ctx context.Context, taskID, attachID uuid.UUID) (io.ReadCloser, string, string, error) {
-	if _, err := s.mustTask(ctx, taskID); err != nil {
+func (s *taskService) DownloadAttachment(ctx context.Context, viewer, taskID, attachID uuid.UUID, scope *rbacModel.DataScopeCondition) (io.ReadCloser, string, string, error) {
+	if _, err := s.mustVisible(ctx, taskID, viewer, scope); err != nil {
 		return nil, "", "", err
 	}
 	named, err := s.mustAttachment(ctx, attachID, taskID)

--- a/backend/internal/task/service/comment.go
+++ b/backend/internal/task/service/comment.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"time"
 
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/task/model"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/google/uuid"
 )
 
-func (s *taskService) ListComments(ctx context.Context, taskID uuid.UUID) ([]dto.CommentResponse, error) {
-	if _, err := s.mustTask(ctx, taskID); err != nil {
+func (s *taskService) ListComments(ctx context.Context, viewer, taskID uuid.UUID, scope *rbacModel.DataScopeCondition) ([]dto.CommentResponse, error) {
+	if _, err := s.mustVisible(ctx, taskID, viewer, scope); err != nil {
 		return nil, err
 	}
 	rows, err := s.comments.ListByTask(ctx, taskID)

--- a/backend/internal/task/service/extra_test.go
+++ b/backend/internal/task/service/extra_test.go
@@ -12,6 +12,7 @@ import (
 	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/google/uuid"
 )
 
@@ -57,7 +58,7 @@ func TestUpdateDeleteListParent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := svc.Get(ctx, pid)
+	got, err := svc.Get(ctx, creator, pid, nil)
 	if err != nil || len(got.Children) != 1 || got.Children[0].ID != child.ID {
 		t.Fatalf("children %+v %v", got, err)
 	}
@@ -115,7 +116,7 @@ func TestCommentUpdateDeleteAndLogs(t *testing.T) {
 	if err := svc.DeleteComment(ctx, id, uuid.MustParse(cmt.ID), creator); err != nil {
 		t.Fatal(err)
 	}
-	logs, err := svc.ListLogs(ctx, id)
+	logs, err := svc.ListLogs(ctx, creator, id, nil)
 	if err != nil || len(logs) == 0 {
 		t.Fatalf("logs %v %d", err, len(logs))
 	}
@@ -138,11 +139,11 @@ func TestAttachments(t *testing.T) {
 	named, _ := files.GetNamed(ctx, uuid.MustParse(att.ID))
 	named.FilePath = "obj/f.txt"
 	named.FileName = "a.txt"
-	list, err := svc.ListAttachments(ctx, id)
+	list, err := svc.ListAttachments(ctx, creator, id, nil)
 	if err != nil || len(list) != 1 {
 		t.Fatalf("list att %v %d", err, len(list))
 	}
-	rc, name, _, err := svc.DownloadAttachment(ctx, id, uuid.MustParse(att.ID))
+	rc, name, _, err := svc.DownloadAttachment(ctx, creator, id, uuid.MustParse(att.ID), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,5 +204,62 @@ func TestNotifyAdapterNil(t *testing.T) {
 	n := reminderTargets(&model.Task{CreatorID: uuid.New()})
 	if len(n) != 1 {
 		t.Fatalf("targets %d", n)
+	}
+}
+
+func TestDataScopeVisibility(t *testing.T) {
+	svc, tasks, _, notify := newTestSvc()
+	ctx := context.Background()
+	creator := uuid.New()
+	assignee := uuid.New()
+	outsider := uuid.New()
+	dept := uuid.New()
+	otherDept := uuid.New()
+	tasks.users[assignee] = &model.NamedUser{ID: assignee, Username: "alice", RealName: "爱丽丝"}
+	tasks.users[outsider] = &model.NamedUser{ID: outsider, Username: "eve"}
+
+	row, err := svc.Create(ctx, creator, &dto.CreateTaskRequest{
+		Title: "范围", AssigneeID: assignee.String(), DepartmentID: dept.String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(row.ID)
+	if notify.calls < 1 || notify.last["real_name"] != "爱丽丝" {
+		t.Fatalf("assign notify %+v calls=%d", notify.last, notify.calls)
+	}
+
+	self := &rbacModel.DataScopeCondition{Query: "1 = 0"}
+	if _, err := svc.Get(ctx, outsider, id, self); err == nil {
+		t.Fatal("self scope outsider should be denied")
+	} else if ae, ok := err.(*response.AppError); !ok || ae.Code != response.CodeTaskNoAccess {
+		t.Fatalf("want 9003 got %v", err)
+	}
+	if _, err := svc.Get(ctx, creator, id, self); err != nil {
+		t.Fatalf("creator self scope %v", err)
+	}
+	if _, err := svc.Get(ctx, assignee, id, self); err != nil {
+		t.Fatalf("assignee self scope %v", err)
+	}
+	if _, err := svc.ListComments(ctx, outsider, id, self); err == nil {
+		t.Fatal("comments should honor scope")
+	}
+	if _, err := svc.ListLogs(ctx, outsider, id, self); err == nil {
+		t.Fatal("logs should honor scope")
+	}
+	if _, err := svc.ListAttachments(ctx, outsider, id, self); err == nil {
+		t.Fatal("attachments should honor scope")
+	}
+	if _, _, _, err := svc.DownloadAttachment(ctx, outsider, id, uuid.New(), self); err == nil {
+		t.Fatal("download should honor scope")
+	}
+
+	deptScope := &rbacModel.DataScopeCondition{Query: "department_id = ?", Args: []interface{}{dept}}
+	if _, err := svc.Get(ctx, outsider, id, deptScope); err != nil {
+		t.Fatalf("same dept %v", err)
+	}
+	wrongDept := &rbacModel.DataScopeCondition{Query: "department_id = ?", Args: []interface{}{otherDept}}
+	if _, err := svc.Get(ctx, outsider, id, wrongDept); err == nil {
+		t.Fatal("other dept should be denied")
 	}
 }

--- a/backend/internal/task/service/flow.go
+++ b/backend/internal/task/service/flow.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/task/model"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
@@ -32,7 +33,7 @@ func (s *taskService) Assign(ctx context.Context, id, operator uuid.UUID, assign
 	}
 	s.addLog(ctx, t.ID, operator, model.ActionAssign, old, assignee.ID.String(), "")
 	s.notifyUsers(ctx, []uuid.UUID{assignee.ID}, tplTaskAssigned, t, "")
-	return s.Get(ctx, id)
+	return s.Get(ctx, operator, id, nil)
 }
 
 func (s *taskService) Transfer(ctx context.Context, id, operator uuid.UUID, req *dto.TransferRequest) (*dto.TaskResponse, error) {
@@ -55,7 +56,7 @@ func (s *taskService) Transfer(ctx context.Context, id, operator uuid.UUID, req 
 	}
 	s.addLog(ctx, t.ID, operator, model.ActionTransfer, old, target.ID.String(), req.Reason)
 	s.notifyUsers(ctx, []uuid.UUID{target.ID}, tplTaskTransferred, t, req.Reason)
-	return s.Get(ctx, id)
+	return s.Get(ctx, operator, id, nil)
 }
 
 func (s *taskService) ChangeStatus(ctx context.Context, id, operator uuid.UUID, req *dto.StatusRequest) (*dto.TaskResponse, error) {
@@ -86,7 +87,7 @@ func (s *taskService) ChangeStatus(ctx context.Context, id, operator uuid.UUID, 
 		return nil, fmt.Errorf("change status: %w", err)
 	}
 	s.addLog(ctx, t.ID, operator, model.ActionStatusChange, old, strconv.Itoa(int(req.Status)), req.Comment)
-	return s.Get(ctx, id)
+	return s.Get(ctx, operator, id, nil)
 }
 
 func (s *taskService) Urge(ctx context.Context, id, operator uuid.UUID, message string) error {
@@ -108,8 +109,8 @@ func (s *taskService) Urge(ctx context.Context, id, operator uuid.UUID, message 
 	return nil
 }
 
-func (s *taskService) ListLogs(ctx context.Context, id uuid.UUID) ([]dto.LogResponse, error) {
-	if _, err := s.mustTask(ctx, id); err != nil {
+func (s *taskService) ListLogs(ctx context.Context, viewer, id uuid.UUID, scope *rbacModel.DataScopeCondition) ([]dto.LogResponse, error) {
+	if _, err := s.mustVisible(ctx, id, viewer, scope); err != nil {
 		return nil, err
 	}
 	rows, err := s.logs.ListByTask(ctx, id)
@@ -135,8 +136,8 @@ func (s *taskService) ListMy(ctx context.Context, userID uuid.UUID, kind string,
 	return out, total, nil
 }
 
-func (s *taskService) Stats(ctx context.Context, req *dto.StatsRequest) (*dto.StatsResponse, error) {
-	out, err := s.tasks.Stats(ctx, req, time.Now())
+func (s *taskService) Stats(ctx context.Context, viewer uuid.UUID, req *dto.StatsRequest, scope *rbacModel.DataScopeCondition) (*dto.StatsResponse, error) {
+	out, err := s.tasks.Stats(ctx, req, time.Now(), rewriteTaskScopeAlias(scope, viewer, ""))
 	if err != nil {
 		return nil, fmt.Errorf("task stats: %w", err)
 	}

--- a/backend/internal/task/service/mem_test.go
+++ b/backend/internal/task/service/mem_test.go
@@ -118,7 +118,7 @@ func (m *memTasks) ListOverdue(_ context.Context, now time.Time) ([]model.Task, 
 	}
 	return out, nil
 }
-func (m *memTasks) Stats(_ context.Context, _ *dto.StatsRequest, now time.Time) (*dto.StatsResponse, error) {
+func (m *memTasks) Stats(_ context.Context, _ *dto.StatsRequest, now time.Time, _ *rbacModel.DataScopeCondition) (*dto.StatsResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	out := &dto.StatsResponse{
@@ -274,11 +274,13 @@ func (m *memFiles) ListByTask(_ context.Context, taskID uuid.UUID) ([]model.Task
 type memNotify struct {
 	mu    sync.Mutex
 	calls int
+	last  map[string]interface{}
 }
 
-func (m *memNotify) Send(_ context.Context, _ []uuid.UUID, _ string, _ map[string]interface{}) error {
+func (m *memNotify) Send(_ context.Context, _ []uuid.UUID, _ string, vars map[string]interface{}) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls++
+	m.last = vars
 	return nil
 }

--- a/backend/internal/task/service/mention.go
+++ b/backend/internal/task/service/mention.go
@@ -70,11 +70,14 @@ func encodeTags(tags []string) string {
 			clean = append(clean, t)
 		}
 	}
-	s := encodeJSONList(clean)
-	if len(s) > 500 {
-		s = s[:500]
+	for len(clean) > 0 {
+		s := encodeJSONList(clean)
+		if len(s) <= 500 {
+			return s
+		}
+		clean = clean[:len(clean)-1]
 	}
-	return s
+	return "[]"
 }
 
 func parseUUIDPtr(raw string) *uuid.UUID {

--- a/backend/internal/task/service/mention_test.go
+++ b/backend/internal/task/service/mention_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -35,5 +36,8 @@ func TestEncodeTagsTruncates(t *testing.T) {
 	s := encodeTags(tags)
 	if len(s) > 500 {
 		t.Fatalf("len=%d", len(s))
+	}
+	if !json.Valid([]byte(s)) {
+		t.Fatalf("invalid json %s", s)
 	}
 }

--- a/backend/internal/task/service/notify.go
+++ b/backend/internal/task/service/notify.go
@@ -47,16 +47,26 @@ func (s *taskService) notifyUsers(ctx context.Context, userIDs []uuid.UUID, temp
 	if s.notify == nil || len(userIDs) == 0 || t == nil {
 		return
 	}
-	vars := map[string]interface{}{
-		"title":     t.Title,
-		"real_name": "",
-		"message":   extra,
-		"due_date":  "",
-	}
+	due := ""
 	if t.DueDate != nil {
-		vars["due_date"] = t.DueDate.Format("2006-01-02 15:04")
+		due = t.DueDate.Format("2006-01-02 15:04")
 	}
-	if err := s.notify.Send(ctx, userIDs, template, vars); err != nil {
-		logger.Warn("send task notify failed", zap.Error(err), zap.String("tpl", template))
+	for _, uid := range userIDs {
+		name := ""
+		if u, err := s.tasks.GetUser(ctx, uid); err == nil && u != nil {
+			name = u.RealName
+			if name == "" {
+				name = u.Username
+			}
+		}
+		vars := map[string]interface{}{
+			"title":     t.Title,
+			"real_name": name,
+			"message":   extra,
+			"due_date":  due,
+		}
+		if err := s.notify.Send(ctx, []uuid.UUID{uid}, template, vars); err != nil {
+			logger.Warn("send task notify failed", zap.Error(err), zap.String("tpl", template))
+		}
 	}
 }

--- a/backend/internal/task/service/service.go
+++ b/backend/internal/task/service/service.go
@@ -29,7 +29,7 @@ type ObjectDownloader interface {
 type TaskService interface {
 	Create(ctx context.Context, operator uuid.UUID, req *dto.CreateTaskRequest) (*dto.TaskResponse, error)
 	List(ctx context.Context, viewer uuid.UUID, req *dto.ListTaskRequest, scope *rbacModel.DataScopeCondition) ([]*dto.TaskResponse, int64, error)
-	Get(ctx context.Context, id uuid.UUID) (*dto.TaskResponse, error)
+	Get(ctx context.Context, viewer, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.TaskResponse, error)
 	Update(ctx context.Context, id, operator uuid.UUID, req *dto.UpdateTaskRequest) (*dto.TaskResponse, error)
 	Delete(ctx context.Context, id, operator uuid.UUID) error
 
@@ -37,20 +37,20 @@ type TaskService interface {
 	Transfer(ctx context.Context, id, operator uuid.UUID, req *dto.TransferRequest) (*dto.TaskResponse, error)
 	ChangeStatus(ctx context.Context, id, operator uuid.UUID, req *dto.StatusRequest) (*dto.TaskResponse, error)
 	Urge(ctx context.Context, id, operator uuid.UUID, message string) error
-	ListLogs(ctx context.Context, id uuid.UUID) ([]dto.LogResponse, error)
+	ListLogs(ctx context.Context, viewer, id uuid.UUID, scope *rbacModel.DataScopeCondition) ([]dto.LogResponse, error)
 
-	ListComments(ctx context.Context, taskID uuid.UUID) ([]dto.CommentResponse, error)
+	ListComments(ctx context.Context, viewer, taskID uuid.UUID, scope *rbacModel.DataScopeCondition) ([]dto.CommentResponse, error)
 	AddComment(ctx context.Context, taskID, operator uuid.UUID, req *dto.CommentRequest) (*dto.CommentResponse, error)
 	UpdateComment(ctx context.Context, taskID, commentID, operator uuid.UUID, content string) (*dto.CommentResponse, error)
 	DeleteComment(ctx context.Context, taskID, commentID, operator uuid.UUID) error
 
 	UploadAttachment(ctx context.Context, taskID, operator uuid.UUID, header *multipart.FileHeader) (*dto.AttachmentResponse, error)
-	ListAttachments(ctx context.Context, taskID uuid.UUID) ([]dto.AttachmentResponse, error)
-	DownloadAttachment(ctx context.Context, taskID, attachID uuid.UUID) (io.ReadCloser, string, string, error)
+	ListAttachments(ctx context.Context, viewer, taskID uuid.UUID, scope *rbacModel.DataScopeCondition) ([]dto.AttachmentResponse, error)
+	DownloadAttachment(ctx context.Context, viewer, taskID, attachID uuid.UUID, scope *rbacModel.DataScopeCondition) (io.ReadCloser, string, string, error)
 	DeleteAttachment(ctx context.Context, taskID, attachID, operator uuid.UUID) error
 
 	ListMy(ctx context.Context, userID uuid.UUID, kind string, req *dto.MyTaskRequest) ([]*dto.TaskResponse, int64, error)
-	Stats(ctx context.Context, req *dto.StatsRequest) (*dto.StatsResponse, error)
+	Stats(ctx context.Context, viewer uuid.UUID, req *dto.StatsRequest, scope *rbacModel.DataScopeCondition) (*dto.StatsResponse, error)
 	RemindDueAndOverdue(ctx context.Context) (int, error)
 }
 

--- a/backend/internal/task/service/task.go
+++ b/backend/internal/task/service/task.go
@@ -59,7 +59,7 @@ func (s *taskService) Create(ctx context.Context, operator uuid.UUID, req *dto.C
 		s.notifyUsers(ctx, []uuid.UUID{*t.AssigneeID}, tplTaskAssigned, t, "")
 		s.addLog(ctx, t.ID, operator, model.ActionAssign, "", t.AssigneeID.String(), "")
 	}
-	return s.Get(ctx, t.ID)
+	return s.Get(ctx, operator, t.ID, nil)
 }
 
 func (s *taskService) List(ctx context.Context, viewer uuid.UUID, req *dto.ListTaskRequest, scope *rbacModel.DataScopeCondition) ([]*dto.TaskResponse, int64, error) {
@@ -74,7 +74,10 @@ func (s *taskService) List(ctx context.Context, viewer uuid.UUID, req *dto.ListT
 	return out, total, nil
 }
 
-func (s *taskService) Get(ctx context.Context, id uuid.UUID) (*dto.TaskResponse, error) {
+func (s *taskService) Get(ctx context.Context, viewer, id uuid.UUID, scope *rbacModel.DataScopeCondition) (*dto.TaskResponse, error) {
+	if _, err := s.mustVisible(ctx, id, viewer, scope); err != nil {
+		return nil, err
+	}
 	row, err := s.tasks.GetByIDWithNames(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("get task: %w", err)
@@ -121,7 +124,7 @@ func (s *taskService) Update(ctx context.Context, id, operator uuid.UUID, req *d
 	if err := s.tasks.Update(ctx, t); err != nil {
 		return nil, fmt.Errorf("update task: %w", err)
 	}
-	return s.Get(ctx, id)
+	return s.Get(ctx, operator, id, nil)
 }
 
 func (s *taskService) Delete(ctx context.Context, id, operator uuid.UUID) error {
@@ -152,6 +155,17 @@ func (s *taskService) mustTask(ctx context.Context, id uuid.UUID) (*model.Task, 
 	return t, nil
 }
 
+func (s *taskService) mustVisible(ctx context.Context, id, viewer uuid.UUID, scope *rbacModel.DataScopeCondition) (*model.Task, error) {
+	t, err := s.mustTask(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canViewTask(t, viewer, scope) {
+		return nil, response.NewError(response.CodeTaskNoAccess, "无权查看该任务")
+	}
+	return t, nil
+}
+
 func (s *taskService) ensureMutable(t *model.Task, operator uuid.UUID) error {
 	if model.IsClosed(t.Status) {
 		return response.NewError(response.CodeTaskClosed, "任务已关闭，无法操作")
@@ -163,15 +177,54 @@ func (s *taskService) ensureMutable(t *model.Task, operator uuid.UUID) error {
 }
 
 func rewriteTaskScope(scope *rbacModel.DataScopeCondition, userID uuid.UUID) *rbacModel.DataScopeCondition {
+	return rewriteTaskScopeAlias(scope, userID, "t")
+}
+
+func rewriteTaskScopeAlias(scope *rbacModel.DataScopeCondition, userID uuid.UUID, alias string) *rbacModel.DataScopeCondition {
 	if scope == nil || scope.IsEmpty() {
 		return scope
 	}
+	prefix := ""
+	if alias != "" {
+		prefix = alias + "."
+	}
 	if scope.Query == "1 = 0" {
 		return &rbacModel.DataScopeCondition{
-			Query: "t.creator_id = ? OR t.assignee_id = ?",
+			Query: prefix + "creator_id = ? OR " + prefix + "assignee_id = ?",
 			Args:  []interface{}{userID, userID},
 		}
 	}
-	q := strings.ReplaceAll(scope.Query, "department_id", "t.department_id")
+	q := strings.ReplaceAll(scope.Query, "department_id", prefix+"department_id")
 	return &rbacModel.DataScopeCondition{Query: q, Args: scope.Args}
+}
+
+func canViewTask(t *model.Task, viewer uuid.UUID, scope *rbacModel.DataScopeCondition) bool {
+	rewritten := rewriteTaskScopeAlias(scope, viewer, "")
+	if rewritten == nil || rewritten.IsEmpty() {
+		return true
+	}
+	if strings.Contains(rewritten.Query, "creator_id = ? OR") {
+		if t.CreatorID == viewer {
+			return true
+		}
+		return t.AssigneeID != nil && *t.AssigneeID == viewer
+	}
+	if t.DepartmentID == nil {
+		return false
+	}
+	for _, arg := range rewritten.Args {
+		switch v := arg.(type) {
+		case uuid.UUID:
+			if v == *t.DepartmentID {
+				return true
+			}
+		case []uuid.UUID:
+			for _, id := range v {
+				if id == *t.DepartmentID {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/backend/internal/task/service/task_test.go
+++ b/backend/internal/task/service/task_test.go
@@ -87,7 +87,7 @@ func TestStateMachineAndTransfer(t *testing.T) {
 	if _, err := svc.Transfer(ctx, id, creator, &dto.TransferRequest{NewAssigneeID: a2.String(), Reason: "忙不过来"}); err != nil {
 		t.Fatal(err)
 	}
-	got, _ := svc.Get(ctx, id)
+	got, _ := svc.Get(ctx, creator, id, nil)
 	if got.Assignee == nil || got.Assignee.ID != a2.String() {
 		t.Fatalf("transfer %+v", got.Assignee)
 	}
@@ -120,7 +120,7 @@ func TestCommentMentionAndMyLists(t *testing.T) {
 	if len(cmt.Mentions) != 1 || cmt.Mentions[0] != assignee.String() {
 		t.Fatalf("mentions %+v", cmt.Mentions)
 	}
-	list, err := svc.ListComments(ctx, id)
+	list, err := svc.ListComments(ctx, creator, id, nil)
 	if err != nil || len(list) != 1 {
 		t.Fatalf("list comments %v %d", err, len(list))
 	}
@@ -141,7 +141,7 @@ func TestCommentMentionAndMyLists(t *testing.T) {
 	if err != nil || n != 1 || over[0].Title != "late" {
 		t.Fatalf("overdue %v %d %+v", err, n, over)
 	}
-	stats, err := svc.Stats(ctx, &dto.StatsRequest{})
+	stats, err := svc.Stats(ctx, creator, &dto.StatsRequest{}, nil)
 	if err != nil || stats.Total < 2 || stats.Overdue < 1 {
 		t.Fatalf("stats %+v %v", stats, err)
 	}
@@ -162,7 +162,7 @@ func TestRemindDueAndOverdue(t *testing.T) {
 	if err != nil || n != 2 {
 		t.Fatalf("remind n=%d err=%v", n, err)
 	}
-	if notify.calls != 2 {
+	if notify.calls != 4 {
 		t.Fatalf("notify=%d", notify.calls)
 	}
 	n, err = svc.RemindDueAndOverdue(ctx)
@@ -174,7 +174,7 @@ func TestRemindDueAndOverdue(t *testing.T) {
 func TestNoAccessAndNotFound(t *testing.T) {
 	svc, _, _, _ := newTestSvc()
 	ctx := context.Background()
-	if _, err := svc.Get(ctx, uuid.New()); err == nil {
+	if _, err := svc.Get(ctx, uuid.New(), uuid.New(), nil); err == nil {
 		t.Fatal("expected not found")
 	}
 	creator := uuid.New()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

单独修复已合入 PR #116（#9 任务流转）的 Bugbot 四项问题，**不改 #116 原 PR，不与 #117 实习管理混单**。

1. **High：详情/评论/日志/附件/下载未走数据范围**  
   `Get`、`ListComments`、`ListLogs`、`ListAttachments`、`DownloadAttachment` 统一先 `mustVisible`：`self` 仅创建人/负责人可见，`department` 仅本部门任务可见，`all`/空 scope 放行。
2. **Medium：`/tasks/stats` 忽略数据范围**  
   handler 传入 `dataScope`，repo `Stats` 走 `applyScope`。
3. **Medium：分配通知 `real_name` 为空**  
   `notifyUsers` 按用户查档案，逐人发送并填 `real_name`（空则用 username）。
4. **Low：`encodeTags` 按 500 字节硬截 JSON**  
   超长时丢弃末尾标签，保证落库仍是合法 JSON。

写操作后的内部 `Get` 传 `scope=nil`（操作者已通过 `ensureMutable`）。

## 关联 Issue

Related to #9（已合入，本 PR 不 Closes）。

## 测试方式

1. `cd backend && go test ./internal/task/service -cover`（当前 77.6%）
2. 用 `self` 数据范围账号访问他人任务详情/评论/附件，应返回 9003
3. 分配任务后检查站内通知文案是否带真实姓名，不再出现「，你被分配了任务」
4. 创建超多标签任务，确认 `tags` 列为合法 JSON

## 截图 / GIF

后端权限修复，无前端页面变更。

## 注意事项

- 部署无需新迁移。
- 不影响 #117 实习管理分支。
- 部长/干事的写操作仍走原 `ensureMutable`（创建人或负责人），本 PR 只补读路径数据范围。

## 检查清单

- [x] 代码遵循项目开发规范
- [x] 已进行自测（单测覆盖范围拒绝、通知姓名、tags JSON）
- [x] CI 检查通过（HEAD `c914bc5` 4/4 全绿）
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

