### PR TITLE
fix(internship): 日历日入库并允许改开始日期与类型

### DIFF
--- a/backend/internal/internship/dto/internship.go
+++ b/backend/internal/internship/dto/internship.go
@@ -25,7 +25,10 @@ type UpdateInternshipRequest struct {
 	Title        *string    `json:"title"`
 	Organization *string    `json:"organization"`
 	Description  *string    `json:"description"`
+	StartDate    *time.Time `json:"start_date"`
 	EndDate      *time.Time `json:"end_date"`
+	ClearEndDate bool       `json:"clear_end_date"`
+	Type         *int16     `json:"type" binding:"omitempty,oneof=0 1 2"`
 	Skills       []string   `json:"skills"`
 	Achievements *string    `json:"achievements"`
 	MentorID     *string    `json:"mentor_id"`

--- a/backend/internal/internship/service/crud.go
+++ b/backend/internal/internship/service/crud.go
@@ -45,6 +45,12 @@ func (s *internshipService) Create(ctx context.Context, operator uuid.UUID, req 
 		return nil, err
 	}
 	now := time.Now()
+	start := dateOnly(req.StartDate)
+	var end *time.Time
+	if req.EndDate != nil {
+		d := dateOnly(*req.EndDate)
+		end = &d
+	}
 	row := &model.Internship{
 		ID:           uuid.New(),
 		UserID:       ownerID,
@@ -52,8 +58,8 @@ func (s *internshipService) Create(ctx context.Context, operator uuid.UUID, req 
 		Title:        strings.TrimSpace(req.Title),
 		Organization: strings.TrimSpace(req.Organization),
 		Description:  req.Description,
-		StartDate:    req.StartDate,
-		EndDate:      req.EndDate,
+		StartDate:    start,
+		EndDate:      end,
 		Status:       model.StatusOngoing,
 		Type:         req.Type,
 		MentorID:     mentorID,
@@ -210,8 +216,17 @@ func applyUpdate(row *model.Internship, req *dto.UpdateInternshipRequest) error 
 	if req.Description != nil {
 		row.Description = *req.Description
 	}
-	if req.EndDate != nil {
-		row.EndDate = req.EndDate
+	if req.StartDate != nil {
+		row.StartDate = dateOnly(*req.StartDate)
+	}
+	if req.Type != nil {
+		row.Type = *req.Type
+	}
+	if req.ClearEndDate {
+		row.EndDate = nil
+	} else if req.EndDate != nil {
+		d := dateOnly(*req.EndDate)
+		row.EndDate = &d
 	}
 	if req.Skills != nil {
 		row.Skills = encodeSkills(req.Skills)

--- a/backend/internal/internship/service/crud_test.go
+++ b/backend/internal/internship/service/crud_test.go
@@ -91,6 +91,32 @@ func TestGetDeniedByScope(t *testing.T) {
 	require.Equal(t, response.CodeInternshipNoAccess, ae.Code)
 }
 
+func TestUpdatePersistsStartTypeAndClearsEnd(t *testing.T) {
+	svc, mem := newTestSvc()
+	ctx := context.Background()
+	owner := uuid.New()
+	mem.users[owner] = &model.NamedUser{ID: owner, RealName: "赵六"}
+	end := time.Date(2026, 9, 20, 0, 0, 0, 0, time.UTC)
+	created, err := svc.Create(ctx, owner, &dto.CreateInternshipRequest{
+		Title: "A", Organization: "B", StartDate: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		EndDate: &end, Type: 0,
+	}, nil)
+	require.NoError(t, err)
+	id := uuid.MustParse(created.ID)
+	require.NotNil(t, created.EndDate)
+
+	start := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
+	typ := int16(2)
+	updated, err := svc.Update(ctx, owner, id, &dto.UpdateInternshipRequest{
+		StartDate: &start, Type: &typ, ClearEndDate: true,
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, typ, updated.Type)
+	require.Nil(t, updated.EndDate)
+	require.Equal(t, 15, updated.StartDate.Day())
+	require.Equal(t, time.August, updated.StartDate.Month())
+}
+
 func TestUpdateClosedDenied(t *testing.T) {
 	svc, mem := newTestSvc()
 	ctx := context.Background()

--- a/frontend/src/pages/internship/FormDrawer.tsx
+++ b/frontend/src/pages/internship/FormDrawer.tsx
@@ -18,11 +18,25 @@ interface FormValues {
   achievements?: string;
 }
 
+interface InternshipFormPayload extends CreateInternshipParams {
+  clear_end_date?: boolean;
+}
+
 interface Props {
   open: boolean;
   editing: Internship | null;
   onClose: () => void;
-  onSubmit: (values: CreateInternshipParams) => Promise<void>;
+  onSubmit: (values: InternshipFormPayload) => Promise<void>;
+}
+
+function toCalendarDate(d: Dayjs): string {
+  return `${d.format('YYYY-MM-DD')}T00:00:00Z`;
+}
+
+function fromCalendarDate(raw?: string): Dayjs | undefined {
+  if (!raw) return undefined;
+  const d = dayjs(raw.slice(0, 10));
+  return d.isValid() ? d : undefined;
 }
 
 const FormDrawer: React.FC<Props> = ({ open, editing, onClose, onSubmit }) => {
@@ -46,8 +60,8 @@ const FormDrawer: React.FC<Props> = ({ open, editing, onClose, onSubmit }) => {
         skills: editing.skills,
         achievements: editing.achievements,
         range: [
-          dayjs(editing.start_date),
-          editing.end_date ? dayjs(editing.end_date) : undefined,
+          fromCalendarDate(editing.start_date),
+          fromCalendarDate(editing.end_date),
         ],
       });
     } else {
@@ -71,8 +85,9 @@ const FormDrawer: React.FC<Props> = ({ open, editing, onClose, onSubmit }) => {
         mentor_id: values.mentor_id,
         skills: values.skills || [],
         achievements: values.achievements,
-        start_date: start.startOf('day').toISOString(),
-        end_date: end ? end.startOf('day').toISOString() : null,
+        start_date: toCalendarDate(start),
+        end_date: end ? toCalendarDate(end) : null,
+        clear_end_date: !end,
       });
     } finally {
       setLoading(false);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -850,7 +850,10 @@ export interface UpdateInternshipParams {
   title?: string;
   organization?: string;
   description?: string;
+  start_date?: string;
   end_date?: string | null;
+  clear_end_date?: boolean;
+  type?: InternshipType;
   skills?: string[];
   achievements?: string;
   mentor_id?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

单独修复已合入 #117 的 Bugbot 两项问题，**不改原 PR**。

1. **High：实习日期时区错一天**  
   表单不再用 `startOf('day').toISOString()`（中国时区 9 月 1 日会变成 8 月 31 日 UTC）。改为按用户选择的日历日发送 `YYYY-MM-DDT00:00:00Z`，回填也按日期前 10 位解析。后端入库前 `dateOnly` 归一化。
2. **Medium：编辑丢失开始日期 / 类型 / 清空结束日**  
   `UpdateInternshipRequest` 补 `start_date`、`type`，并用 `clear_end_date` 区分「省略结束日」和「清空结束日」。

## 关联 Issue

Related to #10（已合入，本 PR 不 Closes）。

## 测试方式

1. `cd backend && go test ./internal/internship/service -cover`（当前 77.9%）
2. 用中国时区选 2026-09-01 登记实习，详情应显示 9 月 1 日，而不是 8 月 31 日
3. 编辑进行中的实习：改开始日期、改类型为校外实习、清空结束日期，保存后应持久化

浏览器已走查：登录 admin → 实习记录 → 登记 2026-09-01 → 详情周期为 2026-09-01 → 编辑改为 2026-08-15 / 校外实习 → 详情已更新。

## 截图 / GIF

| 页面/功能 | 截图 |
|----------|------|
| 登记后详情（2026-09-01，未错成 08-31） | [登记后详情显示 2026-09-01](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Finternship-create-sept1.webp) |
| 编辑后详情（2026-08-15 + 校外实习） | [编辑后详情显示 2026-08-15 与校外实习](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Finternship-edit-aug15.webp) |

## 注意事项

- 无需新迁移。
- 已错一天的旧数据不会自动回改，重新编辑保存即可。

## 检查清单

- [x] 代码遵循项目开发规范
- [x] 已进行自测（单测 + 浏览器走查）
- [x] CI 检查通过（HEAD `b0ba2fd` 4/4 全绿）
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

