### PR TITLE
feat(auth): 在线会话列表与强制下线

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -293,7 +293,7 @@ func main() {
 
 		// 认证路由（登录、刷新、第三方登录预留）
 		// 登录端点额外应用 LoginRateLimit（5 req/min，防暴力破解）
-		authHandler.RegisterRoutes(public, nil, authH, middleware.RateLimitWithFallback(redis.Client(), middleware.LoginRateLimit))
+		authHandler.RegisterRoutes(public, nil, authH, middleware.RateLimitWithFallback(redis.Client(), middleware.LoginRateLimit), cacheService)
 
 		// 注册仍由 user handler 处理
 		public.POST("/auth/register", userHandler.Register)
@@ -307,8 +307,8 @@ func main() {
 	protected.Use(authmiddleware.JWTAuth(&cfg.JWT, redis.Client()))
 	protected.Use(middleware.RateLimit(redis.Client(), middleware.PerIPRateLimit))
 	{
-		// 认证路由（登出、当前用户、修改密码）
-		authHandler.RegisterRoutes(nil, protected, authH, nil)
+		// 认证路由（登出、当前用户、修改密码、在线会话 #50）
+		authHandler.RegisterRoutes(nil, protected, authH, nil, cacheService)
 
 		// 用户模块
 		handler.RegisterUserRoutes(protected, userHandler)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
+	github.com/alicebob/miniredis/v2 v2.39.0
 	github.com/disintegration/imaging v1.6.2
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-mail/mail v2.3.1+incompatible
@@ -62,6 +63,7 @@ require (
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/xuri/efp v0.0.0-20231025114914-d1ff6096ae53 // indirect
 	github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/image v0.14.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,7 @@
 github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/alicebob/miniredis/v2 v2.39.0 h1:M7WbmV5BmV56L8KTG0rw6vEQ+woTOghpDgin2xv4A0g=
+github.com/alicebob/miniredis/v2 v2.39.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -128,6 +130,8 @@ github.com/xuri/excelize/v2 v2.8.1 h1:pZLMEwK8ep+CLIUWpWmvW8IWE/yxqG0I1xcN6cVMGu
 github.com/xuri/excelize/v2 v2.8.1/go.mod h1:oli1E4C3Pa5RXg1TBXn4ENCXDV5JUMlBluUhG7c+CEE=
 github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05 h1:qhbILQo1K3mphbwKh1vNm4oGezE1eF9fQWmNiIpSfI4=
 github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05/go.mod h1:WwHg+CVyzlv/TX9xqBFXEZAuxOPxn2k1GNHwG41IIUQ=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/backend/internal/auth/dto/session.go
+++ b/backend/internal/auth/dto/session.go
@@ -1,0 +1,36 @@
+package dto
+
+import "time"
+
+// SessionView is one online access-token session shown in the admin UI.
+type SessionView struct {
+	TokenID     string    `json:"token_id"`
+	UserID      string    `json:"user_id"`
+	Username    string    `json:"username"`
+	RealName    string    `json:"real_name"`
+	IP          string    `json:"ip"`
+	UserAgent   string    `json:"user_agent"`
+	Browser     string    `json:"browser"`
+	OS          string    `json:"os"`
+	Device      string    `json:"device"`
+	LoginAt     time.Time `json:"login_at"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	MultiDevice bool      `json:"multi_device"`
+	MultiIP     bool      `json:"multi_ip"`
+}
+
+// SessionListResponse is GET /auth/sessions.
+type SessionListResponse struct {
+	List  []SessionView `json:"list"`
+	Total int64         `json:"total"`
+}
+
+// UserSessionsResponse is GET /auth/sessions/:user_id.
+type UserSessionsResponse struct {
+	UserID      string        `json:"user_id"`
+	Username    string        `json:"username"`
+	RealName    string        `json:"real_name"`
+	MultiDevice bool          `json:"multi_device"`
+	MultiIP     bool          `json:"multi_ip"`
+	Sessions    []SessionView `json:"sessions"`
+}

--- a/backend/internal/auth/handler/auth_handler.go
+++ b/backend/internal/auth/handler/auth_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/Yogdunana/StarByte/backend/internal/auth/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/auth/service"
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
 	authmiddleware "github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/gin-gonic/gin"
@@ -61,7 +62,7 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	result, err := h.authService.RefreshToken(c.Request.Context(), &req)
+	result, err := h.authService.RefreshToken(c.Request.Context(), &req, c.ClientIP(), c.GetHeader("User-Agent"))
 	if err != nil {
 		response.Error(c, err)
 		return
@@ -189,14 +190,16 @@ func (h *AuthHandler) OAuthLogin(c *gin.Context) {
 
 // RegisterRoutes registers all authentication routes.
 // public routes (no auth): login, refresh, wechat, oauth
-// protected routes (auth): logout, me, password
+// protected routes (auth): logout, me, password, sessions
 // loginRateLimiter is an optional middleware applied to the login endpoint
 // for brute-force protection (e.g., 5 req/min). Pass nil to skip.
+// cacheService is required to register session admin routes; pass nil to skip.
 func RegisterRoutes(
 	public *gin.RouterGroup,
 	protected *gin.RouterGroup,
 	handler *AuthHandler,
 	loginRateLimiter gin.HandlerFunc,
+	cacheService rbacService.PermissionCacheService,
 ) {
 	if public != nil {
 		authGroup := public.Group("/auth")
@@ -219,6 +222,7 @@ func RegisterRoutes(
 			authProtected.POST("/logout", handler.Logout)
 			authProtected.GET("/me", handler.GetCurrentUser)
 			authProtected.PUT("/password", handler.ChangePassword)
+			registerSessionRoutes(authProtected, handler, cacheService)
 		}
 	}
 }

--- a/backend/internal/auth/handler/session_handler.go
+++ b/backend/internal/auth/handler/session_handler.go
@@ -1,0 +1,84 @@
+package handler
+
+import (
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
+}
+
+func registerSessionRoutes(
+	authProtected *gin.RouterGroup,
+	handler *AuthHandler,
+	cacheService rbacService.PermissionCacheService,
+) {
+	if cacheService == nil {
+		return
+	}
+	sessions := authProtected.Group("/sessions")
+	withPermission(sessions, "session:read", cacheService).GET("", handler.ListSessions)
+	withPermission(sessions, "session:read", cacheService).GET("/:user_id", handler.GetUserSessions)
+	// /user/:user_id 必须在 /:token 之前，避免 "user" 被当成 token
+	withPermission(sessions, "session:delete", cacheService).DELETE("/user/:user_id", handler.KickUserSessions)
+	withPermission(sessions, "session:delete", cacheService).DELETE("/:token", handler.KickSession)
+}
+
+// ListSessions handles GET /api/v1/auth/sessions
+func (h *AuthHandler) ListSessions(c *gin.Context) {
+	result, err := h.authService.ListSessions(c.Request.Context(), c.Query("keyword"), c.Query("user_id"))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, result)
+}
+
+// GetUserSessions handles GET /api/v1/auth/sessions/:user_id
+func (h *AuthHandler) GetUserSessions(c *gin.Context) {
+	userID := c.Param("user_id")
+	if userID == "" {
+		response.BadRequest(c, "缺少用户 ID")
+		return
+	}
+	result, err := h.authService.GetUserSessions(c.Request.Context(), userID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, result)
+}
+
+// KickSession handles DELETE /api/v1/auth/sessions/:token
+func (h *AuthHandler) KickSession(c *gin.Context) {
+	tokenID := c.Param("token")
+	if tokenID == "" || tokenID == "user" {
+		response.BadRequest(c, "缺少会话标识")
+		return
+	}
+	if err := h.authService.KickSession(c.Request.Context(), tokenID); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OKWithoutData(c)
+}
+
+// KickUserSessions handles DELETE /api/v1/auth/sessions/user/:user_id
+func (h *AuthHandler) KickUserSessions(c *gin.Context) {
+	userID := c.Param("user_id")
+	if userID == "" {
+		response.BadRequest(c, "缺少用户 ID")
+		return
+	}
+	if err := h.authService.KickUserSessions(c.Request.Context(), userID); err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OKWithoutData(c)
+}

--- a/backend/internal/auth/handler/session_handler_test.go
+++ b/backend/internal/auth/handler/session_handler_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/auth/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sessionStub struct {
+	list *dto.SessionListResponse
+	user *dto.UserSessionsResponse
+	err  error
+}
+
+func (s *sessionStub) Login(context.Context, *dto.LoginRequest, string, string) (*dto.LoginResponse, error) {
+	return nil, nil
+}
+func (s *sessionStub) RefreshToken(context.Context, *dto.RefreshTokenRequest, string, string) (*dto.RefreshResponse, error) {
+	return nil, nil
+}
+func (s *sessionStub) Logout(context.Context, string, string, string) error { return nil }
+func (s *sessionStub) GetCurrentUser(context.Context, string) (*dto.UserInfo, error) {
+	return nil, nil
+}
+func (s *sessionStub) ChangePassword(context.Context, string, *dto.ChangePasswordRequest) error {
+	return nil
+}
+func (s *sessionStub) ListSessions(context.Context, string, string) (*dto.SessionListResponse, error) {
+	return s.list, s.err
+}
+func (s *sessionStub) GetUserSessions(context.Context, string) (*dto.UserSessionsResponse, error) {
+	return s.user, s.err
+}
+func (s *sessionStub) KickSession(context.Context, string) error     { return s.err }
+func (s *sessionStub) KickUserSessions(context.Context, string) error { return s.err }
+
+func TestListSessions_OK(t *testing.T) {
+	h := NewAuthHandler(&sessionStub{list: &dto.SessionListResponse{List: []dto.SessionView{{TokenID: "j1"}}, Total: 1}})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/auth/sessions", nil)
+	c.Set("request_id", "rid")
+	h.ListSessions(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp response.Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.Code)
+}
+
+func TestKickSession_Missing(t *testing.T) {
+	h := NewAuthHandler(&sessionStub{})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/v1/auth/sessions/user", nil)
+	c.Params = gin.Params{{Key: "token", Value: "user"}}
+	c.Set("request_id", "rid")
+	h.KickSession(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestKickSession_NotFound(t *testing.T) {
+	h := NewAuthHandler(&sessionStub{err: response.NewError(response.CodeSessionNotFound, "会话不存在或已失效")})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/v1/auth/sessions/j1", nil)
+	c.Params = gin.Params{{Key: "token", Value: "j1"}}
+	c.Set("request_id", "rid")
+	h.KickSession(c)
+	var resp response.Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, response.CodeSessionNotFound, resp.Code)
+}
+
+func TestGetUserSessions_OK(t *testing.T) {
+	h := NewAuthHandler(&sessionStub{user: &dto.UserSessionsResponse{UserID: "u1", Sessions: []dto.SessionView{}}})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/auth/sessions/u1", nil)
+	c.Params = gin.Params{{Key: "user_id", Value: "u1"}}
+	c.Set("request_id", "rid")
+	h.GetUserSessions(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestKickUserSessions_OK(t *testing.T) {
+	h := NewAuthHandler(&sessionStub{})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/v1/auth/sessions/user/u1", nil)
+	c.Params = gin.Params{{Key: "user_id", Value: "u1"}}
+	c.Set("request_id", "rid")
+	h.KickUserSessions(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/backend/internal/auth/handler/session_handler_test.go
+++ b/backend/internal/auth/handler/session_handler_test.go
@@ -39,7 +39,7 @@ func (s *sessionStub) ListSessions(context.Context, string, string) (*dto.Sessio
 func (s *sessionStub) GetUserSessions(context.Context, string) (*dto.UserSessionsResponse, error) {
 	return s.user, s.err
 }
-func (s *sessionStub) KickSession(context.Context, string) error     { return s.err }
+func (s *sessionStub) KickSession(context.Context, string) error      { return s.err }
 func (s *sessionStub) KickUserSessions(context.Context, string) error { return s.err }
 
 func TestListSessions_OK(t *testing.T) {

--- a/backend/internal/auth/repo/auth_repo.go
+++ b/backend/internal/auth/repo/auth_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/internal/auth/model"
@@ -13,48 +14,29 @@ import (
 
 // AuthRepo handles all Redis-based authentication data operations.
 type AuthRepo interface {
-	// StoreRefreshToken stores a refresh token in Redis with the given TTL.
-	// The token is stored at key "auth:refresh:{token}" with userID as value.
-	StoreRefreshToken(ctx context.Context, token, userID string, ttl time.Duration) error
-
-	// GetRefreshTokenUserID retrieves the userID associated with a refresh token.
-	// Returns "" and redis.Nil if the token does not exist.
+	StoreRefreshToken(ctx context.Context, token, userID, accessJTI string, ttl time.Duration) error
 	GetRefreshTokenUserID(ctx context.Context, token string) (string, error)
-
-	// DeleteRefreshToken removes a refresh token from Redis (used during rotation).
+	GetRefreshTokenMeta(ctx context.Context, token string) (userID, jti string, err error)
 	DeleteRefreshToken(ctx context.Context, token string) error
+	DeleteRefreshTokensByUser(ctx context.Context, userID string) error
+	DeleteRefreshTokensByJTI(ctx context.Context, userID, jti string) error
 
-	// BlacklistToken adds a token (access or refresh) to the blacklist with the given TTL.
 	BlacklistToken(ctx context.Context, tokenID string, ttl time.Duration) error
-
-	// IsBlacklisted checks whether a token ID is in the blacklist.
 	IsBlacklisted(ctx context.Context, tokenID string) (bool, error)
 
-	// IncrLoginAttempts increments the failed login attempt counter for a username.
 	IncrLoginAttempts(ctx context.Context, username string) (int64, error)
-
-	// GetLoginAttempts returns the current failed attempt count for a username.
 	GetLoginAttempts(ctx context.Context, username string) (int64, error)
-
-	// ResetLoginAttempts clears the failed attempt counter for a username.
 	ResetLoginAttempts(ctx context.Context, username string) error
-
-	// SetLockout locks a username for the given duration.
 	SetLockout(ctx context.Context, username string, duration time.Duration) error
-
-	// IsLockedOut checks whether a username is currently locked out.
 	IsLockedOut(ctx context.Context, username string) (bool, error)
-
-	// GetLockoutTTL returns the remaining lockout time for a username.
 	GetLockoutTTL(ctx context.Context, username string) (time.Duration, error)
 
-	// StoreSession stores session metadata for a user.
 	StoreSession(ctx context.Context, userID, tokenID, ip, userAgent string, ttl time.Duration) error
-
-	// DeleteSession removes a session by token ID.
+	GetSession(ctx context.Context, tokenID string) (*model.Session, error)
 	DeleteSession(ctx context.Context, tokenID string) error
+	ListSessions(ctx context.Context) ([]model.Session, error)
+	ListSessionsByUser(ctx context.Context, userID string) ([]model.Session, error)
 
-	// GenerateRefreshToken generates a cryptographically random refresh token string.
 	GenerateRefreshToken() string
 }
 
@@ -73,33 +55,83 @@ const (
 	keyLoginAttempts = "auth:login_attempts:%s"
 	keyLockout       = "auth:lockout:%s"
 	keySession       = "auth:session:%s"
+	keyUserSessions  = "auth:user_sessions:%s"
+	keyUserRefresh   = "auth:user_refresh:%s"
 
 	maxLoginAttempts = 5
 	lockoutDuration  = 15 * time.Minute
+	sessionIndexTTL  = 8 * 24 * time.Hour
 )
 
-func (r *authRepo) StoreRefreshToken(ctx context.Context, token, userID string, ttl time.Duration) error {
+type refreshRecord struct {
+	UserID string `json:"user_id"`
+	JTI    string `json:"jti,omitempty"`
+}
+
+func parseRefreshRecord(val string) (userID, jti string) {
+	val = strings.TrimSpace(val)
+	if strings.HasPrefix(val, "{") {
+		var rec refreshRecord
+		if json.Unmarshal([]byte(val), &rec) == nil && rec.UserID != "" {
+			return rec.UserID, rec.JTI
+		}
+	}
+	return val, ""
+}
+
+func (r *authRepo) StoreRefreshToken(ctx context.Context, token, userID, accessJTI string, ttl time.Duration) error {
 	key := fmt.Sprintf(keyRefreshToken, token)
-	return r.rdb.Set(ctx, key, userID, ttl).Err()
+	data, err := json.Marshal(refreshRecord{UserID: userID, JTI: accessJTI})
+	if err != nil {
+		return fmt.Errorf("marshal refresh: %w", err)
+	}
+	pipe := r.rdb.TxPipeline()
+	pipe.Set(ctx, key, string(data), ttl)
+	ukey := fmt.Sprintf(keyUserRefresh, userID)
+	pipe.SAdd(ctx, ukey, token)
+	pipe.Expire(ctx, ukey, ttl)
+	_, err = pipe.Exec(ctx)
+	return err
 }
 
 func (r *authRepo) GetRefreshTokenUserID(ctx context.Context, token string) (string, error) {
+	uid, _, err := r.GetRefreshTokenMeta(ctx, token)
+	return uid, err
+}
+
+func (r *authRepo) GetRefreshTokenMeta(ctx context.Context, token string) (string, string, error) {
 	key := fmt.Sprintf(keyRefreshToken, token)
 	val, err := r.rdb.Get(ctx, key).Result()
 	if err == redis.Nil {
-		return "", redis.Nil
+		return "", "", redis.Nil
 	}
-	return val, err
+	if err != nil {
+		return "", "", err
+	}
+	uid, jti := parseRefreshRecord(val)
+	return uid, jti, nil
 }
 
 func (r *authRepo) DeleteRefreshToken(ctx context.Context, token string) error {
 	key := fmt.Sprintf(keyRefreshToken, token)
-	return r.rdb.Del(ctx, key).Err()
+	val, err := r.rdb.Get(ctx, key).Result()
+	if err != nil && err != redis.Nil {
+		return err
+	}
+	if err := r.rdb.Del(ctx, key).Err(); err != nil {
+		return err
+	}
+	if val != "" {
+		if userID, _ := parseRefreshRecord(val); userID != "" {
+			_ = r.rdb.SRem(ctx, fmt.Sprintf(keyUserRefresh, userID), token).Err()
+		}
+	}
+	return nil
 }
 
 func (r *authRepo) BlacklistToken(ctx context.Context, tokenID string, ttl time.Duration) error {
 	if ttl <= 0 {
-		return nil // no need to blacklist an already-expired token
+		return nil
 	}
 	key := fmt.Sprintf(keyBlacklist, tokenID)
 	return r.rdb.Set(ctx, key, "1", ttl).Err()
@@ -180,12 +212,27 @@ func (r *authRepo) StoreSession(ctx context.Context, userID, tokenID, ip, userAg
 	if err != nil {
 		return fmt.Errorf("marshal session: %w", err)
 	}
-	return r.rdb.Set(ctx, key, string(data), ttl).Err()
+	pipe := r.rdb.TxPipeline()
+	pipe.Set(ctx, key, string(data), ttl)
+	ukey := fmt.Sprintf(keyUserSessions, userID)
+	pipe.SAdd(ctx, ukey, tokenID)
+	pipe.Expire(ctx, ukey, sessionIndexTTL)
+	_, err = pipe.Exec(ctx)
+	return err
 }
 
 func (r *authRepo) DeleteSession(ctx context.Context, tokenID string) error {
-	key := fmt.Sprintf(keySession, tokenID)
-	return r.rdb.Del(ctx, key).Err()
+	sess, err := r.GetSession(ctx, tokenID)
+	if err != nil {
+		return err
+	}
+	if err := r.rdb.Del(ctx, fmt.Sprintf(keySession, tokenID)).Err(); err != nil {
+		return err
+	}
+	if sess != nil && sess.UserID != "" {
+		_ = r.rdb.SRem(ctx, fmt.Sprintf(keyUserSessions, sess.UserID), tokenID).Err()
+	}
+	return nil
 }
 
 // GenerateRefreshToken generates a cryptographically random refresh token string.

--- a/backend/internal/auth/repo/auth_repo_redis_test.go
+++ b/backend/internal/auth/repo/auth_repo_redis_test.go
@@ -63,6 +63,24 @@ func TestSessionIndex_ScanFallback(t *testing.T) {
 	assert.Equal(t, "legacy", got[0].TokenID)
 }
 
+func TestSessionIndex_ScanFallbackWithPartialIndex(t *testing.T) {
+	r, mr := newTestRepo(t)
+	ctx := context.Background()
+	require.NoError(t, r.StoreSession(ctx, "u1", "legacy", "1.1.1.1", "ua", time.Hour))
+	mr.Del("auth:user_sessions:u1")
+	require.NoError(t, r.StoreSession(ctx, "u1", "new", "2.2.2.2", "ua", time.Hour))
+
+	got, err := r.ListSessionsByUser(ctx, "u1")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	ids := map[string]struct{}{}
+	for _, s := range got {
+		ids[s.TokenID] = struct{}{}
+	}
+	assert.Contains(t, ids, "legacy")
+	assert.Contains(t, ids, "new")
+}
+
 func TestRefreshToken_JSONAndLegacy(t *testing.T) {
 	r, mr := newTestRepo(t)
 	ctx := context.Background()
@@ -106,6 +124,35 @@ func TestRefreshToken_DeleteByUserAndJTI(t *testing.T) {
 	_, _, err = r.GetRefreshTokenMeta(ctx, "b")
 	assert.Error(t, err)
 	uid, err = r.GetRefreshTokenUserID(ctx, "c")
+	require.NoError(t, err)
+	assert.Equal(t, "u2", uid)
+}
+
+func TestRefreshToken_DeleteLegacyUnindexed(t *testing.T) {
+	r, mr := newTestRepo(t)
+	ctx := context.Background()
+
+	mr.Set("auth:refresh:legacy-tok", "u1")
+	require.NoError(t, r.StoreRefreshToken(ctx, "new-tok", "u1", "j-new", time.Hour))
+	mr.Set("auth:refresh:other-user", "u2")
+
+	require.NoError(t, r.DeleteRefreshTokensByJTI(ctx, "u1", "old-jti"))
+	_, _, err := r.GetRefreshTokenMeta(ctx, "legacy-tok")
+	assert.Error(t, err)
+	uid, err := r.GetRefreshTokenUserID(ctx, "new-tok")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", uid)
+	uid, err = r.GetRefreshTokenUserID(ctx, "other-user")
+	require.NoError(t, err)
+	assert.Equal(t, "u2", uid)
+
+	mr.Set("auth:refresh:legacy-tok2", "u1")
+	require.NoError(t, r.DeleteRefreshTokensByUser(ctx, "u1"))
+	_, _, err = r.GetRefreshTokenMeta(ctx, "legacy-tok2")
+	assert.Error(t, err)
+	_, _, err = r.GetRefreshTokenMeta(ctx, "new-tok")
+	assert.Error(t, err)
+	uid, err = r.GetRefreshTokenUserID(ctx, "other-user")
 	require.NoError(t, err)
 	assert.Equal(t, "u2", uid)
 }

--- a/backend/internal/auth/repo/auth_repo_redis_test.go
+++ b/backend/internal/auth/repo/auth_repo_redis_test.go
@@ -1,0 +1,156 @@
+package repo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRepo(t *testing.T) (*authRepo, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return &authRepo{rdb: rdb}, mr
+}
+
+func TestSessionIndex_StoreListDelete(t *testing.T) {
+	r, _ := newTestRepo(t)
+	ctx := context.Background()
+
+	require.NoError(t, r.StoreSession(ctx, "u1", "j1", "1.1.1.1", "Chrome UA", time.Hour))
+	require.NoError(t, r.StoreSession(ctx, "u1", "j2", "2.2.2.2", "Safari UA", time.Hour))
+	require.NoError(t, r.StoreSession(ctx, "u2", "j3", "3.3.3.3", "Firefox UA", time.Hour))
+
+	got, err := r.GetSession(ctx, "j1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "u1", got.UserID)
+	assert.Equal(t, "1.1.1.1", got.IP)
+
+	all, err := r.ListSessions(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	mine, err := r.ListSessionsByUser(ctx, "u1")
+	require.NoError(t, err)
+	assert.Len(t, mine, 2)
+
+	require.NoError(t, r.DeleteSession(ctx, "j1"))
+	gone, err := r.GetSession(ctx, "j1")
+	require.NoError(t, err)
+	assert.Nil(t, gone)
+
+	mine, err = r.ListSessionsByUser(ctx, "u1")
+	require.NoError(t, err)
+	assert.Len(t, mine, 1)
+}
+
+func TestSessionIndex_ScanFallback(t *testing.T) {
+	r, mr := newTestRepo(t)
+	ctx := context.Background()
+	require.NoError(t, r.StoreSession(ctx, "u9", "legacy", "8.8.8.8", "ua", time.Hour))
+	mr.Del("auth:user_sessions:u9")
+
+	got, err := r.ListSessionsByUser(ctx, "u9")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "legacy", got[0].TokenID)
+}
+
+func TestRefreshToken_JSONAndLegacy(t *testing.T) {
+	r, mr := newTestRepo(t)
+	ctx := context.Background()
+
+	require.NoError(t, r.StoreRefreshToken(ctx, "tok-new", "u1", "jti-1", time.Hour))
+	uid, jti, err := r.GetRefreshTokenMeta(ctx, "tok-new")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", uid)
+	assert.Equal(t, "jti-1", jti)
+
+	uid, err = r.GetRefreshTokenUserID(ctx, "tok-new")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", uid)
+
+	mr.Set("auth:refresh:tok-old", "plain-user")
+	uid, jti, err = r.GetRefreshTokenMeta(ctx, "tok-old")
+	require.NoError(t, err)
+	assert.Equal(t, "plain-user", uid)
+	assert.Equal(t, "", jti)
+
+	require.NoError(t, r.DeleteRefreshToken(ctx, "tok-new"))
+	_, _, err = r.GetRefreshTokenMeta(ctx, "tok-new")
+	assert.Error(t, err)
+}
+
+func TestRefreshToken_DeleteByUserAndJTI(t *testing.T) {
+	r, _ := newTestRepo(t)
+	ctx := context.Background()
+	require.NoError(t, r.StoreRefreshToken(ctx, "a", "u1", "j1", time.Hour))
+	require.NoError(t, r.StoreRefreshToken(ctx, "b", "u1", "j2", time.Hour))
+	require.NoError(t, r.StoreRefreshToken(ctx, "c", "u2", "j3", time.Hour))
+
+	require.NoError(t, r.DeleteRefreshTokensByJTI(ctx, "u1", "j1"))
+	_, _, err := r.GetRefreshTokenMeta(ctx, "a")
+	assert.Error(t, err)
+	uid, err := r.GetRefreshTokenUserID(ctx, "b")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", uid)
+
+	require.NoError(t, r.DeleteRefreshTokensByUser(ctx, "u1"))
+	_, _, err = r.GetRefreshTokenMeta(ctx, "b")
+	assert.Error(t, err)
+	uid, err = r.GetRefreshTokenUserID(ctx, "c")
+	require.NoError(t, err)
+	assert.Equal(t, "u2", uid)
+}
+
+func TestBlacklistAndLockout(t *testing.T) {
+	r, _ := newTestRepo(t)
+	ctx := context.Background()
+
+	ok, err := r.IsBlacklisted(ctx, "j1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	require.NoError(t, r.BlacklistToken(ctx, "j1", time.Minute))
+	ok, err = r.IsBlacklisted(ctx, "j1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	n, err := r.IncrLoginAttempts(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+	n, err = r.GetLoginAttempts(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+	require.NoError(t, r.ResetLoginAttempts(ctx, "alice"))
+	n, err = r.GetLoginAttempts(ctx, "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	locked, err := r.IsLockedOut(ctx, "alice")
+	require.NoError(t, err)
+	assert.False(t, locked)
+	require.NoError(t, r.SetLockout(ctx, "alice", time.Minute))
+	locked, err = r.IsLockedOut(ctx, "alice")
+	require.NoError(t, err)
+	assert.True(t, locked)
+	ttl, err := r.GetLockoutTTL(ctx, "alice")
+	require.NoError(t, err)
+	assert.Greater(t, ttl, time.Duration(0))
+}
+
+func TestGetSession_Empty(t *testing.T) {
+	r, _ := newTestRepo(t)
+	got, err := r.GetSession(context.Background(), "")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	got, err = r.GetSession(context.Background(), "missing")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}

--- a/backend/internal/auth/repo/session_repo.go
+++ b/backend/internal/auth/repo/session_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/Yogdunana/StarByte/backend/internal/auth/model"
 	"github.com/redis/go-redis/v9"
@@ -35,26 +36,7 @@ func (r *authRepo) ListSessionsByUser(ctx context.Context, userID string) ([]mod
 	if userID == "" {
 		return nil, nil
 	}
-	ids, err := r.rdb.SMembers(ctx, fmt.Sprintf(keyUserSessions, userID)).Result()
-	if err != nil && err != redis.Nil {
-		return nil, err
-	}
-	out := make([]model.Session, 0, len(ids))
-	for _, id := range ids {
-		sess, err := r.GetSession(ctx, id)
-		if err != nil {
-			return nil, err
-		}
-		if sess == nil {
-			_ = r.rdb.SRem(ctx, fmt.Sprintf(keyUserSessions, userID), id).Err()
-			continue
-		}
-		out = append(out, *sess)
-	}
-	if len(out) > 0 {
-		return out, nil
-	}
-	// 兼容登录时尚未写入用户索引的旧 session
+	// 始终 SCAN：索引里已有新登录时，部署前未入集的旧 session 仍需一并返回
 	return r.scanSessions(ctx, userID)
 }
 
@@ -100,32 +82,49 @@ func (r *authRepo) DeleteRefreshTokensByUser(ctx context.Context, userID string)
 	if userID == "" {
 		return nil
 	}
-	ukey := fmt.Sprintf(keyUserRefresh, userID)
-	tokens, err := r.rdb.SMembers(ctx, ukey).Result()
-	if err != nil && err != redis.Nil {
+	if err := r.deleteRefreshTokensMatching(ctx, userID, ""); err != nil {
 		return err
 	}
-	for _, token := range tokens {
-		_ = r.rdb.Del(ctx, fmt.Sprintf(keyRefreshToken, token)).Err()
-	}
-	return r.rdb.Del(ctx, ukey).Err()
+	return r.rdb.Del(ctx, fmt.Sprintf(keyUserRefresh, userID)).Err()
 }
 
 func (r *authRepo) DeleteRefreshTokensByJTI(ctx context.Context, userID, jti string) error {
 	if userID == "" || jti == "" {
 		return nil
 	}
-	tokens, err := r.rdb.SMembers(ctx, fmt.Sprintf(keyUserRefresh, userID)).Result()
-	if err != nil && err != redis.Nil {
-		return err
-	}
-	for _, token := range tokens {
-		uid, recJTI, err := r.GetRefreshTokenMeta(ctx, token)
+	return r.deleteRefreshTokensMatching(ctx, userID, jti)
+}
+
+// deleteRefreshTokensMatching 扫描 auth:refresh:*，覆盖从未写入 auth:user_refresh 的旧 key。
+// jti 为空时删除该用户全部 refresh；非空时删除匹配 jti 的记录，以及无法绑定会话的旧格式（无 jti）记录。
+func (r *authRepo) deleteRefreshTokensMatching(ctx context.Context, userID, jti string) error {
+	var cursor uint64
+	prefix := fmt.Sprintf(keyRefreshToken, "")
+	for {
+		keys, next, err := r.rdb.Scan(ctx, cursor, fmt.Sprintf(keyRefreshToken, "*"), 64).Result()
 		if err != nil {
-			continue
+			return err
 		}
-		if uid == userID && recJTI == jti {
-			_ = r.DeleteRefreshToken(ctx, token)
+		for _, key := range keys {
+			val, err := r.rdb.Get(ctx, key).Result()
+			if err == redis.Nil {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			uid, recJTI := parseRefreshRecord(val)
+			if uid != userID {
+				continue
+			}
+			if jti != "" && recJTI != "" && recJTI != jti {
+				continue
+			}
+			_ = r.DeleteRefreshToken(ctx, strings.TrimPrefix(key, prefix))
+		}
+		cursor = next
+		if cursor == 0 {
+			break
 		}
 	}
 	return nil

--- a/backend/internal/auth/repo/session_repo.go
+++ b/backend/internal/auth/repo/session_repo.go
@@ -1,0 +1,132 @@
+package repo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Yogdunana/StarByte/backend/internal/auth/model"
+	"github.com/redis/go-redis/v9"
+)
+
+func (r *authRepo) GetSession(ctx context.Context, tokenID string) (*model.Session, error) {
+	if tokenID == "" {
+		return nil, nil
+	}
+	val, err := r.rdb.Get(ctx, fmt.Sprintf(keySession, tokenID)).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var sess model.Session
+	if err := json.Unmarshal([]byte(val), &sess); err != nil {
+		return nil, err
+	}
+	return &sess, nil
+}
+
+func (r *authRepo) ListSessions(ctx context.Context) ([]model.Session, error) {
+	return r.scanSessions(ctx, "")
+}
+
+func (r *authRepo) ListSessionsByUser(ctx context.Context, userID string) ([]model.Session, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	ids, err := r.rdb.SMembers(ctx, fmt.Sprintf(keyUserSessions, userID)).Result()
+	if err != nil && err != redis.Nil {
+		return nil, err
+	}
+	out := make([]model.Session, 0, len(ids))
+	for _, id := range ids {
+		sess, err := r.GetSession(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if sess == nil {
+			_ = r.rdb.SRem(ctx, fmt.Sprintf(keyUserSessions, userID), id).Err()
+			continue
+		}
+		out = append(out, *sess)
+	}
+	if len(out) > 0 {
+		return out, nil
+	}
+	// 兼容登录时尚未写入用户索引的旧 session
+	return r.scanSessions(ctx, userID)
+}
+
+func (r *authRepo) scanSessions(ctx context.Context, userID string) ([]model.Session, error) {
+	var (
+		out    []model.Session
+		cursor uint64
+	)
+	for {
+		keys, next, err := r.rdb.Scan(ctx, cursor, "auth:session:*", 64).Result()
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range keys {
+			val, err := r.rdb.Get(ctx, key).Result()
+			if err == redis.Nil {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			var sess model.Session
+			if err := json.Unmarshal([]byte(val), &sess); err != nil {
+				continue
+			}
+			if userID != "" && sess.UserID != userID {
+				continue
+			}
+			out = append(out, sess)
+			if userID != "" && sess.TokenID != "" {
+				_ = r.rdb.SAdd(ctx, fmt.Sprintf(keyUserSessions, userID), sess.TokenID).Err()
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (r *authRepo) DeleteRefreshTokensByUser(ctx context.Context, userID string) error {
+	if userID == "" {
+		return nil
+	}
+	ukey := fmt.Sprintf(keyUserRefresh, userID)
+	tokens, err := r.rdb.SMembers(ctx, ukey).Result()
+	if err != nil && err != redis.Nil {
+		return err
+	}
+	for _, token := range tokens {
+		_ = r.rdb.Del(ctx, fmt.Sprintf(keyRefreshToken, token)).Err()
+	}
+	return r.rdb.Del(ctx, ukey).Err()
+}
+
+func (r *authRepo) DeleteRefreshTokensByJTI(ctx context.Context, userID, jti string) error {
+	if userID == "" || jti == "" {
+		return nil
+	}
+	tokens, err := r.rdb.SMembers(ctx, fmt.Sprintf(keyUserRefresh, userID)).Result()
+	if err != nil && err != redis.Nil {
+		return err
+	}
+	for _, token := range tokens {
+		uid, recJTI, err := r.GetRefreshTokenMeta(ctx, token)
+		if err != nil {
+			continue
+		}
+		if uid == userID && recJTI == jti {
+			_ = r.DeleteRefreshToken(ctx, token)
+		}
+	}
+	return nil
+}

--- a/backend/internal/auth/repo/session_repo_test.go
+++ b/backend/internal/auth/repo/session_repo_test.go
@@ -1,0 +1,25 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRefreshRecord_JSONAndLegacy(t *testing.T) {
+	uid, jti := parseRefreshRecord(`{"user_id":"u-1","jti":"j-9"}`)
+	assert.Equal(t, "u-1", uid)
+	assert.Equal(t, "j-9", jti)
+
+	uid, jti = parseRefreshRecord("plain-user-id")
+	assert.Equal(t, "plain-user-id", uid)
+	assert.Equal(t, "", jti)
+
+	uid, jti = parseRefreshRecord("  {\"user_id\":\"u-2\"}  ")
+	assert.Equal(t, "u-2", uid)
+	assert.Equal(t, "", jti)
+
+	uid, jti = parseRefreshRecord("{not-json")
+	assert.Equal(t, "{not-json", uid)
+	assert.Equal(t, "", jti)
+}

--- a/backend/internal/auth/service/auth_service.go
+++ b/backend/internal/auth/service/auth_service.go
@@ -21,10 +21,14 @@ import (
 // AuthService defines the authentication service interface.
 type AuthService interface {
 	Login(ctx context.Context, req *dto.LoginRequest, ip, userAgent string) (*dto.LoginResponse, error)
-	RefreshToken(ctx context.Context, req *dto.RefreshTokenRequest) (*dto.RefreshResponse, error)
+	RefreshToken(ctx context.Context, req *dto.RefreshTokenRequest, ip, userAgent string) (*dto.RefreshResponse, error)
 	Logout(ctx context.Context, userID, tokenID, refreshToken string) error
 	GetCurrentUser(ctx context.Context, userID string) (*dto.UserInfo, error)
 	ChangePassword(ctx context.Context, userID string, req *dto.ChangePasswordRequest) error
+	ListSessions(ctx context.Context, keyword, userID string) (*dto.SessionListResponse, error)
+	GetUserSessions(ctx context.Context, userID string) (*dto.UserSessionsResponse, error)
+	KickSession(ctx context.Context, tokenID string) error
+	KickUserSessions(ctx context.Context, userID string) error
 }
 
 type authService struct {
@@ -104,16 +108,20 @@ func (s *authService) Login(ctx context.Context, req *dto.LoginRequest, ip, user
 	}
 
 	// 8. Generate and store refresh token (random string in Redis)
+	claims, _ := authmiddleware.ParseToken(accessToken, s.jwtConfig)
+	accessJTI := ""
+	if claims != nil {
+		accessJTI = claims.ID
+	}
+
 	refreshToken := s.authRepo.GenerateRefreshToken()
 	refreshTTL := time.Duration(s.jwtConfig.RefreshTokenExp) * time.Second
-	if err := s.authRepo.StoreRefreshToken(ctx, refreshToken, user.ID.String(), refreshTTL); err != nil {
+	if err := s.authRepo.StoreRefreshToken(ctx, refreshToken, user.ID.String(), accessJTI, refreshTTL); err != nil {
 		return nil, fmt.Errorf("store refresh token: %w", err)
 	}
 
-	// 9. Store session metadata
-	claims, _ := authmiddleware.ParseToken(accessToken, s.jwtConfig)
-	if claims != nil && claims.ID != "" {
-		_ = s.authRepo.StoreSession(ctx, user.ID.String(), claims.ID, ip, userAgent, accessTTL(s.jwtConfig))
+	if accessJTI != "" {
+		_ = s.authRepo.StoreSession(ctx, user.ID.String(), accessJTI, ip, userAgent, accessTTL(s.jwtConfig))
 	}
 
 	// 10. Update last login info
@@ -135,16 +143,18 @@ func (s *authService) Login(ctx context.Context, req *dto.LoginRequest, ip, user
 }
 
 // RefreshToken validates a refresh token, rotates it, and returns a new token pair.
-func (s *authService) RefreshToken(ctx context.Context, req *dto.RefreshTokenRequest) (*dto.RefreshResponse, error) {
-	// 1. Look up refresh token in Redis
-	userID, err := s.authRepo.GetRefreshTokenUserID(ctx, req.RefreshToken)
+func (s *authService) RefreshToken(ctx context.Context, req *dto.RefreshTokenRequest, ip, userAgent string) (*dto.RefreshResponse, error) {
+	userID, oldJTI, err := s.authRepo.GetRefreshTokenMeta(ctx, req.RefreshToken)
 	if err != nil {
 		return nil, response.NewError(response.CodeRefreshTokenInvalid, "Refresh Token 无效")
 	}
 
-	// 2. Delete old refresh token (rotation: one-time use)
 	if err := s.authRepo.DeleteRefreshToken(ctx, req.RefreshToken); err != nil {
 		return nil, fmt.Errorf("delete refresh token: %w", err)
+	}
+	if oldJTI != "" {
+		_ = s.authRepo.BlacklistToken(ctx, oldJTI, accessTTL(s.jwtConfig))
+		_ = s.authRepo.DeleteSession(ctx, oldJTI)
 	}
 
 	// 3. Query user
@@ -177,11 +187,19 @@ func (s *authService) RefreshToken(ctx context.Context, req *dto.RefreshTokenReq
 		return nil, fmt.Errorf("generate access token: %w", err)
 	}
 
-	// 6. Generate and store new refresh token (rotation)
+	newClaims, _ := authmiddleware.ParseToken(accessToken, s.jwtConfig)
+	newJTI := ""
+	if newClaims != nil {
+		newJTI = newClaims.ID
+	}
+
 	newRefreshToken := s.authRepo.GenerateRefreshToken()
 	refreshTTL := time.Duration(s.jwtConfig.RefreshTokenExp) * time.Second
-	if err := s.authRepo.StoreRefreshToken(ctx, newRefreshToken, user.ID.String(), refreshTTL); err != nil {
+	if err := s.authRepo.StoreRefreshToken(ctx, newRefreshToken, user.ID.String(), newJTI, refreshTTL); err != nil {
 		return nil, fmt.Errorf("store refresh token: %w", err)
+	}
+	if newJTI != "" {
+		_ = s.authRepo.StoreSession(ctx, user.ID.String(), newJTI, ip, userAgent, accessTTL(s.jwtConfig))
 	}
 
 	return &dto.RefreshResponse{

--- a/backend/internal/auth/service/auth_service_test.go
+++ b/backend/internal/auth/service/auth_service_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/internal/auth/dto"
+	authmodel "github.com/Yogdunana/StarByte/backend/internal/auth/model"
 	"github.com/Yogdunana/StarByte/backend/internal/user/model"
 	"github.com/Yogdunana/StarByte/backend/pkg/config"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
@@ -69,8 +70,8 @@ type mockAuthRepo struct {
 	mock.Mock
 }
 
-func (m *mockAuthRepo) StoreRefreshToken(ctx context.Context, token, userID string, ttl time.Duration) error {
-	args := m.Called(ctx, token, userID, ttl)
+func (m *mockAuthRepo) StoreRefreshToken(ctx context.Context, token, userID, accessJTI string, ttl time.Duration) error {
+	args := m.Called(ctx, token, userID, accessJTI, ttl)
 	return args.Error(0)
 }
 
@@ -79,8 +80,23 @@ func (m *mockAuthRepo) GetRefreshTokenUserID(ctx context.Context, token string) 
 	return args.String(0), args.Error(1)
 }
 
+func (m *mockAuthRepo) GetRefreshTokenMeta(ctx context.Context, token string) (string, string, error) {
+	args := m.Called(ctx, token)
+	return args.String(0), args.String(1), args.Error(2)
+}
+
 func (m *mockAuthRepo) DeleteRefreshToken(ctx context.Context, token string) error {
 	args := m.Called(ctx, token)
+	return args.Error(0)
+}
+
+func (m *mockAuthRepo) DeleteRefreshTokensByUser(ctx context.Context, userID string) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+func (m *mockAuthRepo) DeleteRefreshTokensByJTI(ctx context.Context, userID, jti string) error {
+	args := m.Called(ctx, userID, jti)
 	return args.Error(0)
 }
 
@@ -132,6 +148,30 @@ func (m *mockAuthRepo) StoreSession(ctx context.Context, userID, tokenID, ip, us
 func (m *mockAuthRepo) DeleteSession(ctx context.Context, tokenID string) error {
 	args := m.Called(ctx, tokenID)
 	return args.Error(0)
+}
+
+func (m *mockAuthRepo) GetSession(ctx context.Context, tokenID string) (*authmodel.Session, error) {
+	args := m.Called(ctx, tokenID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*authmodel.Session), args.Error(1)
+}
+
+func (m *mockAuthRepo) ListSessions(ctx context.Context) ([]authmodel.Session, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]authmodel.Session), args.Error(1)
+}
+
+func (m *mockAuthRepo) ListSessionsByUser(ctx context.Context, userID string) ([]authmodel.Session, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]authmodel.Session), args.Error(1)
 }
 
 func (m *mockAuthRepo) GenerateRefreshToken() string {
@@ -217,7 +257,7 @@ func TestLogin_Success(t *testing.T) {
 	authRepo.On("ResetLoginAttempts", ctx, "testuser").Return(nil)
 	permCache.On("GetUserPermissionsAndSuperAdmin", ctx, userID).Return([]string{"user:read"}, false, nil)
 	permCache.On("GetUserRoleCodes", ctx, userID).Return([]string{"user"}, nil)
-	authRepo.On("StoreRefreshToken", ctx, mock.Anything, userID.String(), mock.Anything).Return(nil)
+	authRepo.On("StoreRefreshToken", ctx, mock.Anything, userID.String(), mock.Anything, mock.Anything).Return(nil)
 	authRepo.On("StoreSession", ctx, userID.String(), mock.Anything, "127.0.0.1", mock.Anything, mock.Anything).Return(nil)
 	userRepo.On("UpdateLastLogin", ctx, userID, "127.0.0.1").Return(nil)
 
@@ -362,16 +402,19 @@ func TestRefreshToken_Success(t *testing.T) {
 		Status:       0,
 	}
 
-	authRepo.On("GetRefreshTokenUserID", ctx, "valid-refresh-token").Return(userID.String(), nil)
+	authRepo.On("GetRefreshTokenMeta", ctx, "valid-refresh-token").Return(userID.String(), "old-jti", nil)
 	authRepo.On("DeleteRefreshToken", ctx, "valid-refresh-token").Return(nil)
+	authRepo.On("BlacklistToken", ctx, "old-jti", mock.Anything).Return(nil)
+	authRepo.On("DeleteSession", ctx, "old-jti").Return(nil)
 	userRepo.On("GetByID", ctx, userID).Return(user, nil)
 	permCache.On("GetUserPermissionsAndSuperAdmin", ctx, userID).Return([]string{"user:read"}, false, nil)
 	permCache.On("GetUserRoleCodes", ctx, userID).Return([]string{"user"}, nil)
-	authRepo.On("StoreRefreshToken", ctx, mock.Anything, userID.String(), mock.Anything).Return(nil)
+	authRepo.On("StoreRefreshToken", ctx, mock.Anything, userID.String(), mock.Anything, mock.Anything).Return(nil)
+	authRepo.On("StoreSession", ctx, userID.String(), mock.Anything, "127.0.0.1", "test-agent", mock.Anything).Return(nil)
 
 	result, err := svc.RefreshToken(ctx, &dto.RefreshTokenRequest{
 		RefreshToken: "valid-refresh-token",
-	})
+	}, "127.0.0.1", "test-agent")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -389,11 +432,11 @@ func TestRefreshToken_InvalidToken(t *testing.T) {
 	ctx := context.Background()
 
 	// Redis returns nil for invalid token
-	authRepo.On("GetRefreshTokenUserID", ctx, "invalid-token").Return("", errors.New("redis: nil"))
+	authRepo.On("GetRefreshTokenMeta", ctx, "invalid-token").Return("", "", errors.New("redis: nil"))
 
 	result, err := svc.RefreshToken(ctx, &dto.RefreshTokenRequest{
 		RefreshToken: "invalid-token",
-	})
+	}, "127.0.0.1", "test-agent")
 
 	assert.Nil(t, result)
 	assert.Error(t, err)
@@ -414,13 +457,13 @@ func TestRefreshToken_UserDisabled(t *testing.T) {
 		Status:       1, // disabled
 	}
 
-	authRepo.On("GetRefreshTokenUserID", ctx, "valid-refresh-token").Return(userID.String(), nil)
+	authRepo.On("GetRefreshTokenMeta", ctx, "valid-refresh-token").Return(userID.String(), "", nil)
 	authRepo.On("DeleteRefreshToken", ctx, "valid-refresh-token").Return(nil)
 	userRepo.On("GetByID", ctx, userID).Return(user, nil)
 
 	result, err := svc.RefreshToken(ctx, &dto.RefreshTokenRequest{
 		RefreshToken: "valid-refresh-token",
-	})
+	}, "127.0.0.1", "test-agent")
 
 	assert.Nil(t, result)
 	assert.Error(t, err)
@@ -629,13 +672,13 @@ func TestRefreshToken_UserNotFound(t *testing.T) {
 	ctx := context.Background()
 	userID := uuid.New()
 
-	authRepo.On("GetRefreshTokenUserID", ctx, "valid-refresh-token").Return(userID.String(), nil)
+	authRepo.On("GetRefreshTokenMeta", ctx, "valid-refresh-token").Return(userID.String(), "", nil)
 	authRepo.On("DeleteRefreshToken", ctx, "valid-refresh-token").Return(nil)
 	userRepo.On("GetByID", ctx, userID).Return((*model.User)(nil), nil)
 
 	result, err := svc.RefreshToken(ctx, &dto.RefreshTokenRequest{
 		RefreshToken: "valid-refresh-token",
-	})
+	}, "127.0.0.1", "test-agent")
 
 	assert.Nil(t, result)
 	assert.Error(t, err)
@@ -648,12 +691,12 @@ func TestRefreshToken_InvalidUserID(t *testing.T) {
 	svc, _, authRepo, _ := setupTestService()
 	ctx := context.Background()
 
-	authRepo.On("GetRefreshTokenUserID", ctx, "valid-refresh-token").Return("not-a-uuid", nil)
+	authRepo.On("GetRefreshTokenMeta", ctx, "valid-refresh-token").Return("not-a-uuid", "", nil)
 	authRepo.On("DeleteRefreshToken", ctx, "valid-refresh-token").Return(nil)
 
 	result, err := svc.RefreshToken(ctx, &dto.RefreshTokenRequest{
 		RefreshToken: "valid-refresh-token",
-	})
+	}, "127.0.0.1", "test-agent")
 
 	assert.Nil(t, result)
 	assert.Error(t, err)
@@ -796,7 +839,7 @@ func TestLogin_SuperAdminRoles(t *testing.T) {
 	authRepo.On("ResetLoginAttempts", ctx, "admin").Return(nil)
 	// Super admin: isSuperAdmin=true, so GetUserRoleCodes is NOT called
 	permCache.On("GetUserPermissionsAndSuperAdmin", ctx, userID).Return([]string{}, true, nil)
-	authRepo.On("StoreRefreshToken", ctx, mock.Anything, userID.String(), mock.Anything).Return(nil)
+	authRepo.On("StoreRefreshToken", ctx, mock.Anything, userID.String(), mock.Anything, mock.Anything).Return(nil)
 	authRepo.On("StoreSession", ctx, userID.String(), mock.Anything, "127.0.0.1", mock.Anything, mock.Anything).Return(nil)
 	userRepo.On("UpdateLastLogin", ctx, userID, "127.0.0.1").Return(nil)
 

--- a/backend/internal/auth/service/device.go
+++ b/backend/internal/auth/service/device.go
@@ -1,0 +1,50 @@
+package service
+
+import "strings"
+
+// ParseUserAgent extracts a coarse browser / OS / device class from UA.
+// No extra dependency: enough for the session admin list.
+func ParseUserAgent(ua string) (browser, osName, device string) {
+	if strings.TrimSpace(ua) == "" {
+		return "Unknown", "Unknown", "Unknown"
+	}
+	l := strings.ToLower(ua)
+	device = "Desktop"
+	switch {
+	case strings.Contains(l, "ipad") || strings.Contains(l, "tablet"):
+		device = "Tablet"
+	case strings.Contains(l, "mobi") || strings.Contains(l, "android") || strings.Contains(l, "iphone"):
+		device = "Mobile"
+	}
+
+	switch {
+	case strings.Contains(l, "edg/") || strings.Contains(l, "edge/"):
+		browser = "Edge"
+	case strings.Contains(l, "opr/") || strings.Contains(l, "opera"):
+		browser = "Opera"
+	case strings.Contains(l, "chrome/") && !strings.Contains(l, "edg"):
+		browser = "Chrome"
+	case strings.Contains(l, "firefox/") || strings.Contains(l, "fxios"):
+		browser = "Firefox"
+	case strings.Contains(l, "safari/") && !strings.Contains(l, "chrome") && !strings.Contains(l, "android"):
+		browser = "Safari"
+	default:
+		browser = "Unknown"
+	}
+
+	switch {
+	case strings.Contains(l, "windows"):
+		osName = "Windows"
+	case strings.Contains(l, "android"):
+		osName = "Android"
+	case strings.Contains(l, "iphone") || strings.Contains(l, "ipad") || strings.Contains(l, "ios"):
+		osName = "iOS"
+	case strings.Contains(l, "mac os") || strings.Contains(l, "macintosh"):
+		osName = "macOS"
+	case strings.Contains(l, "linux"):
+		osName = "Linux"
+	default:
+		osName = "Unknown"
+	}
+	return browser, osName, device
+}

--- a/backend/internal/auth/service/device_test.go
+++ b/backend/internal/auth/service/device_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseUserAgent(t *testing.T) {
+	cases := []struct {
+		ua      string
+		browser string
+		os      string
+		device  string
+	}{
+		{"", "Unknown", "Unknown", "Unknown"},
+		{
+			"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
+			"Chrome", "Windows", "Desktop",
+		},
+		{
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+			"Safari", "macOS", "Desktop",
+		},
+		{
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+			"Safari", "iOS", "Mobile",
+		},
+		{
+			"Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Mobile Safari/537.36",
+			"Chrome", "Android", "Mobile",
+		},
+		{
+			"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.0.0",
+			"Edge", "Windows", "Desktop",
+		},
+		{
+			"Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0",
+			"Firefox", "Linux", "Desktop",
+		},
+		{
+			"Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+			"Safari", "iOS", "Tablet",
+		},
+	}
+	for _, tc := range cases {
+		b, o, d := ParseUserAgent(tc.ua)
+		assert.Equal(t, tc.browser, b, tc.ua)
+		assert.Equal(t, tc.os, o, tc.ua)
+		assert.Equal(t, tc.device, d, tc.ua)
+	}
+}

--- a/backend/internal/auth/service/session_service.go
+++ b/backend/internal/auth/service/session_service.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/auth/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/auth/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+func (s *authService) ListSessions(ctx context.Context, keyword, userID string) (*dto.SessionListResponse, error) {
+	var (
+		sessions []model.Session
+		err      error
+	)
+	if userID != "" {
+		sessions, err = s.authRepo.ListSessionsByUser(ctx, userID)
+	} else {
+		sessions, err = s.authRepo.ListSessions(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+	views := s.toViews(ctx, sessions)
+	annotateAnomalies(views)
+	if keyword != "" {
+		kw := strings.ToLower(strings.TrimSpace(keyword))
+		filtered := make([]dto.SessionView, 0, len(views))
+		for _, v := range views {
+			if sessionMatches(v, kw) {
+				filtered = append(filtered, v)
+			}
+		}
+		views = filtered
+	}
+	if views == nil {
+		views = []dto.SessionView{}
+	}
+	return &dto.SessionListResponse{List: views, Total: int64(len(views))}, nil
+}
+
+func (s *authService) GetUserSessions(ctx context.Context, userID string) (*dto.UserSessionsResponse, error) {
+	sessions, err := s.authRepo.ListSessionsByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	views := s.toViews(ctx, sessions)
+	annotateAnomalies(views)
+	resp := &dto.UserSessionsResponse{
+		UserID:   userID,
+		Sessions: views,
+	}
+	if len(views) > 0 {
+		resp.Username = views[0].Username
+		resp.RealName = views[0].RealName
+		resp.MultiDevice = views[0].MultiDevice
+		resp.MultiIP = views[0].MultiIP
+	} else {
+		resp.Sessions = []dto.SessionView{}
+		s.fillUserNames(ctx, userID, resp)
+	}
+	return resp, nil
+}
+
+func (s *authService) KickSession(ctx context.Context, tokenID string) error {
+	sess, err := s.authRepo.GetSession(ctx, tokenID)
+	if err != nil {
+		return err
+	}
+	if sess == nil {
+		return response.NewError(response.CodeSessionNotFound, "会话不存在或已失效")
+	}
+	ttl := time.Until(sess.ExpiresAt)
+	if ttl < time.Second {
+		ttl = time.Second
+	}
+	_ = s.authRepo.BlacklistToken(ctx, tokenID, ttl)
+	_ = s.authRepo.DeleteSession(ctx, tokenID)
+	_ = s.authRepo.DeleteRefreshTokensByJTI(ctx, sess.UserID, tokenID)
+	return nil
+}
+
+func (s *authService) KickUserSessions(ctx context.Context, userID string) error {
+	sessions, err := s.authRepo.ListSessionsByUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if len(sessions) == 0 {
+		return response.NewError(response.CodeSessionUserOffline, "该用户当前没有在线会话")
+	}
+	accessTTL := time.Duration(s.jwtConfig.AccessTokenExp) * time.Second
+	for _, sess := range sessions {
+		ttl := time.Until(sess.ExpiresAt)
+		if ttl < time.Second {
+			ttl = accessTTL
+		}
+		_ = s.authRepo.BlacklistToken(ctx, sess.TokenID, ttl)
+		_ = s.authRepo.DeleteSession(ctx, sess.TokenID)
+	}
+	_ = s.authRepo.DeleteRefreshTokensByUser(ctx, userID)
+	return nil
+}
+
+func (s *authService) toViews(ctx context.Context, sessions []model.Session) []dto.SessionView {
+	users := map[string][2]string{}
+	out := make([]dto.SessionView, 0, len(sessions))
+	for _, sess := range sessions {
+		browser, osName, device := ParseUserAgent(sess.UserAgent)
+		username, realName := s.lookupUser(ctx, sess.UserID, users)
+		out = append(out, dto.SessionView{
+			TokenID:   sess.TokenID,
+			UserID:    sess.UserID,
+			Username:  username,
+			RealName:  realName,
+			IP:        sess.IP,
+			UserAgent: sess.UserAgent,
+			Browser:   browser,
+			OS:        osName,
+			Device:    device,
+			LoginAt:   sess.LoginAt,
+			ExpiresAt: sess.ExpiresAt,
+		})
+	}
+	return out
+}
+
+func (s *authService) lookupUser(ctx context.Context, userID string, cache map[string][2]string) (string, string) {
+	if userID == "" {
+		return "", ""
+	}
+	if v, ok := cache[userID]; ok {
+		return v[0], v[1]
+	}
+	uid, err := uuid.Parse(userID)
+	if err != nil {
+		cache[userID] = [2]string{}
+		return "", ""
+	}
+	user, err := s.userRepo.GetByID(ctx, uid)
+	if err != nil || user == nil {
+		cache[userID] = [2]string{}
+		return "", ""
+	}
+	cache[userID] = [2]string{user.Username, user.RealName}
+	return user.Username, user.RealName
+}
+
+func (s *authService) fillUserNames(ctx context.Context, userID string, resp *dto.UserSessionsResponse) {
+	uid, err := uuid.Parse(userID)
+	if err != nil {
+		return
+	}
+	user, err := s.userRepo.GetByID(ctx, uid)
+	if err != nil || user == nil {
+		return
+	}
+	resp.Username = user.Username
+	resp.RealName = user.RealName
+}
+
+func sessionMatches(v dto.SessionView, kw string) bool {
+	fields := []string{v.Username, v.RealName, v.IP, v.UserAgent, v.Browser, v.OS, v.Device, v.UserID}
+	for _, f := range fields {
+		if strings.Contains(strings.ToLower(f), kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func annotateAnomalies(views []dto.SessionView) {
+	type acc struct {
+		n   int
+		ips map[string]struct{}
+	}
+	byUser := map[string]*acc{}
+	for i := range views {
+		a := byUser[views[i].UserID]
+		if a == nil {
+			a = &acc{ips: map[string]struct{}{}}
+			byUser[views[i].UserID] = a
+		}
+		a.n++
+		if views[i].IP != "" {
+			a.ips[views[i].IP] = struct{}{}
+		}
+	}
+	for i := range views {
+		a := byUser[views[i].UserID]
+		views[i].MultiDevice = a.n > 1
+		views[i].MultiIP = len(a.ips) > 1
+	}
+}

--- a/backend/internal/auth/service/session_service_test.go
+++ b/backend/internal/auth/service/session_service_test.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/auth/dto"
+	authmodel "github.com/Yogdunana/StarByte/backend/internal/auth/model"
+	"github.com/Yogdunana/StarByte/backend/internal/user/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func sampleSession(userID, tokenID, ip, ua string) authmodel.Session {
+	return authmodel.Session{
+		UserID:    userID,
+		TokenID:   tokenID,
+		IP:        ip,
+		UserAgent: ua,
+		LoginAt:   time.Now().Add(-time.Hour),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+}
+
+func TestListSessions_AnomalyAndKeyword(t *testing.T) {
+	svc, userRepo, authRepo, _ := setupTestService()
+	ctx := context.Background()
+	uid := uuid.New()
+	chrome := "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/128.0.0.0 Safari/537.36"
+	sess := []authmodel.Session{
+		sampleSession(uid.String(), "j1", "1.1.1.1", chrome),
+		sampleSession(uid.String(), "j2", "2.2.2.2", chrome),
+	}
+	authRepo.On("ListSessions", ctx).Return(sess, nil)
+	userRepo.On("GetByID", ctx, uid).Return(&model.User{ID: uid, Username: "alice", RealName: "爱丽丝"}, nil)
+
+	out, err := svc.ListSessions(ctx, "", "")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), out.Total)
+	assert.True(t, out.List[0].MultiDevice)
+	assert.True(t, out.List[0].MultiIP)
+	assert.Equal(t, "Chrome", out.List[0].Browser)
+	assert.Equal(t, "alice", out.List[0].Username)
+
+	filtered, err := svc.ListSessions(ctx, "爱丽丝", "")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), filtered.Total)
+
+	none, err := svc.ListSessions(ctx, "nobody", "")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), none.Total)
+	assert.NotNil(t, none.List)
+}
+
+func TestListSessions_FilterByUser(t *testing.T) {
+	svc, userRepo, authRepo, _ := setupTestService()
+	ctx := context.Background()
+	uid := uuid.New()
+	authRepo.On("ListSessionsByUser", ctx, uid.String()).Return([]authmodel.Session{
+		sampleSession(uid.String(), "j1", "1.1.1.1", "curl/8.0"),
+	}, nil)
+	userRepo.On("GetByID", ctx, uid).Return(&model.User{ID: uid, Username: "bob"}, nil)
+
+	out, err := svc.ListSessions(ctx, "", uid.String())
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), out.Total)
+	assert.False(t, out.List[0].MultiDevice)
+	assert.Equal(t, "bob", out.List[0].Username)
+}
+
+func TestGetUserSessions_EmptyFillsProfile(t *testing.T) {
+	svc, userRepo, authRepo, _ := setupTestService()
+	ctx := context.Background()
+	uid := uuid.New()
+	authRepo.On("ListSessionsByUser", ctx, uid.String()).Return([]authmodel.Session{}, nil)
+	userRepo.On("GetByID", ctx, uid).Return(&model.User{ID: uid, Username: "carol", RealName: "李四"}, nil)
+
+	out, err := svc.GetUserSessions(ctx, uid.String())
+	assert.NoError(t, err)
+	assert.Equal(t, "carol", out.Username)
+	assert.Equal(t, "李四", out.RealName)
+	assert.Empty(t, out.Sessions)
+}
+
+func TestKickSession_NotFound(t *testing.T) {
+	svc, _, authRepo, _ := setupTestService()
+	ctx := context.Background()
+	authRepo.On("GetSession", ctx, "missing").Return(nil, nil)
+
+	err := svc.KickSession(ctx, "missing")
+	var appErr *response.AppError
+	assert.ErrorAs(t, err, &appErr)
+	assert.Equal(t, response.CodeSessionNotFound, appErr.Code)
+}
+
+func TestKickSession_Success(t *testing.T) {
+	svc, _, authRepo, _ := setupTestService()
+	ctx := context.Background()
+	sess := sampleSession("user-1", "jti-1", "1.1.1.1", "ua")
+	authRepo.On("GetSession", ctx, "jti-1").Return(&sess, nil)
+	authRepo.On("BlacklistToken", ctx, "jti-1", mock.Anything).Return(nil)
+	authRepo.On("DeleteSession", ctx, "jti-1").Return(nil)
+	authRepo.On("DeleteRefreshTokensByJTI", ctx, "user-1", "jti-1").Return(nil)
+
+	assert.NoError(t, svc.KickSession(ctx, "jti-1"))
+}
+
+func TestKickUserSessions_Offline(t *testing.T) {
+	svc, _, authRepo, _ := setupTestService()
+	ctx := context.Background()
+	authRepo.On("ListSessionsByUser", ctx, "u1").Return([]authmodel.Session{}, nil)
+
+	err := svc.KickUserSessions(ctx, "u1")
+	var appErr *response.AppError
+	assert.ErrorAs(t, err, &appErr)
+	assert.Equal(t, response.CodeSessionUserOffline, appErr.Code)
+}
+
+func TestKickUserSessions_Success(t *testing.T) {
+	svc, _, authRepo, _ := setupTestService()
+	ctx := context.Background()
+	sess := []authmodel.Session{
+		sampleSession("u1", "a", "1.1.1.1", "ua"),
+		sampleSession("u1", "b", "1.1.1.1", "ua"),
+	}
+	authRepo.On("ListSessionsByUser", ctx, "u1").Return(sess, nil)
+	authRepo.On("BlacklistToken", ctx, "a", mock.Anything).Return(nil)
+	authRepo.On("BlacklistToken", ctx, "b", mock.Anything).Return(nil)
+	authRepo.On("DeleteSession", ctx, "a").Return(nil)
+	authRepo.On("DeleteSession", ctx, "b").Return(nil)
+	authRepo.On("DeleteRefreshTokensByUser", ctx, "u1").Return(nil)
+
+	assert.NoError(t, svc.KickUserSessions(ctx, "u1"))
+}
+
+func TestSessionMatchesAndAnnotate(t *testing.T) {
+	views := []dto.SessionView{
+		{UserID: "u1", IP: "1.1.1.1", Browser: "Chrome", Username: "alice"},
+		{UserID: "u1", IP: "1.1.1.1", Browser: "Safari", Username: "alice"},
+		{UserID: "u2", IP: "9.9.9.9", Browser: "Firefox", Username: "bob"},
+	}
+	annotateAnomalies(views)
+	assert.True(t, views[0].MultiDevice)
+	assert.False(t, views[0].MultiIP)
+	assert.False(t, views[2].MultiDevice)
+	assert.True(t, sessionMatches(views[0], "chrome"))
+	assert.False(t, sessionMatches(views[0], "zzz"))
+}

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -20,6 +20,7 @@ package response
 //	13000-13999 File module (reserved; #18 type/size checks use 1001)
 //	14000-14999 Runtime configstore (#47)
 //	15000-15999 Data dictionary (#48)
+//	16000-16999 Session management (#50)
 
 const (
 	// ===== Success =====
@@ -156,6 +157,10 @@ const (
 	CodeDictItemNotFound = 15003 // 字典项不存在
 	CodeDictItemExists   = 15004 // 字典项值已存在
 	CodeDictSystemLocked = 15005 // 系统字典类型不可删除
+
+	// ===== Session management (#50, 16000-16999) =====
+	CodeSessionNotFound    = 16001 // 会话不存在或已失效
+	CodeSessionUserOffline = 16002 // 该用户当前没有在线会话
 )
 
 // ModuleRanges maps each module name to its error-code range [min, max].
@@ -176,4 +181,5 @@ var ModuleRanges = map[string][2]int{
 	"file":         {13000, 13999},
 	"configstore":  {14000, 14999},
 	"dict":         {15000, 15999},
+	"session":      {16000, 16999},
 }

--- a/backend/scripts/seed_rbac.go
+++ b/backend/scripts/seed_rbac.go
@@ -85,6 +85,10 @@ func allSeedPermissions() []seedPerm {
 		seedPerm{Name: "发送通知", Code: "notification:send", Resource: "notification", Action: "create"},
 	)
 	perms = append(perms, moduleCRUD("config", "运行时配置")...)
+	perms = append(perms,
+		seedPerm{Name: "会话查看", Code: "session:read", Resource: "session", Action: "read"},
+		seedPerm{Name: "强制下线", Code: "session:delete", Resource: "session", Action: "delete"},
+	)
 	return perms
 }
 

--- a/backend/scripts/seed_test.go
+++ b/backend/scripts/seed_test.go
@@ -127,6 +127,18 @@ func TestAllSeedPermissions_IncludesDict(t *testing.T) {
 	}
 }
 
+func TestAllSeedPermissions_IncludesSession(t *testing.T) {
+	seen := map[string]bool{}
+	for _, p := range allSeedPermissions() {
+		seen[p.Code] = true
+	}
+	for _, need := range []string{"session:read", "session:delete"} {
+		assert.True(t, seen[need], "missing permission %s", need)
+	}
+	assert.False(t, seen["session:create"])
+	assert.False(t, seen["session:update"])
+}
+
 func TestOfficerAndMemberPerms_NonEmpty(t *testing.T) {
 	assert.GreaterOrEqual(t, len(officerPermCodes()), 8)
 	assert.GreaterOrEqual(t, len(memberPermCodes()), 5)

--- a/frontend/src/api/session.ts
+++ b/frontend/src/api/session.ts
@@ -1,0 +1,21 @@
+import request from './request';
+import type { AuthSessionList, UserAuthSessions } from '@/types/api';
+
+export function getSessions(params?: {
+  keyword?: string;
+  user_id?: string;
+}): Promise<AuthSessionList> {
+  return request.get('/auth/sessions', { params });
+}
+
+export function getUserSessions(userId: string): Promise<UserAuthSessions> {
+  return request.get(`/auth/sessions/${encodeURIComponent(userId)}`);
+}
+
+export function kickSession(tokenId: string): Promise<void> {
+  return request.delete(`/auth/sessions/${encodeURIComponent(tokenId)}`);
+}
+
+export function kickUserSessions(userId: string): Promise<void> {
+  return request.delete(`/auth/sessions/user/${encodeURIComponent(userId)}`);
+}

--- a/frontend/src/pages/system/session/SessionPage.tsx
+++ b/frontend/src/pages/system/session/SessionPage.tsx
@@ -1,0 +1,192 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button, Card, Descriptions, Drawer, Input, Modal, Select, Space, Table, Tag, message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { ReloadOutlined } from '@ant-design/icons';
+import { getSessions, getUserSessions, kickSession, kickUserSessions } from '@/api/session';
+import { usePermission } from '@/hooks/usePermission';
+import type { AuthSession, UserAuthSessions } from '@/types/api';
+import './session.css';
+
+const deviceOptions = [
+  { value: 'Desktop', label: '桌面' },
+  { value: 'Mobile', label: '手机' },
+  { value: 'Tablet', label: '平板' },
+  { value: 'Unknown', label: '未知' },
+];
+
+const SessionPage: React.FC = () => {
+  const canKick = usePermission('session:delete');
+  const [list, setList] = useState<AuthSession[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [keyword, setKeyword] = useState('');
+  const [device, setDevice] = useState<string>();
+  const [detail, setDetail] = useState<UserAuthSessions | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getSessions({ keyword: keyword || undefined });
+      setList(res?.list || []);
+    } finally {
+      setLoading(false);
+    }
+  }, [keyword]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => { void load(); }, 10000);
+    return () => window.clearInterval(timer);
+  }, [load]);
+
+  const rows = useMemo(
+    () => (device ? list.filter((s) => s.device === device) : list),
+    [list, device],
+  );
+
+  const openDetail = async (row: AuthSession) => {
+    const data = await getUserSessions(row.user_id);
+    setDetail(data);
+    setDetailOpen(true);
+  };
+
+  const onKickOne = (row: AuthSession) => {
+    Modal.confirm({
+      title: '强制下线该会话',
+      content: `${row.username || row.user_id} · ${row.ip} · ${row.browser}/${row.os}`,
+      okType: 'danger',
+      onOk: async () => {
+        await kickSession(row.token_id);
+        message.success('已强制下线');
+        void load();
+      },
+    });
+  };
+
+  const onKickUser = (row: AuthSession) => {
+    Modal.confirm({
+      title: '下线该用户全部会话',
+      content: `将立即失效 ${row.username || row.user_id} 的所有在线设备。`,
+      okType: 'danger',
+      onOk: async () => {
+        await kickUserSessions(row.user_id);
+        message.success('已下线该用户全部会话');
+        void load();
+        setDetailOpen(false);
+      },
+    });
+  };
+
+  const columns: ColumnsType<AuthSession> = useMemo(() => [
+    { title: '用户', dataIndex: 'username', width: 120, render: (v: string, row) => v || row.user_id.slice(0, 8) },
+    { title: '姓名', dataIndex: 'real_name', width: 100 },
+    { title: 'IP', dataIndex: 'ip', width: 130 },
+    {
+      title: '设备',
+      width: 200,
+      render: (_, row) => (
+        <Space size={4} wrap>
+          <Tag>{row.device}</Tag>
+          <span>{row.browser} / {row.os}</span>
+        </Space>
+      ),
+    },
+    {
+      title: '异常',
+      width: 140,
+      render: (_, row) => (
+        <Space size={4}>
+          {row.multi_device && <Tag color="orange">多设备</Tag>}
+          {row.multi_ip && <Tag color="red">异地</Tag>}
+          {!row.multi_device && !row.multi_ip && <Tag>正常</Tag>}
+        </Space>
+      ),
+    },
+    { title: '登录时间', dataIndex: 'login_at', width: 180, render: (v: string) => v?.replace('T', ' ').slice(0, 19) },
+    {
+      title: '操作',
+      width: 200,
+      render: (_, row) => (
+        <Space>
+          <Button type="link" size="small" onClick={() => void openDetail(row)}>详情</Button>
+          {canKick && <Button type="link" size="small" danger onClick={() => onKickOne(row)}>下线</Button>}
+          {canKick && <Button type="link" size="small" danger onClick={() => onKickUser(row)}>下线全部</Button>}
+        </Space>
+      ),
+    },
+  ], [canKick]);
+
+  return (
+    <div>
+      <div className="sess-hero">
+        <div>
+          <h2>在线会话</h2>
+          <p>查看当前有效 Access Token，强制下线立即拉黑并清除 Refresh Token。列表每 10 秒刷新。</p>
+        </div>
+        <Button size="large" icon={<ReloadOutlined />} onClick={() => void load()}>立即刷新</Button>
+      </div>
+      <Card className="sess-shell">
+        <Space style={{ marginBottom: 16 }} wrap>
+          <Input.Search
+            allowClear
+            placeholder="用户 / IP / 浏览器"
+            onSearch={setKeyword}
+            style={{ width: 240 }}
+          />
+          <Select
+            allowClear
+            placeholder="设备类型"
+            style={{ width: 140 }}
+            value={device}
+            options={deviceOptions}
+            onChange={(v) => setDevice(v)}
+          />
+        </Space>
+        <Table
+          rowKey="token_id"
+          loading={loading}
+          columns={columns}
+          dataSource={rows}
+          pagination={{ pageSize: 20 }}
+        />
+      </Card>
+      <Drawer
+        title="会话详情"
+        width={520}
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
+      >
+        {detail && (
+          <>
+            <Descriptions column={1} size="small" style={{ marginBottom: 16 }}>
+              <Descriptions.Item label="用户">{detail.username || detail.user_id}</Descriptions.Item>
+              <Descriptions.Item label="姓名">{detail.real_name || '-'}</Descriptions.Item>
+              <Descriptions.Item label="异常">
+                <Space>
+                  {detail.multi_device && <Tag color="orange">多设备</Tag>}
+                  {detail.multi_ip && <Tag color="red">异地</Tag>}
+                  {!detail.multi_device && !detail.multi_ip && <Tag>正常</Tag>}
+                </Space>
+              </Descriptions.Item>
+            </Descriptions>
+            {detail.sessions?.map((s) => (
+              <Card key={s.token_id} size="small" style={{ marginBottom: 12 }}>
+                <p>{s.ip} · {s.browser} / {s.os} · {s.device}</p>
+                <p className="sess-ua">{s.user_agent || '-'}</p>
+                <p>登录 {s.login_at?.replace('T', ' ').slice(0, 19)}</p>
+                {canKick && (
+                  <Button danger size="small" onClick={() => onKickOne(s)}>强制下线</Button>
+                )}
+              </Card>
+            ))}
+          </>
+        )}
+      </Drawer>
+    </div>
+  );
+};
+
+export default SessionPage;

--- a/frontend/src/pages/system/session/session.css
+++ b/frontend/src/pages/system/session/session.css
@@ -1,0 +1,35 @@
+.sess-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 24px;
+  margin-bottom: 16px;
+  border-radius: 16px;
+  color: #fff;
+  background: linear-gradient(135deg, #0f766e 0%, #1d4ed8 55%, #7c3aed 100%);
+  box-shadow: 0 12px 32px rgba(15, 118, 110, 0.18);
+}
+
+.sess-hero h2 {
+  margin: 0 0 6px;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.sess-hero p {
+  margin: 0;
+  opacity: 0.88;
+}
+
+.sess-shell {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.sess-ua {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  word-break: break-all;
+}

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -19,6 +19,7 @@ const AuditList = lazy(() => import('@/pages/system/audit/AuditList'));
 const DepartmentPage = lazy(() => import('@/pages/system/department/DepartmentPage'));
 const ConfigPage = lazy(() => import('@/pages/system/config/ConfigPage'));
 const DictPage = lazy(() => import('@/pages/system/dict/DictPage'));
+const SessionPage = lazy(() => import('@/pages/system/session/SessionPage'));
 const FileList = lazy(() => import('@/pages/file/FileList'));
 const ApplicationPage = lazy(() => import('@/pages/member/application/ApplicationPage'));
 const ProfilePage = lazy(() => import('@/pages/member/profile/ProfilePage'));
@@ -324,6 +325,11 @@ const routes: AppRouteObject[] = [
             path: 'config',
             element: lazyGuarded(ConfigPage, 'config:read'),
             meta: { title: '系统配置', permission: 'config:read' },
+          },
+          {
+            path: 'sessions',
+            element: lazyGuarded(SessionPage, 'session:read'),
+            meta: { title: '在线会话', permission: 'session:read' },
           },
         ],
       },

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -88,6 +88,36 @@ export interface UserInfo {
   created_at: string;
 }
 
+export interface AuthSession {
+  token_id: string;
+  user_id: string;
+  username: string;
+  real_name: string;
+  ip: string;
+  user_agent: string;
+  browser: string;
+  os: string;
+  device: string;
+  login_at: string;
+  expires_at: string;
+  multi_device: boolean;
+  multi_ip: boolean;
+}
+
+export interface AuthSessionList {
+  list: AuthSession[];
+  total: number;
+}
+
+export interface UserAuthSessions {
+  user_id: string;
+  username: string;
+  real_name: string;
+  multi_device: boolean;
+  multi_ip: boolean;
+  sessions: AuthSession[];
+}
+
 export interface UserListItem {
   id: string;
   username: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 Issue #50 会话管理：管理员可查看当前有效 Access Token 会话、按用户聚合、解析设备信息，并立即强制下线（拉黑 jti + 删除对应 Refresh Token）。

## 关联 Issue

Closes #50

## 实现要点

- Redis：`auth:session:{jti}` + `auth:user_sessions:{userID}` 索引；Refresh 存 JSON（`user_id`/`jti`），兼容旧纯 userID 字符串
- 刷新 Token 时写入新会话并拉黑旧 jti，避免在线列表过期、被踢后还能续期
- 静态路由 `DELETE /auth/sessions/user/:user_id` 注册在 `DELETE /auth/sessions/:token` 之前（`:token` 实为 access JWT 的 **jti**）
- 权限：`session:read` / `session:delete`（社长/超管全量；部长因 `action=read` 可看列表；强制下线不进部长写权限）
- 前端：系统管理 → 在线会话，按用户/设备筛选、详情抽屉、强制下线；列表 10 秒轮询
- 错误码 16001 会话不存在、16002 用户无在线会话
- User-Agent 粗解析浏览器/OS/设备；异地/多设备打标
- Bugbot：列表 SCAN 补齐未入索引的旧会话；踢人时 SCAN 废掉无 jti 的旧 Refresh

合入后请在开发库执行：`APP_ENV=dev make seed`

## 测试方式

1. 后端：`cd backend && go test ./internal/auth/... ./scripts ./pkg/response/`
2. 登录 admin，打开「系统管理 → 在线会话」
3. 另一客户端再登录，列表出现多设备标记
4. 强制下线后被踢账号再请求 401，Refresh 也无法续期

## 截图 / GIF

[session_admin_list_and_kick.mp4](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_admin_list_and_kick.mp4)

| 页面/功能 | 截图 |
|----------|------|
| 在线会话列表 | [在线会话列表](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_list.webp) |
| 会话详情抽屉 | [会话详情抽屉](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_detail_drawer.webp) |
| 强制下线成功 | [强制下线成功](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_kick_success.webp) |


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

