### PR TITLE
fix(org): 清理旧四部残留，避免被标成中心

### DIFF
--- a/backend/internal/rbac/service/department_service.go
+++ b/backend/internal/rbac/service/department_service.go
@@ -116,10 +116,13 @@ func (s *departmentService) GetTree(ctx context.Context) ([]dto.DepartmentTreeRe
 		return nil, fmt.Errorf("list departments: %w", err)
 	}
 
-	// 按 parent_id 分组子部门
+	// 按 parent_id 分组子部门（停用节点不进树，避免旧部残留冒充根中心）
 	childrenMap := make(map[uuid.UUID][]*model.Department)
 	for i := range depts {
 		dept := &depts[i]
+		if dept.Status != model.DepartmentStatusEnabled {
+			continue
+		}
 		if dept.ParentID != nil {
 			childrenMap[*dept.ParentID] = append(childrenMap[*dept.ParentID], dept)
 		}
@@ -139,7 +142,7 @@ func (s *departmentService) GetTree(ctx context.Context) ([]dto.DepartmentTreeRe
 	tree := make([]dto.DepartmentTreeResponse, 0)
 	for i := range depts {
 		dept := &depts[i]
-		if dept.ParentID == nil {
+		if dept.ParentID == nil && dept.Status == model.DepartmentStatusEnabled {
 			tree = append(tree, *buildDepartmentTree(dept, childrenMap))
 		}
 	}

--- a/backend/scripts/seed_departments.go
+++ b/backend/scripts/seed_departments.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -46,7 +47,10 @@ func seedDepartments(db *gorm.DB) error {
 	if err := remapLegacyDepartments(db); err != nil {
 		return err
 	}
-	return upsertSeedDepartments(db)
+	if err := upsertSeedDepartments(db); err != nil {
+		return err
+	}
+	return retireOrphanLegacyDepartments(db)
 }
 
 func upsertSeedCenters(db *gorm.DB) error {
@@ -119,6 +123,81 @@ func upsertSeedDepartments(db *gorm.DB) error {
 			d.Name, d.Code, d.Description, d.Sort, d.ParentCode,
 		).Error; err != nil {
 			return fmt.Errorf("upsert department %s: %w", d.Code, err)
+		}
+	}
+	return nil
+}
+
+// departmentRefTables 业务表上的 department_id。旧四部与新编码并存时先迁引用再删残留行。
+var departmentRefTables = []string{
+	"users",
+	"member_applications",
+	"member_profiles",
+	"tasks",
+	"interview_sessions",
+	"internships",
+	"internship_records",
+	"finance_budgets",
+	"finance_records",
+}
+
+func lookupDeptID(db *gorm.DB, code string) (string, error) {
+	var id string
+	err := db.Raw(`SELECT id::text FROM departments WHERE code = ?`, code).Scan(&id).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	return id, nil
+}
+
+func retireOrphanLegacyDepartments(db *gorm.DB) error {
+	for _, m := range seedLegacyDeptRemaps {
+		oldID, err := lookupDeptID(db, m.Old)
+		if err != nil {
+			return fmt.Errorf("lookup leftover %s: %w", m.Old, err)
+		}
+		if oldID == "" {
+			continue
+		}
+		newID, err := lookupDeptID(db, m.New)
+		if err != nil {
+			return fmt.Errorf("lookup target %s: %w", m.New, err)
+		}
+		if newID == "" {
+			continue
+		}
+		if err := reassignDepartmentRefs(db, oldID, newID); err != nil {
+			return fmt.Errorf("reassign %s -> %s: %w", m.Old, m.New, err)
+		}
+		if err := db.Exec(`DELETE FROM departments WHERE id = ?`, oldID).Error; err != nil {
+			return fmt.Errorf("delete leftover %s: %w", m.Old, err)
+		}
+	}
+	return nil
+}
+
+func reassignDepartmentRefs(db *gorm.DB, oldID, newID string) error {
+	if err := db.Exec(`
+		DELETE FROM role_data_scopes a
+		USING role_data_scopes b
+		WHERE a.department_id = ?::uuid
+		  AND b.department_id = ?::uuid
+		  AND a.role_permission_id = b.role_permission_id`, oldID, newID).Error; err != nil {
+		return fmt.Errorf("role_data_scopes overlap: %w", err)
+	}
+	if err := db.Exec(
+		`UPDATE role_data_scopes SET department_id = ?::uuid WHERE department_id = ?::uuid`,
+		newID, oldID,
+	).Error; err != nil {
+		return fmt.Errorf("role_data_scopes: %w", err)
+	}
+	for _, table := range departmentRefTables {
+		q := fmt.Sprintf(`UPDATE %s SET department_id = ?::uuid WHERE department_id = ?::uuid`, table)
+		if err := db.Exec(q, newID, oldID).Error; err != nil {
+			return fmt.Errorf("%s: %w", table, err)
 		}
 	}
 	return nil

--- a/backend/scripts/seed_test.go
+++ b/backend/scripts/seed_test.go
@@ -72,6 +72,14 @@ func TestSeedDepartments_CharterLayout(t *testing.T) {
 		assert.False(t, seenOld[m.Old], "duplicate legacy code %s", m.Old)
 		seenOld[m.Old] = true
 	}
+
+	assert.NotEmpty(t, departmentRefTables)
+	seenTbl := map[string]bool{}
+	for _, tbl := range departmentRefTables {
+		assert.NotEmpty(t, tbl)
+		assert.False(t, seenTbl[tbl], "duplicate ref table %s", tbl)
+		seenTbl[tbl] = true
+	}
 }
 
 func TestSeedRoles_OnlyTopRolesAreSystem(t *testing.T) {

--- a/frontend/src/pages/system/department/DepartmentPage.tsx
+++ b/frontend/src/pages/system/department/DepartmentPage.tsx
@@ -9,7 +9,14 @@ import './department.css';
 const { Paragraph, Text } = Typography;
 
 function isCenter(node: Department): boolean {
-  return !node.parent_id;
+  return node.code.startsWith('center_');
+}
+
+function charterTree(nodes: Department[]): Department[] {
+  return nodes.filter(isCenter).map((n) => ({
+    ...n,
+    children: (n.children || []).filter((c) => !isCenter(c)),
+  }));
 }
 
 function flattenLeaves(nodes: Department[]): Department[] {
@@ -73,7 +80,7 @@ const DepartmentPage: React.FC = () => {
     setLoading(true);
     void getDepartmentTree()
       .then((rows) => {
-        const list = rows || [];
+        const list = charterTree(rows || []);
         setTree(list);
         setExpandedKeys(allKeys(list));
         setSelectedId((cur) => cur ?? list[0]?.id);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

部门设置页把旧四部（技术部 / 活动部 / 宣传部 / 外联部）当成根节点，并用「无 parent_id = 中心」打标，看起来像中心下面多出一堆被标成中心的部门。

根因：章程种子先原地改码；若 `project` / `events` / `brand` / `strategy` 已经存在，改码被 `NOT EXISTS` 跳过，旧行一直留在根上。

修复：

- 种子在 upsert 七部之后，把仍存在的旧编码迁引用并删除
- 部门树 API 跳过停用节点
- 前端用 `center_*` 判断中心，且只展示三大中心根节点

## 关联 Issue

章程组织 RC-20260906-002 的数据残留修复（PR #121 之后 dev 库并存旧四部）。

## 测试方式

1. `APP_ENV=dev make seed`
2. `SELECT code FROM departments ORDER BY sort_order` 应为 3 个 `center_*` + 7 个职能部门，不再有 `tech` / `activity` / `publicity` / `liaison`
3. 打开「系统管理 → 部门管理」，树里只有三大中心，子节点标签为「部门」

本地已 seed，库中 10 行（3 中心 + 7 部）。浏览器已确认无旧四部、无误标中心。

## 截图 / GIF

| 页面/功能 | 截图 |
|----------|------|
| 三大中心 + 七部，无旧四部 | [组织架构三大中心](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdept-org-three-centers.webp) |
| 职能部门标签正确 | [项目开发部为职能部门](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdept-org-functional-tag.webp) |

## 注意事项

- 合入后请再跑一次 `APP_ENV=dev make seed`，清掉已有库里的旧四部
- 旧部若仍被用户/申请/任务引用，会先改到对应新部门再删行
- 不合并任何 Autofix 旁路

## 检查清单

- [x] 代码遵循项目开发规范
- [x] 已进行自测
- [x] 已添加/更新必要的文档
- [ ] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

