### PR TITLE
feat(config): 运行时 configs 表 CRUD 与热更新 (#47)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -15,6 +15,9 @@ import (
 	authHandler "github.com/Yogdunana/StarByte/backend/internal/auth/handler"
 	authRepo "github.com/Yogdunana/StarByte/backend/internal/auth/repo"
 	authService "github.com/Yogdunana/StarByte/backend/internal/auth/service"
+	cfgstoreHandler "github.com/Yogdunana/StarByte/backend/internal/configstore/handler"
+	cfgstoreRepo "github.com/Yogdunana/StarByte/backend/internal/configstore/repo"
+	cfgstoreService "github.com/Yogdunana/StarByte/backend/internal/configstore/service"
 	fileHandler "github.com/Yogdunana/StarByte/backend/internal/file/handler"
 	fileRepo "github.com/Yogdunana/StarByte/backend/internal/file/repo"
 	fileService "github.com/Yogdunana/StarByte/backend/internal/file/service"
@@ -46,6 +49,7 @@ import (
 	"github.com/Yogdunana/StarByte/backend/internal/workflow"
 	wfHandler "github.com/Yogdunana/StarByte/backend/internal/workflow/handler"
 	"github.com/Yogdunana/StarByte/backend/pkg/config"
+	"github.com/Yogdunana/StarByte/backend/pkg/configstore"
 	"github.com/Yogdunana/StarByte/backend/pkg/database"
 	"github.com/Yogdunana/StarByte/backend/pkg/events"
 	"github.com/Yogdunana/StarByte/backend/pkg/logger"
@@ -233,6 +237,12 @@ func main() {
 	mtSvc := meetingService.NewMeetingService(mtMeetingRepo, mtAgendaRepo, mtAttendeeRepo, mtVoteRepo, mtNotifier)
 	mtH := meetingHandler.NewMeetingHandler(mtSvc)
 
+	// 运行时业务配置（#47，复用 configs 表，不改 pkg/config YAML）
+	cfgRows := cfgstoreRepo.NewConfigRepo(database.DB())
+	cfgStore := configstore.New(redis.Client(), &cfgstoreRepo.BackendAdapter{Rows: cfgRows})
+	cfgSvc := cfgstoreService.NewConfigService(cfgRows, cfgStore)
+	cfgH := cfgstoreHandler.NewConfigHandler(cfgSvc)
+
 	// IT 实习管理
 	internRepo := internshipRepo.NewInternshipRepo(database.DB())
 	internSvc := internshipService.NewInternshipService(internRepo)
@@ -322,6 +332,9 @@ func main() {
 
 		// IT 实习管理（/internships, /system/internship-config）
 		internshipHandler.RegisterRoutes(protected, internH, cacheService, database.DB(), deptRepo)
+
+		// 运行时配置（/system/configs）
+		cfgstoreHandler.RegisterRoutes(protected, cfgH, cacheService)
 
 		// 审计日志模块路由（/system/audit-logs，audit:read / audit:export / audit:archive）
 		auditHandler.RegisterRoutes(protected, auditH, cacheService)

--- a/backend/internal/configstore/dto/config.go
+++ b/backend/internal/configstore/dto/config.go
@@ -1,0 +1,37 @@
+package dto
+
+import "time"
+
+type ConfigResponse struct {
+	ID          string    `json:"id"`
+	ConfigKey   string    `json:"config_key"`
+	ConfigValue string    `json:"config_value"`
+	ConfigType  string    `json:"config_type"`
+	Description string    `json:"description"`
+	Category    string    `json:"category"`
+	IsPublic    bool      `json:"is_public"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type CreateConfigRequest struct {
+	ConfigKey   string `json:"config_key" binding:"required,max=100"`
+	ConfigValue string `json:"config_value"`
+	ConfigType  string `json:"config_type" binding:"required,oneof=string number boolean json"`
+	Description string `json:"description" binding:"max=255"`
+	Category    string `json:"category" binding:"required,max=50"`
+	IsPublic    bool   `json:"is_public"`
+}
+
+type UpdateConfigRequest struct {
+	ConfigValue *string `json:"config_value"`
+	ConfigType  *string `json:"config_type" binding:"omitempty,oneof=string number boolean json"`
+	Description *string `json:"description" binding:"omitempty,max=255"`
+	Category    *string `json:"category" binding:"omitempty,max=50"`
+	IsPublic    *bool   `json:"is_public"`
+}
+
+type ListQuery struct {
+	Category string `form:"category"`
+	Keyword  string `form:"keyword"`
+}

--- a/backend/internal/configstore/handler/config_handler.go
+++ b/backend/internal/configstore/handler/config_handler.go
@@ -1,0 +1,109 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type ConfigHandler struct {
+	svc service.ConfigService
+}
+
+func NewConfigHandler(svc service.ConfigService) *ConfigHandler {
+	return &ConfigHandler{svc: svc}
+}
+
+func (h *ConfigHandler) List(c *gin.Context) {
+	var q dto.ListQuery
+	if err := c.ShouldBindQuery(&q); err != nil {
+		response.BadRequest(c, "参数错误")
+		return
+	}
+	list, err := h.svc.List(c.Request.Context(), q)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, list)
+}
+
+func (h *ConfigHandler) GetByKey(c *gin.Context) {
+	out, err := h.svc.GetByKey(c.Request.Context(), c.Param("key"))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+func (h *ConfigHandler) Create(c *gin.Context) {
+	operator, err := currentUser(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	var req dto.CreateConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Create(c.Request.Context(), operator, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+func (h *ConfigHandler) Update(c *gin.Context) {
+	operator, err := currentUser(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		response.BadRequest(c, "无效的配置ID")
+		return
+	}
+	var req dto.UpdateConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	out, err := h.svc.Update(c.Request.Context(), operator, id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, out)
+}
+
+func (h *ConfigHandler) Delete(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		response.BadRequest(c, "无效的配置ID")
+		return
+	}
+	if err := h.svc.Delete(c.Request.Context(), id); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OKWithoutData(c)
+}
+
+func currentUser(c *gin.Context) (uuid.UUID, error) {
+	raw := auth.GetUserID(c)
+	if raw == "" {
+		return uuid.Nil, response.NewUnauthorizedError("用户未认证")
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "无效的用户ID")
+	}
+	return id, nil
+}

--- a/backend/internal/configstore/handler/routes.go
+++ b/backend/internal/configstore/handler/routes.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
+}
+
+// RegisterRoutes 注册 /api/v1/system/configs。/key/:key 必须在 /:id 之前。
+func RegisterRoutes(
+	r *gin.RouterGroup,
+	h *ConfigHandler,
+	cacheService rbacService.PermissionCacheService,
+) {
+	g := r.Group("/system/configs")
+	withPermission(g, "config:read", cacheService).GET("", h.List)
+	withPermission(g, "config:read", cacheService).GET("/key/:key", h.GetByKey)
+	withPermission(g, "config:create", cacheService).POST("", h.Create)
+	withPermission(g, "config:update", cacheService).PUT("/:id", h.Update)
+	withPermission(g, "config:delete", cacheService).DELETE("/:id", h.Delete)
+}

--- a/backend/internal/configstore/model/config.go
+++ b/backend/internal/configstore/model/config.go
@@ -1,0 +1,56 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	TypeString  = "string"
+	TypeNumber  = "number"
+	TypeBoolean = "boolean"
+	TypeJSON    = "json"
+)
+
+// Config 对应已有 configs 表，不改列名。
+type Config struct {
+	ID          uuid.UUID  `gorm:"type:uuid;primaryKey"`
+	ConfigKey   string     `gorm:"column:config_key;type:varchar(100);uniqueIndex"`
+	ConfigValue string     `gorm:"column:config_value;type:text"`
+	ConfigType  string     `gorm:"column:config_type;type:varchar(20)"`
+	Description string     `gorm:"type:varchar(255)"`
+	Category    string     `gorm:"type:varchar(50)"`
+	IsPublic    bool       `gorm:"column:is_public"`
+	UpdatedBy   *uuid.UUID `gorm:"type:uuid"`
+	UpdatedAt   time.Time
+	CreatedAt   time.Time
+}
+
+func (Config) TableName() string { return "configs" }
+
+func ValidType(t string) bool {
+	switch t {
+	case TypeString, TypeNumber, TypeBoolean, TypeJSON:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidCategory(c string) bool {
+	switch c {
+	case "system", "business", "notification", "security", "internship", "meeting":
+		return true
+	default:
+		return false
+	}
+}
+
+// ProtectedKeys 业务模块已占用，禁止删除。
+func ProtectedKeys() map[string]struct{} {
+	return map[string]struct{}{
+		"internship_config":  {},
+		"vote_weight_config": {},
+	}
+}

--- a/backend/internal/configstore/repo/backend.go
+++ b/backend/internal/configstore/repo/backend.go
@@ -1,0 +1,52 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/model"
+	"github.com/google/uuid"
+)
+
+// BackendAdapter 让 pkg/configstore 读写已有 configs 表。
+type BackendAdapter struct {
+	Rows ConfigRepo
+}
+
+func (a *BackendAdapter) Load(ctx context.Context, key string) (string, bool, error) {
+	row, err := a.Rows.GetByKey(ctx, key)
+	if err != nil {
+		return "", false, err
+	}
+	if row == nil {
+		return "", false, nil
+	}
+	return row.ConfigValue, true, nil
+}
+
+func (a *BackendAdapter) Save(ctx context.Context, key, value string) error {
+	row, err := a.Rows.GetByKey(ctx, key)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if row == nil {
+		row = &model.Config{
+			ID:          uuid.New(),
+			ConfigKey:   key,
+			ConfigType:  model.TypeString,
+			Category:    "system",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+			ConfigValue: value,
+		}
+		if err := a.Rows.Create(ctx, row); err != nil {
+			return fmt.Errorf("create config: %w", err)
+		}
+		return nil
+	}
+	row.ConfigValue = value
+	row.UpdatedAt = now
+	return a.Rows.Update(ctx, row)
+}

--- a/backend/internal/configstore/repo/config_repo.go
+++ b/backend/internal/configstore/repo/config_repo.go
@@ -1,0 +1,70 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type ConfigRepo interface {
+	Create(ctx context.Context, row *model.Config) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Config, error)
+	GetByKey(ctx context.Context, key string) (*model.Config, error)
+	List(ctx context.Context, category, keyword string) ([]model.Config, error)
+	Update(ctx context.Context, row *model.Config) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+type configRepo struct {
+	db *gorm.DB
+}
+
+func NewConfigRepo(db *gorm.DB) ConfigRepo {
+	return &configRepo{db: db}
+}
+
+func (r *configRepo) Create(ctx context.Context, row *model.Config) error {
+	return r.db.WithContext(ctx).Create(row).Error
+}
+
+func (r *configRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Config, error) {
+	var row model.Config
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&row).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &row, err
+}
+
+func (r *configRepo) GetByKey(ctx context.Context, key string) (*model.Config, error) {
+	var row model.Config
+	err := r.db.WithContext(ctx).Where("config_key = ?", key).First(&row).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &row, err
+}
+
+func (r *configRepo) List(ctx context.Context, category, keyword string) ([]model.Config, error) {
+	q := r.db.WithContext(ctx).Model(&model.Config{})
+	if category != "" {
+		q = q.Where("category = ?", category)
+	}
+	if keyword != "" {
+		like := "%" + keyword + "%"
+		q = q.Where("config_key ILIKE ? OR description ILIKE ?", like, like)
+	}
+	var rows []model.Config
+	err := q.Order("category ASC, config_key ASC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *configRepo) Update(ctx context.Context, row *model.Config) error {
+	return r.db.WithContext(ctx).Save(row).Error
+}
+
+func (r *configRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.Config{}, id).Error
+}

--- a/backend/internal/configstore/service/config_service.go
+++ b/backend/internal/configstore/service/config_service.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/model"
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/configstore"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+var keyPattern = regexp.MustCompile(`^[a-z][a-z0-9_.]{1,99}$`)
+
+type ConfigService interface {
+	List(ctx context.Context, q dto.ListQuery) ([]dto.ConfigResponse, error)
+	GetByKey(ctx context.Context, key string) (*dto.ConfigResponse, error)
+	Create(ctx context.Context, operator uuid.UUID, req *dto.CreateConfigRequest) (*dto.ConfigResponse, error)
+	Update(ctx context.Context, operator uuid.UUID, id uuid.UUID, req *dto.UpdateConfigRequest) (*dto.ConfigResponse, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+type configService struct {
+	rows  repo.ConfigRepo
+	store configstore.Store
+}
+
+func NewConfigService(rows repo.ConfigRepo, store configstore.Store) ConfigService {
+	return &configService{rows: rows, store: store}
+}
+
+func (s *configService) List(ctx context.Context, q dto.ListQuery) ([]dto.ConfigResponse, error) {
+	rows, err := s.rows.List(ctx, q.Category, q.Keyword)
+	if err != nil {
+		return nil, fmt.Errorf("list configs: %w", err)
+	}
+	out := make([]dto.ConfigResponse, 0, len(rows))
+	for i := range rows {
+		out = append(out, toResp(&rows[i]))
+	}
+	return out, nil
+}
+
+func (s *configService) GetByKey(ctx context.Context, key string) (*dto.ConfigResponse, error) {
+	row, err := s.rows.GetByKey(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("get config: %w", err)
+	}
+	if row == nil {
+		return nil, response.NewError(response.CodeConfigNotFound, "配置不存在")
+	}
+	return ptrResp(row), nil
+}
+
+func (s *configService) Create(ctx context.Context, operator uuid.UUID, req *dto.CreateConfigRequest) (*dto.ConfigResponse, error) {
+	key := strings.TrimSpace(req.ConfigKey)
+	if !keyPattern.MatchString(key) {
+		return nil, response.NewError(response.CodeConfigInvalidKey, "配置键须为小写字母开头，仅含字母数字._")
+	}
+	if !model.ValidType(req.ConfigType) {
+		return nil, response.NewError(response.CodeConfigInvalidType, "不支持的配置类型")
+	}
+	if !model.ValidCategory(req.Category) {
+		return nil, response.NewError(response.CodeConfigInvalidType, "不支持的配置分组")
+	}
+	if err := validateValue(req.ConfigType, req.ConfigValue); err != nil {
+		return nil, err
+	}
+	exist, err := s.rows.GetByKey(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("check key: %w", err)
+	}
+	if exist != nil {
+		return nil, response.NewError(response.CodeConfigKeyExists, "配置键已存在")
+	}
+	now := time.Now()
+	row := &model.Config{
+		ID:          uuid.New(),
+		ConfigKey:   key,
+		ConfigValue: req.ConfigValue,
+		ConfigType:  req.ConfigType,
+		Description: req.Description,
+		Category:    req.Category,
+		IsPublic:    req.IsPublic,
+		UpdatedBy:   &operator,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.rows.Create(ctx, row); err != nil {
+		return nil, fmt.Errorf("create config: %w", err)
+	}
+	_ = s.store.Invalidate(ctx, key)
+	return ptrResp(row), nil
+}
+
+func (s *configService) Update(ctx context.Context, operator uuid.UUID, id uuid.UUID, req *dto.UpdateConfigRequest) (*dto.ConfigResponse, error) {
+	row, err := s.rows.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get config: %w", err)
+	}
+	if row == nil {
+		return nil, response.NewError(response.CodeConfigNotFound, "配置不存在")
+	}
+	if req.ConfigType != nil {
+		if !model.ValidType(*req.ConfigType) {
+			return nil, response.NewError(response.CodeConfigInvalidType, "不支持的配置类型")
+		}
+		row.ConfigType = *req.ConfigType
+	}
+	if req.Category != nil {
+		if !model.ValidCategory(*req.Category) {
+			return nil, response.NewError(response.CodeConfigInvalidType, "不支持的配置分组")
+		}
+		row.Category = *req.Category
+	}
+	if req.ConfigValue != nil {
+		row.ConfigValue = *req.ConfigValue
+	}
+	if req.Description != nil {
+		row.Description = *req.Description
+	}
+	if req.IsPublic != nil {
+		row.IsPublic = *req.IsPublic
+	}
+	if err := validateValue(row.ConfigType, row.ConfigValue); err != nil {
+		return nil, err
+	}
+	row.UpdatedBy = &operator
+	row.UpdatedAt = time.Now()
+	if err := s.rows.Update(ctx, row); err != nil {
+		return nil, fmt.Errorf("update config: %w", err)
+	}
+	_ = s.store.Invalidate(ctx, row.ConfigKey)
+	return ptrResp(row), nil
+}
+
+func (s *configService) Delete(ctx context.Context, id uuid.UUID) error {
+	row, err := s.rows.GetByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get config: %w", err)
+	}
+	if row == nil {
+		return response.NewError(response.CodeConfigNotFound, "配置不存在")
+	}
+	if _, ok := model.ProtectedKeys()[row.ConfigKey]; ok {
+		return response.NewError(response.CodeConfigProtected, "该配置由业务模块占用，不能删除")
+	}
+	if err := s.rows.Delete(ctx, id); err != nil {
+		return fmt.Errorf("delete config: %w", err)
+	}
+	_ = s.store.Invalidate(ctx, row.ConfigKey)
+	return nil
+}
+
+func validateValue(typ, raw string) error {
+	switch typ {
+	case model.TypeNumber:
+		if _, err := strconv.ParseFloat(strings.TrimSpace(raw), 64); err != nil {
+			return response.NewError(response.CodeConfigInvalidValue, "数值类型格式不正确")
+		}
+	case model.TypeBoolean:
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case "true", "false", "1", "0":
+		default:
+			return response.NewError(response.CodeConfigInvalidValue, "布尔值须为 true/false")
+		}
+	case model.TypeJSON:
+		if raw == "" {
+			return response.NewError(response.CodeConfigInvalidValue, "JSON 不能为空")
+		}
+		if !json.Valid([]byte(raw)) {
+			return response.NewError(response.CodeConfigInvalidValue, "JSON 格式不正确")
+		}
+	}
+	return nil
+}
+
+func toResp(row *model.Config) dto.ConfigResponse {
+	return dto.ConfigResponse{
+		ID:          row.ID.String(),
+		ConfigKey:   row.ConfigKey,
+		ConfigValue: row.ConfigValue,
+		ConfigType:  row.ConfigType,
+		Description: row.Description,
+		Category:    row.Category,
+		IsPublic:    row.IsPublic,
+		UpdatedAt:   row.UpdatedAt,
+		CreatedAt:   row.CreatedAt,
+	}
+}
+
+func ptrResp(row *model.Config) *dto.ConfigResponse {
+	r := toResp(row)
+	return &r
+}

--- a/backend/internal/configstore/service/config_service_test.go
+++ b/backend/internal/configstore/service/config_service_test.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/configstore"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSvc() ConfigService {
+	return NewConfigService(newMemRepo(), configstore.New(nil, configstore.NewMemoryBackend()))
+}
+
+func TestConfigService_CRUD(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestSvc()
+	op := uuid.New()
+
+	created, err := svc.Create(ctx, op, &dto.CreateConfigRequest{
+		ConfigKey:   "site.name",
+		ConfigValue: "计协",
+		ConfigType:  model.TypeString,
+		Category:    "system",
+		Description: "协会名称",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "site.name", created.ConfigKey)
+
+	got, err := svc.GetByKey(ctx, "site.name")
+	require.NoError(t, err)
+	assert.Equal(t, "计协", got.ConfigValue)
+
+	list, err := svc.List(ctx, dto.ListQuery{Category: "system"})
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	val := "计算机协会"
+	updated, err := svc.Update(ctx, op, uuid.MustParse(created.ID), &dto.UpdateConfigRequest{ConfigValue: &val})
+	require.NoError(t, err)
+	assert.Equal(t, "计算机协会", updated.ConfigValue)
+
+	require.NoError(t, svc.Delete(ctx, uuid.MustParse(created.ID)))
+	_, err = svc.GetByKey(ctx, "site.name")
+	assert.Error(t, err)
+}
+
+func TestConfigService_RejectBadKeyAndProtectedDelete(t *testing.T) {
+	ctx := context.Background()
+	rows := newMemRepo()
+	svc := NewConfigService(rows, configstore.New(nil, configstore.NewMemoryBackend()))
+	op := uuid.New()
+
+	_, err := svc.Create(ctx, op, &dto.CreateConfigRequest{
+		ConfigKey: "Bad Key", ConfigValue: "x", ConfigType: model.TypeString, Category: "system",
+	})
+	assert.Error(t, err)
+
+	_, err = svc.Create(ctx, op, &dto.CreateConfigRequest{
+		ConfigKey: "dup.key", ConfigValue: "1", ConfigType: model.TypeNumber, Category: "business",
+	})
+	require.NoError(t, err)
+	_, err = svc.Create(ctx, op, &dto.CreateConfigRequest{
+		ConfigKey: "dup.key", ConfigValue: "2", ConfigType: model.TypeNumber, Category: "business",
+	})
+	assert.Error(t, err)
+
+	id := uuid.New()
+	require.NoError(t, rows.Create(ctx, &model.Config{
+		ID: id, ConfigKey: "internship_config", ConfigType: model.TypeJSON,
+		ConfigValue: `{"a":1}`, Category: "internship",
+	}))
+	err = svc.Delete(ctx, id)
+	assert.Error(t, err)
+}
+
+func TestValidateValue(t *testing.T) {
+	assert.NoError(t, validateValue(model.TypeNumber, "3.14"))
+	assert.Error(t, validateValue(model.TypeNumber, "x"))
+	assert.NoError(t, validateValue(model.TypeBoolean, "true"))
+	assert.Error(t, validateValue(model.TypeBoolean, "yes"))
+	assert.NoError(t, validateValue(model.TypeJSON, `{"a":1}`))
+	assert.Error(t, validateValue(model.TypeJSON, "{"))
+}

--- a/backend/internal/configstore/service/mem_test.go
+++ b/backend/internal/configstore/service/mem_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Yogdunana/StarByte/backend/internal/configstore/model"
+	"github.com/google/uuid"
+)
+
+type memRepo struct {
+	mu   sync.Mutex
+	rows map[uuid.UUID]*model.Config
+}
+
+func newMemRepo() *memRepo {
+	return &memRepo{rows: map[uuid.UUID]*model.Config{}}
+}
+
+func (m *memRepo) Create(_ context.Context, row *model.Config) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *row
+	m.rows[row.ID] = &cp
+	return nil
+}
+
+func (m *memRepo) GetByID(_ context.Context, id uuid.UUID) (*model.Config, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	row := m.rows[id]
+	if row == nil {
+		return nil, nil
+	}
+	cp := *row
+	return &cp, nil
+}
+
+func (m *memRepo) GetByKey(_ context.Context, key string) (*model.Config, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, row := range m.rows {
+		if row.ConfigKey == key {
+			cp := *row
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *memRepo) List(_ context.Context, category, keyword string) ([]model.Config, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]model.Config, 0, len(m.rows))
+	for _, row := range m.rows {
+		if category != "" && row.Category != category {
+			continue
+		}
+		if keyword != "" && row.ConfigKey != keyword && row.Description != keyword {
+			continue
+		}
+		out = append(out, *row)
+	}
+	return out, nil
+}
+
+func (m *memRepo) Update(_ context.Context, row *model.Config) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *row
+	m.rows[row.ID] = &cp
+	return nil
+}
+
+func (m *memRepo) Delete(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.rows, id)
+	return nil
+}

--- a/backend/pkg/configstore/errors.go
+++ b/backend/pkg/configstore/errors.go
@@ -1,0 +1,6 @@
+package configstore
+
+import "errors"
+
+// ErrNotFound 配置键不存在。
+var ErrNotFound = errors.New("configstore: key not found")

--- a/backend/pkg/configstore/memory.go
+++ b/backend/pkg/configstore/memory.go
@@ -1,0 +1,30 @@
+package configstore
+
+import (
+	"context"
+	"sync"
+)
+
+// MemoryBackend 进程内 Backend，供单测使用。
+type MemoryBackend struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+func NewMemoryBackend() *MemoryBackend {
+	return &MemoryBackend{data: map[string]string{}}
+}
+
+func (m *MemoryBackend) Load(_ context.Context, key string) (string, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.data[key]
+	return v, ok, nil
+}
+
+func (m *MemoryBackend) Save(_ context.Context, key, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = value
+	return nil
+}

--- a/backend/pkg/configstore/store.go
+++ b/backend/pkg/configstore/store.go
@@ -1,0 +1,117 @@
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	cachePrefix = "configstore:"
+	cacheTTL    = 10 * time.Minute
+)
+
+// Backend 从持久层读写配置值。实现放在业务模块，避免本包依赖 GORM。
+type Backend interface {
+	Load(ctx context.Context, key string) (value string, ok bool, err error)
+	Save(ctx context.Context, key, value string) error
+}
+
+// Store 运行时业务配置 SDK。不要与 pkg/config 的 YAML loader 混淆。
+type Store interface {
+	Get(ctx context.Context, key string) (string, error)
+	GetBool(ctx context.Context, key string) (bool, error)
+	Set(ctx context.Context, key, value string) error
+	Invalidate(ctx context.Context, key string) error
+}
+
+type redisStore struct {
+	rdb     *redis.Client
+	backend Backend
+}
+
+// New 用 Redis 缓存包装 Backend。rdb 可为 nil（仅走 Backend，便于单测）。
+func New(rdb *redis.Client, backend Backend) Store {
+	return &redisStore{rdb: rdb, backend: backend}
+}
+
+func cacheKey(key string) string {
+	return cachePrefix + key
+}
+
+func (s *redisStore) Get(ctx context.Context, key string) (string, error) {
+	if key == "" {
+		return "", fmt.Errorf("configstore: empty key")
+	}
+	if s.rdb != nil {
+		cached, err := s.rdb.Get(ctx, cacheKey(key)).Result()
+		if err == nil {
+			return cached, nil
+		}
+		if err != redis.Nil {
+			return "", fmt.Errorf("configstore cache get: %w", err)
+		}
+	}
+	value, ok, err := s.backend.Load(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", ErrNotFound
+	}
+	if s.rdb != nil {
+		_ = s.rdb.Set(ctx, cacheKey(key), value, cacheTTL).Err()
+	}
+	return value, nil
+}
+
+func (s *redisStore) GetBool(ctx context.Context, key string) (bool, error) {
+	raw, err := s.Get(ctx, key)
+	if err != nil {
+		return false, err
+	}
+	v, err := parseBool(raw)
+	if err != nil {
+		return false, err
+	}
+	return v, nil
+}
+
+func (s *redisStore) Set(ctx context.Context, key, value string) error {
+	if key == "" {
+		return fmt.Errorf("configstore: empty key")
+	}
+	if err := s.backend.Save(ctx, key, value); err != nil {
+		return err
+	}
+	return s.Invalidate(ctx, key)
+}
+
+func (s *redisStore) Invalidate(ctx context.Context, key string) error {
+	if s.rdb == nil || key == "" {
+		return nil
+	}
+	if err := s.rdb.Del(ctx, cacheKey(key)).Err(); err != nil {
+		return fmt.Errorf("configstore invalidate: %w", err)
+	}
+	return nil
+}
+
+func parseBool(raw string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off", "":
+		return false, nil
+	default:
+		v, err := strconv.ParseBool(raw)
+		if err != nil {
+			return false, fmt.Errorf("configstore: not a boolean: %q", raw)
+		}
+		return v, nil
+	}
+}

--- a/backend/pkg/configstore/store_test.go
+++ b/backend/pkg/configstore/store_test.go
@@ -1,0 +1,51 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_GetSetGetBool(t *testing.T) {
+	ctx := context.Background()
+	store := New(nil, NewMemoryBackend())
+
+	_, err := store.Get(ctx, "missing")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	require.NoError(t, store.Set(ctx, "site.name", "计协"))
+	got, err := store.Get(ctx, "site.name")
+	require.NoError(t, err)
+	assert.Equal(t, "计协", got)
+
+	require.NoError(t, store.Set(ctx, "flag", "true"))
+	ok, err := store.GetBool(ctx, "flag")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	require.NoError(t, store.Set(ctx, "flag", "0"))
+	ok, err = store.GetBool(ctx, "flag")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestStore_EmptyKey(t *testing.T) {
+	ctx := context.Background()
+	store := New(nil, NewMemoryBackend())
+	_, err := store.Get(ctx, "")
+	assert.Error(t, err)
+	assert.Error(t, store.Set(ctx, "", "x"))
+}
+
+func TestParseBool(t *testing.T) {
+	ok, err := parseBool("yes")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	ok, err = parseBool("off")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	_, err = parseBool("maybe")
+	assert.Error(t, err)
+}

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -18,6 +18,7 @@ package response
 //	11000-11999 Statistics module
 //	12000-12999 Notification module
 //	13000-13999 File module (reserved; #18 type/size checks use 1001)
+//	14000-14999 Runtime configstore (#47)
 
 const (
 	// ===== Success =====
@@ -139,6 +140,14 @@ const (
 	CodeNotificationEmailFail   = 12006 // 邮件发送失败
 	CodeNotificationBadChannel  = 12007 // 不支持的通知渠道
 	CodeNotificationNoAccess    = 12008 // 无权操作该通知
+
+	// ===== Runtime configstore (#47, 14000-14999) =====
+	CodeConfigNotFound     = 14001 // 配置不存在
+	CodeConfigKeyExists    = 14002 // 配置键已存在
+	CodeConfigInvalidType  = 14003 // 不支持的类型或分组
+	CodeConfigInvalidValue = 14004 // 配置值与类型不匹配
+	CodeConfigProtected    = 14005 // 业务占用配置不可删除
+	CodeConfigInvalidKey   = 14006 // 配置键格式不合法
 )
 
 // ModuleRanges maps each module name to its error-code range [min, max].
@@ -157,4 +166,5 @@ var ModuleRanges = map[string][2]int{
 	"statistics":   {11000, 11999},
 	"notification": {12000, 12999},
 	"file":         {13000, 13999},
+	"configstore":  {14000, 14999},
 }

--- a/backend/scripts/seed.go
+++ b/backend/scripts/seed.go
@@ -70,6 +70,9 @@ func SeedAll(db *gorm.DB) error {
 		if err := seedInternships(tx); err != nil {
 			return fmt.Errorf("seed internships: %w", err)
 		}
+		if err := seedRuntimeConfigs(tx); err != nil {
+			return fmt.Errorf("seed runtime configs: %w", err)
+		}
 		return nil
 	})
 }

--- a/backend/scripts/seed_configs.go
+++ b/backend/scripts/seed_configs.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+type seedConfig struct {
+	Key         string
+	Value       string
+	Type        string
+	Category    string
+	Description string
+}
+
+var seedConfigsData = []seedConfig{
+	{Key: "site.name", Value: "深圳北理莫斯科大学计算机协会", Type: "string", Category: "system", Description: "协会显示名称"},
+	{Key: "site.allow_register", Value: "true", Type: "boolean", Category: "security", Description: "是否开放注册"},
+	{Key: "notification.email_enabled", Value: "false", Type: "boolean", Category: "notification", Description: "是否启用邮件通知"},
+}
+
+func seedRuntimeConfigs(db *gorm.DB) error {
+	for _, c := range seedConfigsData {
+		if err := db.Exec(`
+			INSERT INTO configs (id, config_key, config_value, config_type, description, category, is_public)
+			VALUES (uuid_generate_v4(), ?, ?, ?, ?, ?, false)
+			ON CONFLICT (config_key) DO NOTHING`,
+			c.Key, c.Value, c.Type, c.Description, c.Category,
+		).Error; err != nil {
+			return fmt.Errorf("seed config %s: %w", c.Key, err)
+		}
+	}
+	return nil
+}

--- a/backend/scripts/seed_rbac.go
+++ b/backend/scripts/seed_rbac.go
@@ -145,15 +145,25 @@ func seedRolePermissions(db *gorm.DB) error {
 		return fmt.Errorf("assign all perms to president: %w", err)
 	}
 
-	// 副社长：除系统配置外的全部权限
+	// 副社长：可读运行时配置，但不能改/删（与 system:config 对齐，避免绕过实习/投票开关）
 	if err := db.Exec(`
 		INSERT INTO role_permissions (id, role_id, permission_id, data_scope)
 		SELECT uuid_generate_v4(), r.id, p.id, 'all'
 		FROM roles r CROSS JOIN permissions p
-		WHERE r.code = 'vice_president' AND p.code <> 'system:config'
+		WHERE r.code = 'vice_president'
+		  AND p.code NOT IN ('system:config', 'config:create', 'config:update', 'config:delete')
 		ON CONFLICT (role_id, permission_id) DO NOTHING
 	`).Error; err != nil {
 		return fmt.Errorf("assign vice_president perms: %w", err)
+	}
+	if err := db.Exec(`
+		DELETE FROM role_permissions rp
+		USING roles r, permissions p
+		WHERE rp.role_id = r.id AND rp.permission_id = p.id
+		  AND r.code = 'vice_president'
+		  AND p.code IN ('config:create', 'config:update', 'config:delete')
+	`).Error; err != nil {
+		return fmt.Errorf("revoke vice_president config writes: %w", err)
 	}
 
 	// 部长：全部 read + 业务 create/update
@@ -213,6 +223,10 @@ func memberPermCodes() []string {
 		"user:read", "member:read", "meeting:read", "task:read",
 		"file:read", "file:create", "internship:read", "internship:create", "internship:update", "internship:delete",
 	}
+}
+
+func vicePresidentExcludedPerms() []string {
+	return []string{"system:config", "config:create", "config:update", "config:delete"}
 }
 
 func assignPermCodes(db *gorm.DB, roleCode, dataScope string, codes []string) error {

--- a/backend/scripts/seed_rbac.go
+++ b/backend/scripts/seed_rbac.go
@@ -83,6 +83,7 @@ func allSeedPermissions() []seedPerm {
 		seedPerm{Name: "通知模板查看", Code: "notification:template:read", Resource: "notification", Action: "read"},
 		seedPerm{Name: "发送通知", Code: "notification:send", Resource: "notification", Action: "create"},
 	)
+	perms = append(perms, moduleCRUD("config", "运行时配置")...)
 	return perms
 }
 

--- a/backend/scripts/seed_test.go
+++ b/backend/scripts/seed_test.go
@@ -95,6 +95,17 @@ func TestSeedRuntimeConfigs_Keys(t *testing.T) {
 	}
 }
 
+func TestVicePresident_ExcludesConfigWrites(t *testing.T) {
+	excluded := map[string]bool{}
+	for _, c := range vicePresidentExcludedPerms() {
+		excluded[c] = true
+	}
+	for _, need := range []string{"system:config", "config:create", "config:update", "config:delete"} {
+		assert.True(t, excluded[need], "vice_president must not inherit %s", need)
+	}
+	assert.False(t, excluded["config:read"])
+}
+
 func TestOfficerAndMemberPerms_NonEmpty(t *testing.T) {
 	assert.GreaterOrEqual(t, len(officerPermCodes()), 8)
 	assert.GreaterOrEqual(t, len(memberPermCodes()), 5)

--- a/backend/scripts/seed_test.go
+++ b/backend/scripts/seed_test.go
@@ -17,6 +17,10 @@ func TestAllSeedPermissions_Count(t *testing.T) {
 		assert.False(t, dup, "duplicate permission %s", p.Code)
 		seen[p.Code] = struct{}{}
 	}
+	for _, need := range []string{"config:read", "config:create", "config:update", "config:delete"} {
+		_, ok := seen[need]
+		assert.True(t, ok, "missing permission %s", need)
+	}
 }
 
 func TestSeedRoles_IncludesRequired(t *testing.T) {
@@ -78,6 +82,16 @@ func TestSeedRoles_OnlyTopRolesAreSystem(t *testing.T) {
 		default:
 			assert.False(t, r.IsSystem, "%s should not be system", r.Code)
 		}
+	}
+}
+
+func TestSeedRuntimeConfigs_Keys(t *testing.T) {
+	assert.GreaterOrEqual(t, len(seedConfigsData), 3)
+	seen := map[string]bool{}
+	for _, c := range seedConfigsData {
+		assert.NotEmpty(t, c.Key)
+		assert.False(t, seen[c.Key], "duplicate config %s", c.Key)
+		seen[c.Key] = true
 	}
 }
 

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -1,0 +1,29 @@
+import request from './request';
+import type {
+  RuntimeConfig,
+  CreateRuntimeConfigParams,
+  UpdateRuntimeConfigParams,
+} from '@/types/api';
+
+export function getRuntimeConfigs(params?: {
+  category?: string;
+  keyword?: string;
+}): Promise<RuntimeConfig[]> {
+  return request.get('/system/configs', { params });
+}
+
+export function getRuntimeConfigByKey(key: string): Promise<RuntimeConfig> {
+  return request.get(`/system/configs/key/${encodeURIComponent(key)}`);
+}
+
+export function createRuntimeConfig(data: CreateRuntimeConfigParams): Promise<RuntimeConfig> {
+  return request.post('/system/configs', data);
+}
+
+export function updateRuntimeConfig(id: string, data: UpdateRuntimeConfigParams): Promise<RuntimeConfig> {
+  return request.put(`/system/configs/${id}`, data);
+}
+
+export function deleteRuntimeConfig(id: string): Promise<void> {
+  return request.delete(`/system/configs/${id}`);
+}

--- a/frontend/src/pages/system/config/ConfigPage.tsx
+++ b/frontend/src/pages/system/config/ConfigPage.tsx
@@ -1,0 +1,228 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button, Card, Drawer, Form, Input, InputNumber, Modal, Select, Space, Switch, Table, Tag, message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { PlusOutlined } from '@ant-design/icons';
+import {
+  createRuntimeConfig, deleteRuntimeConfig, getRuntimeConfigs, updateRuntimeConfig,
+} from '@/api/config';
+import { usePermission } from '@/hooks/usePermission';
+import type { CreateRuntimeConfigParams, RuntimeConfig, RuntimeConfigType } from '@/types/api';
+import './config.css';
+
+const protectedKeys = new Set(['internship_config', 'vote_weight_config']);
+
+const categoryOptions = [
+  { value: 'system', label: '系统' },
+  { value: 'business', label: '业务' },
+  { value: 'notification', label: '通知' },
+  { value: 'security', label: '安全' },
+  { value: 'internship', label: '实习' },
+  { value: 'meeting', label: '会议' },
+];
+
+const typeOptions: { value: RuntimeConfigType; label: string }[] = [
+  { value: 'string', label: '字符串' },
+  { value: 'number', label: '数字' },
+  { value: 'boolean', label: '布尔' },
+  { value: 'json', label: 'JSON' },
+];
+
+const categoryLabel = Object.fromEntries(categoryOptions.map((c) => [c.value, c.label]));
+
+interface FormValues {
+  config_key: string;
+  config_type: RuntimeConfigType;
+  category: string;
+  description?: string;
+  is_public?: boolean;
+  text_value?: string;
+  number_value?: number;
+  bool_value?: boolean;
+}
+
+function valueFromForm(v: FormValues): string {
+  if (v.config_type === 'boolean') return v.bool_value ? 'true' : 'false';
+  if (v.config_type === 'number') return String(v.number_value ?? 0);
+  return v.text_value ?? '';
+}
+
+function fillForm(row: RuntimeConfig): FormValues {
+  return {
+    config_key: row.config_key,
+    config_type: row.config_type,
+    category: row.category,
+    description: row.description,
+    is_public: row.is_public,
+    text_value: row.config_type === 'string' || row.config_type === 'json' ? row.config_value : '',
+    number_value: row.config_type === 'number' ? Number(row.config_value) : undefined,
+    bool_value: row.config_type === 'boolean' ? row.config_value === 'true' || row.config_value === '1' : false,
+  };
+}
+
+const ConfigPage: React.FC = () => {
+  const canCreate = usePermission('config:create');
+  const canUpdate = usePermission('config:update');
+  const canDelete = usePermission('config:delete');
+  const [list, setList] = useState<RuntimeConfig[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [category, setCategory] = useState<string>();
+  const [keyword, setKeyword] = useState('');
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<RuntimeConfig | null>(null);
+  const [form] = Form.useForm<FormValues>();
+  const watchType = Form.useWatch('config_type', form);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setList(await getRuntimeConfigs({ category, keyword: keyword || undefined }) || []);
+    } finally {
+      setLoading(false);
+    }
+  }, [category, keyword]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const openCreate = () => {
+    setEditing(null);
+    form.resetFields();
+    form.setFieldsValue({ config_type: 'string', category: 'system', bool_value: false });
+    setOpen(true);
+  };
+
+  const openEdit = (row: RuntimeConfig) => {
+    setEditing(row);
+    form.setFieldsValue(fillForm(row));
+    setOpen(true);
+  };
+
+  const submit = async () => {
+    const values = await form.validateFields();
+    const payload: CreateRuntimeConfigParams = {
+      config_key: values.config_key,
+      config_type: values.config_type,
+      category: values.category,
+      description: values.description,
+      is_public: values.is_public,
+      config_value: valueFromForm(values),
+    };
+    if (editing) {
+      await updateRuntimeConfig(editing.id, {
+        config_value: payload.config_value,
+        config_type: payload.config_type,
+        category: payload.category,
+        description: payload.description,
+        is_public: payload.is_public,
+      });
+      message.success('已保存');
+    } else {
+      await createRuntimeConfig(payload);
+      message.success('已创建');
+    }
+    setOpen(false);
+    void load();
+  };
+
+  const columns: ColumnsType<RuntimeConfig> = useMemo(() => [
+    { title: '键', dataIndex: 'config_key', width: 220 },
+    { title: '分组', dataIndex: 'category', width: 90, render: (v: string) => categoryLabel[v] || v },
+    { title: '类型', dataIndex: 'config_type', width: 80, render: (v: string) => <Tag>{v}</Tag> },
+    {
+      title: '值',
+      dataIndex: 'config_value',
+      ellipsis: true,
+      render: (v: string) => <span className="cfg-value">{v}</span>,
+    },
+    { title: '说明', dataIndex: 'description', ellipsis: true },
+    {
+      title: '操作',
+      width: 140,
+      render: (_, row) => (
+        <Space>
+          {canUpdate && <Button type="link" size="small" onClick={() => openEdit(row)}>编辑</Button>}
+          {canDelete && !protectedKeys.has(row.config_key) && (
+            <Button type="link" size="small" danger onClick={() => {
+              Modal.confirm({
+                title: '删除配置',
+                content: `确定删除 ${row.config_key}？`,
+                onOk: async () => {
+                  await deleteRuntimeConfig(row.id);
+                  message.success('已删除');
+                  void load();
+                },
+              });
+            }}
+            >
+              删除
+            </Button>
+          )}
+        </Space>
+      ),
+    },
+  ], [canDelete, canUpdate, load]);
+
+  return (
+    <div>
+      <div className="cfg-hero">
+        <div>
+          <h2>运行时配置</h2>
+          <p>改完立即生效，不必重启服务。实习开关、投票权重等业务键不可删除。</p>
+        </div>
+        {canCreate && (
+          <Button type="primary" size="large" icon={<PlusOutlined />} onClick={openCreate}>新建配置</Button>
+        )}
+      </div>
+      <Card className="page-shell">
+        <Space style={{ marginBottom: 16 }} wrap>
+          <Select
+            allowClear
+            placeholder="分组"
+            style={{ width: 140 }}
+            value={category}
+            options={categoryOptions}
+            onChange={(v) => setCategory(v)}
+          />
+          <Input.Search allowClear placeholder="搜索键/说明" onSearch={setKeyword} style={{ width: 240 }} />
+        </Space>
+        <Table rowKey="id" loading={loading} columns={columns} dataSource={list} pagination={false} />
+      </Card>
+      <Drawer
+        title={editing ? '编辑配置' : '新建配置'}
+        open={open}
+        onClose={() => setOpen(false)}
+        extra={<Button type="primary" onClick={() => void submit()}>保存</Button>}
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item name="config_key" label="键" rules={[{ required: true }]}>
+            <Input disabled={!!editing} placeholder="site.name" />
+          </Form.Item>
+          <Form.Item name="category" label="分组" rules={[{ required: true }]}>
+            <Select options={categoryOptions} />
+          </Form.Item>
+          <Form.Item name="config_type" label="类型" rules={[{ required: true }]}>
+            <Select options={typeOptions} disabled={!!editing} />
+          </Form.Item>
+          {watchType === 'boolean' && (
+            <Form.Item name="bool_value" label="值" valuePropName="checked"><Switch /></Form.Item>
+          )}
+          {watchType === 'number' && (
+            <Form.Item name="number_value" label="值" rules={[{ required: true }]}>
+              <InputNumber style={{ width: '100%' }} />
+            </Form.Item>
+          )}
+          {(watchType === 'string' || watchType === 'json' || !watchType) && (
+            <Form.Item name="text_value" label="值">
+              <Input.TextArea rows={watchType === 'json' ? 8 : 3} />
+            </Form.Item>
+          )}
+          <Form.Item name="description" label="说明"><Input /></Form.Item>
+          <Form.Item name="is_public" label="公开可读" valuePropName="checked"><Switch /></Form.Item>
+        </Form>
+      </Drawer>
+    </div>
+  );
+};
+
+export default ConfigPage;

--- a/frontend/src/pages/system/config/config.css
+++ b/frontend/src/pages/system/config/config.css
@@ -1,0 +1,34 @@
+.cfg-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 24px;
+  margin-bottom: 16px;
+  border-radius: 16px;
+  color: #fff;
+  background: linear-gradient(135deg, #0f766e 0%, #1d4ed8 55%, #7c3aed 100%);
+  box-shadow: 0 12px 32px rgba(15, 118, 110, 0.18);
+}
+
+.cfg-hero h2 {
+  margin: 0 0 6px;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.cfg-hero p {
+  margin: 0;
+  opacity: 0.88;
+}
+
+.page-shell {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.cfg-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -17,6 +17,7 @@ const NotificationList = lazy(() => import('@/pages/notification/NotificationLis
 const TemplateList = lazy(() => import('@/pages/notification/TemplateList'));
 const AuditList = lazy(() => import('@/pages/system/audit/AuditList'));
 const DepartmentPage = lazy(() => import('@/pages/system/department/DepartmentPage'));
+const ConfigPage = lazy(() => import('@/pages/system/config/ConfigPage'));
 const FileList = lazy(() => import('@/pages/file/FileList'));
 const ApplicationPage = lazy(() => import('@/pages/member/application/ApplicationPage'));
 const ProfilePage = lazy(() => import('@/pages/member/profile/ProfilePage'));
@@ -315,8 +316,8 @@ const routes: AppRouteObject[] = [
           },
           {
             path: 'config',
-            element: guarded(<div style={{ padding: 24 }}>系统配置（开发中）</div>, 'system:config'),
-            meta: { title: '系统配置', permission: 'system:config' },
+            element: lazyGuarded(ConfigPage, 'config:read'),
+            meta: { title: '系统配置', permission: 'config:read' },
           },
         ],
       },

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1146,6 +1146,41 @@ export interface ListFileParams extends ListParams {
 }
 
 // ============================================================
+// 运行时配置
+// ============================================================
+
+export type RuntimeConfigType = 'string' | 'number' | 'boolean' | 'json';
+
+export interface RuntimeConfig {
+  id: string;
+  config_key: string;
+  config_value: string;
+  config_type: RuntimeConfigType;
+  description: string;
+  category: string;
+  is_public: boolean;
+  updated_at: string;
+  created_at: string;
+}
+
+export interface CreateRuntimeConfigParams {
+  config_key: string;
+  config_value: string;
+  config_type: RuntimeConfigType;
+  description?: string;
+  category: string;
+  is_public?: boolean;
+}
+
+export interface UpdateRuntimeConfigParams {
+  config_value?: string;
+  config_type?: RuntimeConfigType;
+  description?: string;
+  category?: string;
+  is_public?: boolean;
+}
+
+// ============================================================
 // 统计
 // ============================================================
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 P1 扩展 **#47 运行时系统配置**：复用已有 `configs` 表（不改列名），不改动 #13 的 `pkg/config` YAML loader。

- SDK：`pkg/configstore` 提供 `Get` / `Set` / `GetBool`，Redis 缓存，写入后失效
- API：`GET/POST /api/v1/system/configs`、`GET /system/configs/key/:key`、`PUT/DELETE /system/configs/:id`
- 权限：`config:read/create/update/delete`
- 前端「系统管理 → 系统配置」：按分组筛选、按类型动态表单
- 种子：`site.name` / `site.allow_register` / `notification.email_enabled`
- 保护键：`internship_config`、`vote_weight_config` 不可删除
- **Bugbot**：副社长不再继承 `config:create/update/delete`，与 `system:config` 对齐，避免改实习/投票开关

## 关联 Issue

Related to #47（历史与回滚一期不做，拆 follow-up，故不 Closes）

## 测试方式

1. `cd backend && go test ./pkg/configstore ./internal/configstore/service ./scripts`
2. `APP_ENV=dev make seed` 后登录 `admin/admin123`
3. 打开「系统管理 → 系统配置」，改 `site.name` 保存后再读立即变化
4. 删除 `internship_config` 返回 14005 / 页面无删除按钮

## 截图 / GIF

[runtime_config_walkthrough.mp4](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fruntime_config_walkthrough.mp4)

| 页面/功能 | 截图 |
|----------|------|
| 配置列表 | [运行时配置列表](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconfig_page_list.webp) |
| 系统分组筛选 | [筛选系统分组](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconfig_page_system_filter.webp) |

## 注意事项

- **不做**配置历史与回滚（Issue 允许一期不做）
- 不修改 `pkg/config` 三层加载
- 实习/投票专用配置接口保留
- 合入后需 `APP_ENV=dev make seed` 写入 `config:*` 权限并收回副社长误授的写权限
- 本单不计入 P1 核心 8/8 门禁

## 检查清单

- [x] 代码遵循项目开发规范
- [x] 已进行自测
- [x] 已添加/更新必要的文档
- [ ] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

