### PR TITLE
feat(stats): 数据统计与 ECharts 可视化报表 (#11)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -53,6 +53,9 @@ import (
 	schedService "github.com/Yogdunana/StarByte/backend/internal/scheduler/service"
 	searchHandler "github.com/Yogdunana/StarByte/backend/internal/search/handler"
 	searchService "github.com/Yogdunana/StarByte/backend/internal/search/service"
+	statsHandler "github.com/Yogdunana/StarByte/backend/internal/stats/handler"
+	statsRepo "github.com/Yogdunana/StarByte/backend/internal/stats/repo"
+	statsService "github.com/Yogdunana/StarByte/backend/internal/stats/service"
 	taskHandler "github.com/Yogdunana/StarByte/backend/internal/task/handler"
 	taskRepo "github.com/Yogdunana/StarByte/backend/internal/task/repo"
 	taskService "github.com/Yogdunana/StarByte/backend/internal/task/service"
@@ -393,6 +396,11 @@ func main() {
 		searchSvc := searchService.NewSearchService(database.DB())
 		searchH := searchHandler.NewSearchHandler(searchSvc, database.DB(), deptRepo, cacheService)
 		searchHandler.RegisterRoutes(protected, searchH, cacheService)
+
+		// 数据统计（/stats，#11）
+		statsSvc := statsService.NewStatsService(statsRepo.NewStatsRepo(database.DB()))
+		statsH := statsHandler.NewStatsHandler(statsSvc)
+		statsHandler.RegisterRoutes(protected, statsH, cacheService)
 
 		// 审计日志模块路由（/system/audit-logs，audit:read / audit:export / audit:archive / audit:report）
 		auditHandler.RegisterRoutes(protected, auditH, cacheService)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -400,7 +400,7 @@ func main() {
 		// 数据统计（/stats，#11）
 		statsSvc := statsService.NewStatsService(statsRepo.NewStatsRepo(database.DB()))
 		statsH := statsHandler.NewStatsHandler(statsSvc)
-		statsHandler.RegisterRoutes(protected, statsH, cacheService)
+		statsHandler.RegisterRoutes(protected, statsH, cacheService, database.DB(), deptRepo)
 
 		// 审计日志模块路由（/system/audit-logs，audit:read / audit:export / audit:archive / audit:report）
 		auditHandler.RegisterRoutes(protected, auditH, cacheService)

--- a/backend/internal/stats/dto/types.go
+++ b/backend/internal/stats/dto/types.go
@@ -1,0 +1,79 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// StatsQuery 统一查询参数。
+type StatsQuery struct {
+	StartDate    *time.Time `form:"start_date" json:"start_date"`
+	EndDate      *time.Time `form:"end_date" json:"end_date"`
+	DepartmentID *uuid.UUID `form:"department_id" json:"department_id"`
+	GroupBy      string     `form:"group_by" json:"group_by"`
+	Granularity  string     `form:"granularity" json:"granularity"`
+	Format       string     `form:"format" json:"format"`
+}
+
+// ProviderInfo 注册中心对外描述。
+type ProviderInfo struct {
+	Name        string       `json:"name"`
+	DisplayName string       `json:"display_name"`
+	ChartConfig *ChartConfig `json:"chart_config"`
+}
+
+// ChartConfig 图表建议。
+type ChartConfig struct {
+	ChartType  string `json:"chart_type"`
+	Title      string `json:"title"`
+	Stack      bool   `json:"stack"`
+	Horizontal bool   `json:"horizontal"`
+}
+
+// DataPoint 单点。
+type DataPoint struct {
+	Label string  `json:"label"`
+	Value float64 `json:"value"`
+}
+
+// DataSeries 数据系列。
+type DataSeries struct {
+	Name  string      `json:"name"`
+	Type  string      `json:"type"`
+	Data  []DataPoint `json:"data"`
+	XAxis []string    `json:"x_axis"`
+}
+
+// StatsResult 统计结果。
+type StatsResult struct {
+	Provider    string         `json:"provider"`
+	Summary     map[string]any `json:"summary"`
+	Series      []DataSeries   `json:"series"`
+	ChartConfig *ChartConfig   `json:"chart_config"`
+}
+
+// OverviewMeeting 今日会议。
+type OverviewMeeting struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	StartTime string `json:"start_time"`
+}
+
+// OverviewMyTasks 我的任务计数。
+type OverviewMyTasks struct {
+	Todo    int64 `json:"todo"`
+	Overdue int64 `json:"overdue"`
+}
+
+// OverviewResponse 首页概览。
+type OverviewResponse struct {
+	TotalMembers           int64             `json:"total_members"`
+	TotalMeetingsThisMonth int64             `json:"total_meetings_this_month"`
+	TotalTasksInProgress   int64             `json:"total_tasks_in_progress"`
+	TotalInternshipsActive int64             `json:"total_internships_active"`
+	PendingApprovals       int64             `json:"pending_approvals"`
+	TodayMeetings          []OverviewMeeting `json:"today_meetings"`
+	MyTasks                OverviewMyTasks   `json:"my_tasks"`
+	NotificationsUnread    int64             `json:"notifications_unread"`
+}

--- a/backend/internal/stats/dto/types.go
+++ b/backend/internal/stats/dto/types.go
@@ -8,12 +8,15 @@ import (
 
 // StatsQuery 统一查询参数。
 type StatsQuery struct {
-	StartDate    *time.Time `form:"start_date" json:"start_date"`
-	EndDate      *time.Time `form:"end_date" json:"end_date"`
-	DepartmentID *uuid.UUID `form:"department_id" json:"department_id"`
-	GroupBy      string     `form:"group_by" json:"group_by"`
-	Granularity  string     `form:"granularity" json:"granularity"`
-	Format       string     `form:"format" json:"format"`
+	StartDate    *time.Time  `form:"start_date" json:"start_date"`
+	EndDate      *time.Time  `form:"end_date" json:"end_date"`
+	DepartmentID *uuid.UUID  `form:"department_id" json:"department_id"`
+	GroupBy      string      `form:"group_by" json:"group_by"`
+	Granularity  string      `form:"granularity" json:"granularity"`
+	Format       string      `form:"format" json:"format"`
+	Denied       bool        `json:"-"`
+	AllScope     bool        `json:"-"`
+	ScopeDeptIDs []uuid.UUID `json:"-"`
 }
 
 // ProviderInfo 注册中心对外描述。

--- a/backend/internal/stats/handler/handler.go
+++ b/backend/internal/stats/handler/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/stats/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
 	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/gin-gonic/gin"
@@ -76,7 +77,7 @@ func (h *StatsHandler) serve(c *gin.Context, code string) {
 		response.Error(c, err)
 		return
 	}
-	res, err := h.svc.GetStats(c.Request.Context(), code, q)
+	res, err := h.svc.GetStats(c.Request.Context(), code, applyScope(c, q))
 	if err != nil {
 		response.Error(c, err)
 		return
@@ -100,7 +101,7 @@ func (h *StatsHandler) Export(c *gin.Context) {
 		return
 	}
 	format := c.DefaultQuery("format", "excel")
-	data, filename, err := h.svc.Export(c.Request.Context(), c.Param("provider"), format, q)
+	data, filename, err := h.svc.Export(c.Request.Context(), c.Param("provider"), format, applyScope(c, q))
 	if err != nil {
 		response.Error(c, err)
 		return
@@ -134,6 +135,45 @@ func bindQuery(c *gin.Context) (*dto.StatsQuery, error) {
 		q.DepartmentID = &id
 	}
 	return q, nil
+}
+
+func applyScope(c *gin.Context, q *dto.StatsQuery) *dto.StatsQuery {
+	if q == nil {
+		q = &dto.StatsQuery{}
+	}
+	scope := middleware.GetDataScopeFromContext(c)
+	if scope == nil || scope.IsEmpty() {
+		q.AllScope = true
+		return q
+	}
+	q.AllScope = false
+	if scope.Query == "1 = 0" {
+		q.Denied = true
+		return q
+	}
+	q.ScopeDeptIDs = extractScopeDeptIDs(scope.Args)
+	return q
+}
+
+func extractScopeDeptIDs(args []interface{}) []uuid.UUID {
+	out := make([]uuid.UUID, 0)
+	for _, arg := range args {
+		switch v := arg.(type) {
+		case uuid.UUID:
+			out = append(out, v)
+		case *uuid.UUID:
+			if v != nil {
+				out = append(out, *v)
+			}
+		case []uuid.UUID:
+			out = append(out, v...)
+		case string:
+			if id, err := uuid.Parse(v); err == nil {
+				out = append(out, id)
+			}
+		}
+	}
+	return out
 }
 
 func parseDate(raw string, endOfDay bool) (*time.Time, error) {

--- a/backend/internal/stats/handler/handler.go
+++ b/backend/internal/stats/handler/handler.go
@@ -1,0 +1,154 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/stats/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type StatsHandler struct {
+	svc service.StatsService
+}
+
+func NewStatsHandler(svc service.StatsService) *StatsHandler {
+	return &StatsHandler{svc: svc}
+}
+
+// Providers 统计提供者列表
+// @Summary 列出统计提供者
+// @Tags 数据统计
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} response.Response{data=[]dto.ProviderInfo}
+// @Router /stats/providers [get]
+func (h *StatsHandler) Providers(c *gin.Context) {
+	response.OK(c, h.svc.ListProviders())
+}
+
+// Overview 首页概览
+// @Summary 获取统计概览
+// @Tags 数据统计
+// @Produce json
+// @Security Bearer
+// @Success 200 {object} response.Response{data=dto.OverviewResponse}
+// @Router /stats/overview [get]
+func (h *StatsHandler) Overview(c *gin.Context) {
+	uid, _ := uuid.Parse(auth.GetUserID(c))
+	res, err := h.svc.Overview(c.Request.Context(), uid)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, res)
+}
+
+// Get 按提供者查询统计
+// @Summary 获取指定提供者的统计数据
+// @Tags 数据统计
+// @Produce json
+// @Security Bearer
+// @Param provider path string true "提供者名称"
+// @Param start_date query string false "开始日期 YYYY-MM-DD"
+// @Param end_date query string false "结束日期 YYYY-MM-DD"
+// @Param department_id query string false "部门ID"
+// @Param group_by query string false "分组 date/department/type/status/grade"
+// @Param granularity query string false "粒度 day/week/month"
+// @Success 200 {object} response.Response{data=dto.StatsResult}
+// @Router /stats/{provider} [get]
+func (h *StatsHandler) Get(c *gin.Context) {
+	h.serve(c, c.Param("provider"))
+}
+
+func (h *StatsHandler) serveNamed(code string) gin.HandlerFunc {
+	return func(c *gin.Context) { h.serve(c, code) }
+}
+
+func (h *StatsHandler) serve(c *gin.Context, code string) {
+	q, err := bindQuery(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	res, err := h.svc.GetStats(c.Request.Context(), code, q)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, res)
+}
+
+// Export 导出统计数据
+// @Summary 导出统计数据 CSV/Excel
+// @Tags 数据统计
+// @Produce application/octet-stream
+// @Security Bearer
+// @Param provider path string true "提供者名称"
+// @Param format query string false "csv 或 excel" Enums(csv, excel)
+// @Success 200 {file} file "导出文件"
+// @Router /stats/export/{provider} [get]
+func (h *StatsHandler) Export(c *gin.Context) {
+	q, err := bindQuery(c)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	format := c.DefaultQuery("format", "excel")
+	data, filename, err := h.svc.Export(c.Request.Context(), c.Param("provider"), format, q)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	c.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	c.Header("Content-Transfer-Encoding", "binary")
+	c.Data(http.StatusOK, "application/octet-stream", data)
+}
+
+func bindQuery(c *gin.Context) (*dto.StatsQuery, error) {
+	q := &dto.StatsQuery{
+		GroupBy:     strings.TrimSpace(c.Query("group_by")),
+		Granularity: strings.TrimSpace(c.Query("granularity")),
+		Format:      strings.TrimSpace(c.Query("format")),
+	}
+	start, err := parseDate(c.Query("start_date"), false)
+	if err != nil {
+		return nil, response.NewError(response.CodeStatsInvalidParam, "查询参数无效")
+	}
+	end, err := parseDate(c.Query("end_date"), true)
+	if err != nil {
+		return nil, response.NewError(response.CodeStatsInvalidParam, "查询参数无效")
+	}
+	q.StartDate = start
+	q.EndDate = end
+	if raw := strings.TrimSpace(c.Query("department_id")); raw != "" {
+		id, perr := uuid.Parse(raw)
+		if perr != nil {
+			return nil, response.NewError(response.CodeStatsInvalidParam, "查询参数无效")
+		}
+		q.DepartmentID = &id
+	}
+	return q, nil
+}
+
+func parseDate(raw string, endOfDay bool) (*time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return &t, nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02", raw, time.Local); err == nil {
+		if endOfDay {
+			t = t.Add(24*time.Hour - time.Nanosecond)
+		}
+		return &t, nil
+	}
+	return nil, response.NewError(response.CodeStatsInvalidParam, "查询参数无效")
+}

--- a/backend/internal/stats/handler/handler_test.go
+++ b/backend/internal/stats/handler/handler_test.go
@@ -1,0 +1,135 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+type stubSvc struct {
+	providers []dto.ProviderInfo
+	result    *dto.StatsResult
+	overview  *dto.OverviewResponse
+	bytes     []byte
+	filename  string
+	err       error
+}
+
+func (s *stubSvc) ListProviders() []dto.ProviderInfo { return s.providers }
+func (s *stubSvc) GetStats(context.Context, string, *dto.StatsQuery) (*dto.StatsResult, error) {
+	return s.result, s.err
+}
+func (s *stubSvc) Overview(context.Context, uuid.UUID) (*dto.OverviewResponse, error) {
+	return s.overview, s.err
+}
+func (s *stubSvc) Export(context.Context, string, string, *dto.StatsQuery) ([]byte, string, error) {
+	return s.bytes, s.filename, s.err
+}
+
+func doGET(h gin.HandlerFunc, path string, params gin.Params) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, path, nil)
+	c.Params = params
+	c.Set("request_id", "rid")
+	c.Set("user_id", uuid.New().String())
+	h(c)
+	return w
+}
+
+func TestProviders(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{providers: []dto.ProviderInfo{{Name: "member-distribution", DisplayName: "会员分布统计"}}})
+	w := doGET(h.Providers, "/api/v1/stats/providers", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestOverview(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{overview: &dto.OverviewResponse{TotalMembers: 10}})
+	w := doGET(h.Overview, "/api/v1/stats/overview", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp response.Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.Code)
+}
+
+func TestGet_OK(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{result: &dto.StatsResult{Provider: "member-distribution"}})
+	w := doGET(h.Get, "/api/v1/stats/member-distribution", gin.Params{{Key: "provider", Value: "member-distribution"}})
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGet_InvalidDepartment(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{result: &dto.StatsResult{Provider: "x"}})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/stats/member-distribution?department_id=not-uuid", nil)
+	c.Params = gin.Params{{Key: "provider", Value: "member-distribution"}}
+	c.Set("request_id", "rid")
+	h.Get(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGet_InvalidDate(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/stats/member-distribution?start_date=bogus", nil)
+	c.Params = gin.Params{{Key: "provider", Value: "member-distribution"}}
+	c.Set("request_id", "rid")
+	h.Get(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGet_ServiceError(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{err: response.NewError(response.CodeStatsProviderNotFound, "统计提供者不存在")})
+	w := doGET(h.Get, "/api/v1/stats/missing", gin.Params{{Key: "provider", Value: "missing"}})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestExport_OK(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{bytes: []byte("a,b"), filename: "stats_member-distribution.csv"})
+	w := doGET(h.Export, "/api/v1/stats/export/member-distribution?format=csv", gin.Params{{Key: "provider", Value: "member-distribution"}})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "stats_member-distribution.csv")
+}
+
+func TestExport_Error(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{err: response.NewError(response.CodeStatsExportFormat, "导出格式不支持")})
+	w := doGET(h.Export, "/api/v1/stats/export/member-distribution?format=pdf", gin.Params{{Key: "provider", Value: "member-distribution"}})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRegisterRoutes(t *testing.T) {
+	assert.NotPanics(t, func() {
+		RegisterRoutes(gin.New().Group("/api/v1"), NewStatsHandler(&stubSvc{}), nil)
+	})
+}
+
+func TestServeNamed(t *testing.T) {
+	h := NewStatsHandler(&stubSvc{result: &dto.StatsResult{Provider: "task-progress"}})
+	w := doGET(h.serveNamed("task-progress"), "/api/v1/stats/task-progress", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBindQueryDates(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x?start_date=2026-01-01&end_date=2026-01-31&group_by=department&granularity=month", nil)
+	q, err := bindQuery(c)
+	require.NoError(t, err)
+	require.NotNil(t, q.StartDate)
+	require.NotNil(t, q.EndDate)
+	assert.Equal(t, "department", q.GroupBy)
+	assert.Equal(t, "month", q.Granularity)
+}

--- a/backend/internal/stats/handler/handler_test.go
+++ b/backend/internal/stats/handler/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	rbacModel "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/gin-gonic/gin"
@@ -112,7 +113,7 @@ func TestExport_Error(t *testing.T) {
 
 func TestRegisterRoutes(t *testing.T) {
 	assert.NotPanics(t, func() {
-		RegisterRoutes(gin.New().Group("/api/v1"), NewStatsHandler(&stubSvc{}), nil)
+		RegisterRoutes(gin.New().Group("/api/v1"), NewStatsHandler(&stubSvc{}), nil, nil, nil)
 	})
 }
 
@@ -120,6 +121,36 @@ func TestServeNamed(t *testing.T) {
 	h := NewStatsHandler(&stubSvc{result: &dto.StatsResult{Provider: "task-progress"}})
 	w := doGET(h.serveNamed("task-progress"), "/api/v1/stats/task-progress", nil)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestApplyScopeAllAndDenied(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x", nil)
+	q := applyScope(c, &dto.StatsQuery{})
+	assert.True(t, q.AllScope)
+	assert.False(t, q.Denied)
+
+	deptID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	c.Set("data_scope_condition", &rbacModel.DataScopeCondition{
+		Query: "department_id = ?",
+		Args:  []interface{}{deptID},
+	})
+	q = applyScope(c, &dto.StatsQuery{})
+	assert.False(t, q.AllScope)
+	assert.Equal(t, []uuid.UUID{deptID}, q.ScopeDeptIDs)
+
+	c.Set("data_scope_condition", &rbacModel.DataScopeCondition{Query: "1 = 0"})
+	q = applyScope(c, nil)
+	assert.True(t, q.Denied)
+	assert.False(t, q.AllScope)
+}
+
+func TestExtractScopeDeptIDs(t *testing.T) {
+	d1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	d2 := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	ids := extractScopeDeptIDs([]interface{}{d1, &d2, []uuid.UUID{d1}, d1.String(), "not-uuid"})
+	assert.Equal(t, []uuid.UUID{d1, d2, d1, d1}, ids)
 }
 
 func TestBindQueryDates(t *testing.T) {

--- a/backend/internal/stats/handler/routes.go
+++ b/backend/internal/stats/handler/routes.go
@@ -1,9 +1,11 @@
 package handler
 
 import (
+	rbacRepo "github.com/Yogdunana/StarByte/backend/internal/rbac/repo"
 	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
 	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
@@ -13,14 +15,35 @@ func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacSe
 	return g
 }
 
+func withStatsScope(
+	group *gin.RouterGroup,
+	permCode string,
+	cacheService rbacService.PermissionCacheService,
+	db *gorm.DB,
+	deptRepo rbacRepo.DepartmentRepo,
+) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.RequireDataScope("stats"))
+	g.Use(middleware.PermissionRequired(cacheService))
+	g.Use(middleware.DataScopeMiddleware(db, deptRepo, cacheService))
+	return g
+}
+
 // RegisterRoutes 注册 /api/v1/stats。静态路径必须在 /:provider 之前。
-func RegisterRoutes(r *gin.RouterGroup, h *StatsHandler, cacheService rbacService.PermissionCacheService) {
+func RegisterRoutes(
+	r *gin.RouterGroup,
+	h *StatsHandler,
+	cacheService rbacService.PermissionCacheService,
+	db *gorm.DB,
+	deptRepo rbacRepo.DepartmentRepo,
+) {
 	g := r.Group("/stats")
 	g.GET("/providers", h.Providers)
 	g.GET("/overview", h.Overview)
-	withPermission(g, "stats:export", cacheService).GET("/export/:provider", h.Export)
+	withStatsScope(g, "stats:export", cacheService, db, deptRepo).GET("/export/:provider", h.Export)
 
-	read := withPermission(g, "stats:read", cacheService)
+	read := withStatsScope(g, "stats:read", cacheService, db, deptRepo)
 	read.GET("/member-distribution", h.serveNamed("member-distribution"))
 	read.GET("/interview-data", h.serveNamed("interview-data"))
 	read.GET("/meeting-attendance", h.serveNamed("meeting-attendance"))

--- a/backend/internal/stats/handler/routes.go
+++ b/backend/internal/stats/handler/routes.go
@@ -1,0 +1,30 @@
+package handler
+
+import (
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
+}
+
+// RegisterRoutes 注册 /api/v1/stats。静态路径必须在 /:provider 之前。
+func RegisterRoutes(r *gin.RouterGroup, h *StatsHandler, cacheService rbacService.PermissionCacheService) {
+	g := r.Group("/stats")
+	g.GET("/providers", h.Providers)
+	g.GET("/overview", h.Overview)
+	withPermission(g, "stats:export", cacheService).GET("/export/:provider", h.Export)
+
+	read := withPermission(g, "stats:read", cacheService)
+	read.GET("/member-distribution", h.serveNamed("member-distribution"))
+	read.GET("/interview-data", h.serveNamed("interview-data"))
+	read.GET("/meeting-attendance", h.serveNamed("meeting-attendance"))
+	read.GET("/task-progress", h.serveNamed("task-progress"))
+	read.GET("/internship-duration", h.serveNamed("internship-duration"))
+	read.GET("/:provider", h.Get)
+}

--- a/backend/internal/stats/repo/filter.go
+++ b/backend/internal/stats/repo/filter.go
@@ -1,0 +1,73 @@
+package repo
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Query 仓储层筛选。
+type Query struct {
+	Start        *time.Time
+	End          *time.Time
+	DepartmentID *uuid.UUID
+	Granularity  string
+}
+
+// Bucket 分组桶。
+type Bucket struct {
+	Key   string
+	Label string
+	Value float64
+}
+
+func truncExpr(col, granularity string) string {
+	g := strings.ToLower(strings.TrimSpace(granularity))
+	unit := "month"
+	switch g {
+	case "day":
+		unit = "day"
+	case "week":
+		unit = "week"
+	}
+	return "to_char(date_trunc('" + unit + "', " + col + "), 'YYYY-MM-DD')"
+}
+
+func applyRange(db *gorm.DB, col string, q Query) *gorm.DB {
+	if q.Start != nil {
+		db = db.Where(col+" >= ?", *q.Start)
+	}
+	if q.End != nil {
+		db = db.Where(col+" <= ?", *q.End)
+	}
+	return db
+}
+
+func applyDept(db *gorm.DB, col string, id *uuid.UUID) *gorm.DB {
+	if id == nil {
+		return db
+	}
+	return db.Where(col+" = ?", *id)
+}
+
+func scanBuckets(db *gorm.DB) ([]Bucket, error) {
+	var rows []struct {
+		K string  `gorm:"column:k"`
+		L string  `gorm:"column:l"`
+		V float64 `gorm:"column:v"`
+	}
+	if err := db.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make([]Bucket, 0, len(rows))
+	for _, r := range rows {
+		label := r.L
+		if label == "" {
+			label = r.K
+		}
+		out = append(out, Bucket{Key: r.K, Label: label, Value: r.V})
+	}
+	return out, nil
+}

--- a/backend/internal/stats/repo/filter.go
+++ b/backend/internal/stats/repo/filter.go
@@ -13,7 +13,11 @@ type Query struct {
 	Start        *time.Time
 	End          *time.Time
 	DepartmentID *uuid.UUID
+	DeptIDs      []uuid.UUID
 	Granularity  string
+	Denied       bool
+	AllScope     bool
+	HideRanking  bool
 }
 
 // Bucket 分组桶。
@@ -45,11 +49,27 @@ func applyRange(db *gorm.DB, col string, q Query) *gorm.DB {
 	return db
 }
 
-func applyDept(db *gorm.DB, col string, id *uuid.UUID) *gorm.DB {
-	if id == nil {
-		return db
+func applyDept(db *gorm.DB, col string, q Query) *gorm.DB {
+	if q.Denied {
+		return db.Where("1 = 0")
 	}
-	return db.Where(col+" = ?", *id)
+	if q.DepartmentID != nil {
+		db = db.Where(col+" = ?", *q.DepartmentID)
+	}
+	if len(q.DeptIDs) > 0 {
+		db = db.Where(col+" IN ?", q.DeptIDs)
+	}
+	return db
+}
+
+func applyOverlap(db *gorm.DB, startCol, endCol string, q Query) *gorm.DB {
+	if q.Start != nil {
+		db = db.Where("("+endCol+" IS NULL OR "+endCol+" >= ?)", *q.Start)
+	}
+	if q.End != nil {
+		db = db.Where(startCol+" <= ?", *q.End)
+	}
+	return db
 }
 
 func scanBuckets(db *gorm.DB) ([]Bucket, error) {

--- a/backend/internal/stats/repo/filter.go
+++ b/backend/internal/stats/repo/filter.go
@@ -72,6 +72,28 @@ func applyOverlap(db *gorm.DB, startCol, endCol string, q Query) *gorm.DB {
 	return db
 }
 
+func dateLit(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+func clipStartSQL(q Query) string {
+	if q.Start == nil {
+		return "i.start_date"
+	}
+	return "GREATEST(i.start_date, DATE '" + dateLit(*q.Start) + "')"
+}
+
+func clipEndSQL(q Query) string {
+	if q.End == nil {
+		return "COALESCE(i.end_date, CURRENT_DATE)"
+	}
+	return "LEAST(COALESCE(i.end_date, CURRENT_DATE), DATE '" + dateLit(*q.End) + "')"
+}
+
+func clippedDaysSQL(q Query) string {
+	return "GREATEST(0, (" + clipEndSQL(q) + " - " + clipStartSQL(q) + "))"
+}
+
 func scanBuckets(db *gorm.DB) ([]Bucket, error) {
 	var rows []struct {
 		K string  `gorm:"column:k"`

--- a/backend/internal/stats/repo/filter.go
+++ b/backend/internal/stats/repo/filter.go
@@ -76,6 +76,15 @@ func dateLit(t time.Time) string {
 	return t.Format("2006-01-02")
 }
 
+func exclusiveDate(t time.Time) time.Time {
+	d := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	return d.AddDate(0, 0, 1)
+}
+
+func internEndExclusiveSQL() string {
+	return "(COALESCE(i.end_date, CURRENT_DATE) + 1)"
+}
+
 func clipStartSQL(q Query) string {
 	if q.Start == nil {
 		return "i.start_date"
@@ -84,10 +93,11 @@ func clipStartSQL(q Query) string {
 }
 
 func clipEndSQL(q Query) string {
+	intern := internEndExclusiveSQL()
 	if q.End == nil {
-		return "COALESCE(i.end_date, CURRENT_DATE)"
+		return intern
 	}
-	return "LEAST(COALESCE(i.end_date, CURRENT_DATE), DATE '" + dateLit(*q.End) + "')"
+	return "LEAST(" + intern + ", DATE '" + dateLit(exclusiveDate(*q.End)) + "')"
 }
 
 func clippedDaysSQL(q Query) string {

--- a/backend/internal/stats/repo/filter_test.go
+++ b/backend/internal/stats/repo/filter_test.go
@@ -25,11 +25,14 @@ func TestTruncExpr(t *testing.T) {
 
 func TestQueryFlags(t *testing.T) {
 	id := uuid.New()
-	q := Query{Denied: true, DepartmentID: &id, DeptIDs: []uuid.UUID{id}, AllScope: false, HideRanking: true}
-	assert.True(t, q.Denied)
-	assert.True(t, q.HideRanking)
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
-	overlap := Query{Start: &start, End: &end}
-	assert.False(t, overlap.End.Before(*overlap.Start))
+	q := Query{Denied: true, DepartmentID: &id, DeptIDs: []uuid.UUID{id}, HideRanking: true, Start: &start, End: &end}
+	assert.True(t, q.Denied)
+	assert.Equal(t, id, *q.DepartmentID)
+	assert.Equal(t, []uuid.UUID{id}, q.DeptIDs)
+	assert.True(t, q.HideRanking)
+	assert.Contains(t, clippedDaysSQL(q), "2026-01-01")
+	assert.Contains(t, clippedDaysSQL(q), "2026-01-31")
+	assert.Equal(t, "GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date))", clippedDaysSQL(Query{}))
 }

--- a/backend/internal/stats/repo/filter_test.go
+++ b/backend/internal/stats/repo/filter_test.go
@@ -33,6 +33,11 @@ func TestQueryFlags(t *testing.T) {
 	assert.Equal(t, []uuid.UUID{id}, q.DeptIDs)
 	assert.True(t, q.HideRanking)
 	assert.Contains(t, clippedDaysSQL(q), "2026-01-01")
-	assert.Contains(t, clippedDaysSQL(q), "2026-01-31")
-	assert.Equal(t, "GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date))", clippedDaysSQL(Query{}))
+	assert.Contains(t, clippedDaysSQL(q), "2026-02-01")
+	assert.NotContains(t, clippedDaysSQL(q), "DATE '2026-01-31'")
+	endOfDay := time.Date(2026, 1, 31, 23, 59, 59, 999999999, time.UTC)
+	today := time.Date(2026, 9, 6, 23, 59, 59, 999999999, time.Local)
+	assert.Contains(t, clippedDaysSQL(Query{Start: &endOfDay, End: &endOfDay}), "2026-02-01")
+	assert.Contains(t, clippedDaysSQL(Query{Start: &today, End: &today}), "2026-09-07")
+	assert.Equal(t, "GREATEST(0, ((COALESCE(i.end_date, CURRENT_DATE) + 1) - i.start_date))", clippedDaysSQL(Query{}))
 }

--- a/backend/internal/stats/repo/filter_test.go
+++ b/backend/internal/stats/repo/filter_test.go
@@ -1,0 +1,18 @@
+package repo
+
+import "testing"
+
+func TestTruncExpr(t *testing.T) {
+	if got := truncExpr("created_at", "day"); got != "to_char(date_trunc('day', created_at), 'YYYY-MM-DD')" {
+		t.Fatalf("day: %s", got)
+	}
+	if got := truncExpr("m.start_time", "week"); got != "to_char(date_trunc('week', m.start_time), 'YYYY-MM-DD')" {
+		t.Fatalf("week: %s", got)
+	}
+	if got := truncExpr("created_at", "MONTH"); got != "to_char(date_trunc('month', created_at), 'YYYY-MM-DD')" {
+		t.Fatalf("month: %s", got)
+	}
+	if got := truncExpr("created_at", ""); got != "to_char(date_trunc('month', created_at), 'YYYY-MM-DD')" {
+		t.Fatalf("default: %s", got)
+	}
+}

--- a/backend/internal/stats/repo/filter_test.go
+++ b/backend/internal/stats/repo/filter_test.go
@@ -1,6 +1,12 @@
 package repo
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestTruncExpr(t *testing.T) {
 	if got := truncExpr("created_at", "day"); got != "to_char(date_trunc('day', created_at), 'YYYY-MM-DD')" {
@@ -15,4 +21,15 @@ func TestTruncExpr(t *testing.T) {
 	if got := truncExpr("created_at", ""); got != "to_char(date_trunc('month', created_at), 'YYYY-MM-DD')" {
 		t.Fatalf("default: %s", got)
 	}
+}
+
+func TestQueryFlags(t *testing.T) {
+	id := uuid.New()
+	q := Query{Denied: true, DepartmentID: &id, DeptIDs: []uuid.UUID{id}, AllScope: false, HideRanking: true}
+	assert.True(t, q.Denied)
+	assert.True(t, q.HideRanking)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+	overlap := Query{Start: &start, End: &end}
+	assert.False(t, overlap.End.Before(*overlap.Start))
 }

--- a/backend/internal/stats/repo/internship.go
+++ b/backend/internal/stats/repo/internship.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
@@ -9,11 +10,14 @@ import (
 )
 
 func (r *statsRepo) InternshipRanking(ctx context.Context, q Query) ([]Bucket, error) {
+	if q.HideRanking {
+		return []Bucket{}, nil
+	}
 	db := r.db.WithContext(ctx).Table("internships AS i").
 		Joins("JOIN users u ON u.id = i.user_id").
 		Select("u.id::text AS k, COALESCE(NULLIF(u.real_name, ''), u.username) AS l, SUM(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
-	db = applyDept(db, "i.department_id", q.DepartmentID)
-	db = applyRange(db, "i.start_date", q)
+	db = applyDept(db, "i.department_id", q)
+	db = applyOverlap(db, "i.start_date", "i.end_date", q)
 	return scanBuckets(db.Group("u.id, u.real_name, u.username").Order("v DESC").Limit(15))
 }
 
@@ -21,8 +25,8 @@ func (r *statsRepo) InternshipDeptAvg(ctx context.Context, q Query) ([]Bucket, e
 	db := r.db.WithContext(ctx).Table("internships AS i").
 		Joins("LEFT JOIN departments d ON d.id = i.department_id").
 		Select("COALESCE(i.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, AVG(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
-	db = applyDept(db, "i.department_id", q.DepartmentID)
-	db = applyRange(db, "i.start_date", q)
+	db = applyDept(db, "i.department_id", q)
+	db = applyOverlap(db, "i.start_date", "i.end_date", q)
 	return scanBuckets(db.Group("i.department_id, d.name").Order("v DESC"))
 }
 
@@ -30,9 +34,27 @@ func (r *statsRepo) InternshipTrend(ctx context.Context, q Query) ([]Bucket, err
 	expr := truncExpr("i.start_date", q.Granularity)
 	db := r.db.WithContext(ctx).Table("internships AS i").
 		Select(expr + " AS k, " + expr + " AS l, SUM(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
-	db = applyDept(db, "i.department_id", q.DepartmentID)
-	db = applyRange(db, "i.start_date", q)
+	db = applyDept(db, "i.department_id", q)
+	db = applyOverlap(db, "i.start_date", "i.end_date", q)
 	return scanBuckets(db.Group("k, l").Order("k"))
+}
+
+func (r *statsRepo) RankingHidden(ctx context.Context) (bool, error) {
+	var raw string
+	err := r.db.WithContext(ctx).Table("configs").Select("config_value").Where("config_key = ?", "internship_config").Limit(1).Scan(&raw).Error
+	if err != nil {
+		return false, err
+	}
+	if raw == "" {
+		return false, nil
+	}
+	var cfg struct {
+		RankingVisible *bool `json:"ranking_visible"`
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil || cfg.RankingVisible == nil {
+		return false, nil
+	}
+	return !*cfg.RankingVisible, nil
 }
 
 func (r *statsRepo) Overview(ctx context.Context, userID uuid.UUID) (*dto.OverviewResponse, error) {
@@ -45,7 +67,7 @@ func (r *statsRepo) Overview(ctx context.Context, userID uuid.UUID) (*dto.Overvi
 	if err := r.db.WithContext(ctx).Table("member_profiles").Where("status = 0").Count(&out.TotalMembers).Error; err != nil {
 		return nil, err
 	}
-	if err := r.db.WithContext(ctx).Table("meetings").Where("start_time >= ?", monthStart).Count(&out.TotalMeetingsThisMonth).Error; err != nil {
+	if err := r.db.WithContext(ctx).Table("meetings").Where("start_time >= ? AND start_time < ?", monthStart, monthStart.AddDate(0, 1, 0)).Count(&out.TotalMeetingsThisMonth).Error; err != nil {
 		return nil, err
 	}
 	if err := r.db.WithContext(ctx).Table("tasks").Where("status = 1").Count(&out.TotalTasksInProgress).Error; err != nil {

--- a/backend/internal/stats/repo/internship.go
+++ b/backend/internal/stats/repo/internship.go
@@ -1,0 +1,90 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/google/uuid"
+)
+
+func (r *statsRepo) InternshipRanking(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.db.WithContext(ctx).Table("internships AS i").
+		Joins("JOIN users u ON u.id = i.user_id").
+		Select("u.id::text AS k, COALESCE(NULLIF(u.real_name, ''), u.username) AS l, SUM(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
+	db = applyDept(db, "i.department_id", q.DepartmentID)
+	db = applyRange(db, "i.start_date", q)
+	return scanBuckets(db.Group("u.id, u.real_name, u.username").Order("v DESC").Limit(15))
+}
+
+func (r *statsRepo) InternshipDeptAvg(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.db.WithContext(ctx).Table("internships AS i").
+		Joins("LEFT JOIN departments d ON d.id = i.department_id").
+		Select("COALESCE(i.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, AVG(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
+	db = applyDept(db, "i.department_id", q.DepartmentID)
+	db = applyRange(db, "i.start_date", q)
+	return scanBuckets(db.Group("i.department_id, d.name").Order("v DESC"))
+}
+
+func (r *statsRepo) InternshipTrend(ctx context.Context, q Query) ([]Bucket, error) {
+	expr := truncExpr("i.start_date", q.Granularity)
+	db := r.db.WithContext(ctx).Table("internships AS i").
+		Select(expr + " AS k, " + expr + " AS l, SUM(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
+	db = applyDept(db, "i.department_id", q.DepartmentID)
+	db = applyRange(db, "i.start_date", q)
+	return scanBuckets(db.Group("k, l").Order("k"))
+}
+
+func (r *statsRepo) Overview(ctx context.Context, userID uuid.UUID) (*dto.OverviewResponse, error) {
+	out := &dto.OverviewResponse{TodayMeetings: []dto.OverviewMeeting{}}
+	now := time.Now()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	dayEnd := dayStart.Add(24 * time.Hour)
+
+	if err := r.db.WithContext(ctx).Table("member_profiles").Where("status = 0").Count(&out.TotalMembers).Error; err != nil {
+		return nil, err
+	}
+	if err := r.db.WithContext(ctx).Table("meetings").Where("start_time >= ?", monthStart).Count(&out.TotalMeetingsThisMonth).Error; err != nil {
+		return nil, err
+	}
+	if err := r.db.WithContext(ctx).Table("tasks").Where("status = 1").Count(&out.TotalTasksInProgress).Error; err != nil {
+		return nil, err
+	}
+	if err := r.db.WithContext(ctx).Table("internships").Where("status = 0").Count(&out.TotalInternshipsActive).Error; err != nil {
+		return nil, err
+	}
+	if err := r.db.WithContext(ctx).Table("member_applications").Where("status IN (0, 1, 2, 5)").Count(&out.PendingApprovals).Error; err != nil {
+		return nil, err
+	}
+	if userID != uuid.Nil {
+		if err := r.db.WithContext(ctx).Table("tasks").Where("assignee_id = ? AND status IN (0, 1, 4)", userID).Count(&out.MyTasks.Todo).Error; err != nil {
+			return nil, err
+		}
+		if err := r.db.WithContext(ctx).Table("tasks").
+			Where("assignee_id = ? AND status IN (0, 1, 4) AND due_date IS NOT NULL AND due_date < ?", userID, now).
+			Count(&out.MyTasks.Overdue).Error; err != nil {
+			return nil, err
+		}
+		if err := r.db.WithContext(ctx).Table("notifications").Where("user_id = ? AND is_read = false", userID).Count(&out.NotificationsUnread).Error; err != nil {
+			return nil, err
+		}
+	}
+	var meetings []struct {
+		ID        uuid.UUID
+		Title     string
+		StartTime time.Time
+	}
+	if err := r.db.WithContext(ctx).Table("meetings").
+		Select("id, title, start_time").
+		Where("start_time >= ? AND start_time < ?", dayStart, dayEnd).
+		Order("start_time").Limit(8).Scan(&meetings).Error; err != nil {
+		return nil, err
+	}
+	for _, m := range meetings {
+		out.TodayMeetings = append(out.TodayMeetings, dto.OverviewMeeting{
+			ID: m.ID.String(), Title: m.Title, StartTime: m.StartTime.Format(time.RFC3339),
+		})
+	}
+	return out, nil
+}

--- a/backend/internal/stats/repo/internship.go
+++ b/backend/internal/stats/repo/internship.go
@@ -13,29 +13,35 @@ func (r *statsRepo) InternshipRanking(ctx context.Context, q Query) ([]Bucket, e
 	if q.HideRanking {
 		return []Bucket{}, nil
 	}
+	days := clippedDaysSQL(q)
 	db := r.db.WithContext(ctx).Table("internships AS i").
 		Joins("JOIN users u ON u.id = i.user_id").
-		Select("u.id::text AS k, COALESCE(NULLIF(u.real_name, ''), u.username) AS l, SUM(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
+		Select("u.id::text AS k, COALESCE(NULLIF(u.real_name, ''), u.username) AS l, SUM(" + days + ")::float AS v")
 	db = applyDept(db, "i.department_id", q)
 	db = applyOverlap(db, "i.start_date", "i.end_date", q)
-	return scanBuckets(db.Group("u.id, u.real_name, u.username").Order("v DESC").Limit(15))
+	return scanBuckets(db.Group("u.id, u.real_name, u.username").Having("SUM(" + days + ") > 0").Order("v DESC").Limit(15))
 }
 
 func (r *statsRepo) InternshipDeptAvg(ctx context.Context, q Query) ([]Bucket, error) {
+	days := clippedDaysSQL(q)
 	db := r.db.WithContext(ctx).Table("internships AS i").
 		Joins("LEFT JOIN departments d ON d.id = i.department_id").
-		Select("COALESCE(i.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, AVG(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
+		Select("COALESCE(i.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, AVG(" + days + ")::float AS v")
 	db = applyDept(db, "i.department_id", q)
 	db = applyOverlap(db, "i.start_date", "i.end_date", q)
 	return scanBuckets(db.Group("i.department_id, d.name").Order("v DESC"))
 }
 
 func (r *statsRepo) InternshipTrend(ctx context.Context, q Query) ([]Bucket, error) {
-	expr := truncExpr("i.start_date", q.Granularity)
-	db := r.db.WithContext(ctx).Table("internships AS i").
-		Select(expr + " AS k, " + expr + " AS l, SUM(GREATEST(0, (COALESCE(i.end_date, CURRENT_DATE) - i.start_date)))::float AS v")
+	clipS := clipStartSQL(q)
+	clipE := clipEndSQL(q)
+	expr := truncExpr("gs", q.Granularity)
+	table := "internships AS i CROSS JOIN LATERAL generate_series(" + clipS + ", (" + clipE + ") - 1, interval '1 day') AS gs"
+	db := r.db.WithContext(ctx).Table(table).
+		Select(expr + " AS k, " + expr + " AS l, COUNT(*)::float AS v")
 	db = applyDept(db, "i.department_id", q)
 	db = applyOverlap(db, "i.start_date", "i.end_date", q)
+	db = db.Where(clipE + " > " + clipS)
 	return scanBuckets(db.Group("k, l").Order("k"))
 }
 

--- a/backend/internal/stats/repo/member.go
+++ b/backend/internal/stats/repo/member.go
@@ -9,16 +9,16 @@ import (
 
 func (r *statsRepo) MemberSummary(ctx context.Context, q Query) (total, active, newMonth int64, err error) {
 	base := r.db.WithContext(ctx).Table("member_profiles")
-	base = applyDept(base, "department_id", q.DepartmentID)
-	if err = applyRange(base, "created_at", q).Count(&total).Error; err != nil {
+	base = applyDept(base, "department_id", q)
+	if err = base.Count(&total).Error; err != nil {
 		return
 	}
-	if err = applyRange(applyDept(r.db.WithContext(ctx).Table("member_profiles").Where("status = 0"), "department_id", q.DepartmentID), "created_at", q).Count(&active).Error; err != nil {
+	if err = applyDept(r.db.WithContext(ctx).Table("member_profiles").Where("status = 0"), "department_id", q).Count(&active).Error; err != nil {
 		return
 	}
 	start := time.Now().AddDate(0, 0, -time.Now().Day()+1)
 	start = time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, start.Location())
-	if err = applyDept(r.db.WithContext(ctx).Table("member_profiles").Where("created_at >= ?", start), "department_id", q.DepartmentID).Count(&newMonth).Error; err != nil {
+	if err = applyDept(r.db.WithContext(ctx).Table("member_profiles").Where("created_at >= ?", start), "department_id", q).Count(&newMonth).Error; err != nil {
 		return
 	}
 	return
@@ -28,16 +28,14 @@ func (r *statsRepo) MemberByDepartment(ctx context.Context, q Query) ([]Bucket, 
 	db := r.db.WithContext(ctx).Table("member_profiles AS p").
 		Select("COALESCE(p.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, COUNT(*)::float AS v").
 		Joins("LEFT JOIN departments d ON d.id = p.department_id")
-	db = applyDept(db, "p.department_id", q.DepartmentID)
-	db = applyRange(db, "p.created_at", q)
+	db = applyDept(db, "p.department_id", q)
 	return scanBuckets(db.Group("p.department_id, d.name").Order("v DESC"))
 }
 
 func (r *statsRepo) MemberByGrade(ctx context.Context, q Query) ([]Bucket, error) {
 	db := r.db.WithContext(ctx).Table("member_profiles").
 		Select("COALESCE(NULLIF(grade, ''), '未填写') AS k, COALESCE(NULLIF(grade, ''), '未填写') AS l, COUNT(*)::float AS v")
-	db = applyDept(db, "department_id", q.DepartmentID)
-	db = applyRange(db, "created_at", q)
+	db = applyDept(db, "department_id", q)
 	return scanBuckets(db.Group("k, l").Order("k"))
 }
 
@@ -45,7 +43,7 @@ func (r *statsRepo) MemberTrend(ctx context.Context, q Query) ([]Bucket, error) 
 	expr := truncExpr("created_at", q.Granularity)
 	db := r.db.WithContext(ctx).Table("member_profiles").
 		Select(expr + " AS k, " + expr + " AS l, COUNT(*)::float AS v")
-	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyDept(db, "department_id", q)
 	db = applyRange(db, "created_at", q)
 	return scanBuckets(db.Group("k, l").Order("k"))
 }
@@ -74,7 +72,7 @@ func (r *statsRepo) InterviewSummary(ctx context.Context, q Query) (total int64,
 func (r *statsRepo) ivJoin(ctx context.Context, q Query) *gorm.DB {
 	db := r.db.WithContext(ctx).Table("interviews AS i").
 		Joins("LEFT JOIN member_applications a ON a.id = i.application_id")
-	db = applyDept(db, "a.department_id", q.DepartmentID)
+	db = applyDept(db, "a.department_id", q)
 	db = applyRange(db, "COALESCE(i.scheduled_at, i.created_at)", q)
 	return db
 }

--- a/backend/internal/stats/repo/member.go
+++ b/backend/internal/stats/repo/member.go
@@ -1,0 +1,99 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func (r *statsRepo) MemberSummary(ctx context.Context, q Query) (total, active, newMonth int64, err error) {
+	base := r.db.WithContext(ctx).Table("member_profiles")
+	base = applyDept(base, "department_id", q.DepartmentID)
+	if err = applyRange(base, "created_at", q).Count(&total).Error; err != nil {
+		return
+	}
+	if err = applyRange(applyDept(r.db.WithContext(ctx).Table("member_profiles").Where("status = 0"), "department_id", q.DepartmentID), "created_at", q).Count(&active).Error; err != nil {
+		return
+	}
+	start := time.Now().AddDate(0, 0, -time.Now().Day()+1)
+	start = time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, start.Location())
+	if err = applyDept(r.db.WithContext(ctx).Table("member_profiles").Where("created_at >= ?", start), "department_id", q.DepartmentID).Count(&newMonth).Error; err != nil {
+		return
+	}
+	return
+}
+
+func (r *statsRepo) MemberByDepartment(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.db.WithContext(ctx).Table("member_profiles AS p").
+		Select("COALESCE(p.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, COUNT(*)::float AS v").
+		Joins("LEFT JOIN departments d ON d.id = p.department_id")
+	db = applyDept(db, "p.department_id", q.DepartmentID)
+	db = applyRange(db, "p.created_at", q)
+	return scanBuckets(db.Group("p.department_id, d.name").Order("v DESC"))
+}
+
+func (r *statsRepo) MemberByGrade(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.db.WithContext(ctx).Table("member_profiles").
+		Select("COALESCE(NULLIF(grade, ''), '未填写') AS k, COALESCE(NULLIF(grade, ''), '未填写') AS l, COUNT(*)::float AS v")
+	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyRange(db, "created_at", q)
+	return scanBuckets(db.Group("k, l").Order("k"))
+}
+
+func (r *statsRepo) MemberTrend(ctx context.Context, q Query) ([]Bucket, error) {
+	expr := truncExpr("created_at", q.Granularity)
+	db := r.db.WithContext(ctx).Table("member_profiles").
+		Select(expr + " AS k, " + expr + " AS l, COUNT(*)::float AS v")
+	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyRange(db, "created_at", q)
+	return scanBuckets(db.Group("k, l").Order("k"))
+}
+
+func (r *statsRepo) InterviewSummary(ctx context.Context, q Query) (total int64, passRate, avgScore float64, err error) {
+	type agg struct {
+		Total int64
+		Pass  int64
+		Avg   *float64
+	}
+	var row agg
+	db := r.ivJoin(ctx, q).Select("COUNT(*) AS total, COUNT(*) FILTER (WHERE i.result_code = 1) AS pass, AVG(i.score) AS avg")
+	if err = db.Scan(&row).Error; err != nil {
+		return
+	}
+	total = row.Total
+	if total > 0 {
+		passRate = float64(row.Pass) / float64(total)
+	}
+	if row.Avg != nil {
+		avgScore = *row.Avg
+	}
+	return
+}
+
+func (r *statsRepo) ivJoin(ctx context.Context, q Query) *gorm.DB {
+	db := r.db.WithContext(ctx).Table("interviews AS i").
+		Joins("LEFT JOIN member_applications a ON a.id = i.application_id")
+	db = applyDept(db, "a.department_id", q.DepartmentID)
+	db = applyRange(db, "COALESCE(i.scheduled_at, i.created_at)", q)
+	return db
+}
+
+func (r *statsRepo) InterviewByDepartment(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.ivJoin(ctx, q).
+		Select("COALESCE(a.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, COUNT(*)::float AS v").
+		Joins("LEFT JOIN departments d ON d.id = a.department_id")
+	return scanBuckets(db.Group("a.department_id, d.name").Order("v DESC"))
+}
+
+func (r *statsRepo) InterviewTrend(ctx context.Context, q Query) ([]Bucket, error) {
+	expr := truncExpr("COALESCE(i.scheduled_at, i.created_at)", q.Granularity)
+	db := r.ivJoin(ctx, q).Select(expr + " AS k, " + expr + " AS l, COUNT(*)::float AS v")
+	return scanBuckets(db.Group("k, l").Order("k"))
+}
+
+func (r *statsRepo) InterviewScoreHist(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.ivJoin(ctx, q).Where("i.score IS NOT NULL").
+		Select("(FLOOR(i.score / 10) * 10)::int::text AS k, (FLOOR(i.score / 10) * 10)::int::text || '-' || (FLOOR(i.score / 10) * 10 + 9)::int::text AS l, COUNT(*)::float AS v")
+	return scanBuckets(db.Group("k, l").Order("k"))
+}

--- a/backend/internal/stats/repo/ops.go
+++ b/backend/internal/stats/repo/ops.go
@@ -1,0 +1,89 @@
+package repo
+
+import (
+	"context"
+)
+
+func (r *statsRepo) MeetingAttendanceTrend(ctx context.Context, q Query) ([]Bucket, error) {
+	expr := truncExpr("m.start_time", q.Granularity)
+	db := r.db.WithContext(ctx).Table("meetings AS m").
+		Joins("LEFT JOIN meeting_attendees a ON a.meeting_id = m.id").
+		Joins("LEFT JOIN member_profiles p ON p.user_id = m.organizer_id").
+		Select(expr + ` AS k, ` + expr + ` AS l,
+			CASE WHEN COUNT(a.id) = 0 THEN 0
+			ELSE 100.0 * COUNT(*) FILTER (WHERE a.attended) / COUNT(a.id) END AS v`)
+	db = applyDept(db, "p.department_id", q.DepartmentID)
+	db = applyRange(db, "m.start_time", q)
+	return scanBuckets(db.Group("k, l").Order("k"))
+}
+
+func (r *statsRepo) MeetingByDepartment(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.db.WithContext(ctx).Table("meetings AS m").
+		Joins("LEFT JOIN member_profiles p ON p.user_id = m.organizer_id").
+		Joins("LEFT JOIN departments d ON d.id = p.department_id").
+		Select("COALESCE(p.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, COUNT(*)::float AS v")
+	db = applyDept(db, "p.department_id", q.DepartmentID)
+	db = applyRange(db, "m.start_time", q)
+	return scanBuckets(db.Group("p.department_id, d.name").Order("v DESC"))
+}
+
+func (r *statsRepo) MeetingCalendar(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.db.WithContext(ctx).Table("meetings AS m").
+		Joins("LEFT JOIN member_profiles p ON p.user_id = m.organizer_id").
+		Select("to_char(m.start_time::date, 'YYYY-MM-DD') AS k, to_char(m.start_time::date, 'YYYY-MM-DD') AS l, COUNT(*)::float AS v")
+	db = applyDept(db, "p.department_id", q.DepartmentID)
+	db = applyRange(db, "m.start_time", q)
+	return scanBuckets(db.Group("k, l").Order("k"))
+}
+
+func (r *statsRepo) TaskByStatus(ctx context.Context, q Query) ([]Bucket, error) {
+	db := r.db.WithContext(ctx).Table("tasks").
+		Select("status::text AS k, CASE status WHEN 0 THEN '待处理' WHEN 1 THEN '进行中' WHEN 2 THEN '已完成' WHEN 3 THEN '已取消' WHEN 4 THEN '已挂起' ELSE status::text END AS l, COUNT(*)::float AS v")
+	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyRange(db, "created_at", q)
+	return scanBuckets(db.Group("status").Order("status"))
+}
+
+func (r *statsRepo) TaskOnTimeRate(ctx context.Context, q Query) (float64, error) {
+	type agg struct {
+		Done   int64
+		OnTime int64
+	}
+	var row agg
+	db := r.db.WithContext(ctx).Table("tasks").Where("status = 2")
+	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyRange(db, "created_at", q)
+	err := db.Select("COUNT(*) AS done, COUNT(*) FILTER (WHERE due_date IS NULL OR completed_at IS NULL OR completed_at <= due_date) AS on_time").Scan(&row).Error
+	if err != nil || row.Done == 0 {
+		return 0, err
+	}
+	return float64(row.OnTime) / float64(row.Done), nil
+}
+
+func (r *statsRepo) TaskTrend(ctx context.Context, q Query) ([]string, map[string][]Bucket, error) {
+	expr := truncExpr("created_at", q.Granularity)
+	db := r.db.WithContext(ctx).Table("tasks").
+		Select(expr + " AS k, " + expr + " AS l, status::text AS s, COUNT(*)::float AS v")
+	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyRange(db, "created_at", q)
+	var rows []struct {
+		K string  `gorm:"column:k"`
+		L string  `gorm:"column:l"`
+		S string  `gorm:"column:s"`
+		V float64 `gorm:"column:v"`
+	}
+	if err := db.Group("k, l, s").Order("k, s").Scan(&rows).Error; err != nil {
+		return nil, nil, err
+	}
+	statusSet := map[string]struct{}{}
+	points := map[string][]Bucket{}
+	for _, row := range rows {
+		statusSet[row.S] = struct{}{}
+		points[row.S] = append(points[row.S], Bucket{Key: row.K, Label: row.L, Value: row.V})
+	}
+	statuses := make([]string, 0, len(statusSet))
+	for s := range statusSet {
+		statuses = append(statuses, s)
+	}
+	return statuses, points, nil
+}

--- a/backend/internal/stats/repo/ops.go
+++ b/backend/internal/stats/repo/ops.go
@@ -12,7 +12,7 @@ func (r *statsRepo) MeetingAttendanceTrend(ctx context.Context, q Query) ([]Buck
 		Select(expr + ` AS k, ` + expr + ` AS l,
 			CASE WHEN COUNT(a.id) = 0 THEN 0
 			ELSE 100.0 * COUNT(*) FILTER (WHERE a.attended) / COUNT(a.id) END AS v`)
-	db = applyDept(db, "p.department_id", q.DepartmentID)
+	db = applyDept(db, "p.department_id", q)
 	db = applyRange(db, "m.start_time", q)
 	return scanBuckets(db.Group("k, l").Order("k"))
 }
@@ -22,7 +22,7 @@ func (r *statsRepo) MeetingByDepartment(ctx context.Context, q Query) ([]Bucket,
 		Joins("LEFT JOIN member_profiles p ON p.user_id = m.organizer_id").
 		Joins("LEFT JOIN departments d ON d.id = p.department_id").
 		Select("COALESCE(p.department_id::text, 'none') AS k, COALESCE(d.name, '未分配') AS l, COUNT(*)::float AS v")
-	db = applyDept(db, "p.department_id", q.DepartmentID)
+	db = applyDept(db, "p.department_id", q)
 	db = applyRange(db, "m.start_time", q)
 	return scanBuckets(db.Group("p.department_id, d.name").Order("v DESC"))
 }
@@ -31,7 +31,7 @@ func (r *statsRepo) MeetingCalendar(ctx context.Context, q Query) ([]Bucket, err
 	db := r.db.WithContext(ctx).Table("meetings AS m").
 		Joins("LEFT JOIN member_profiles p ON p.user_id = m.organizer_id").
 		Select("to_char(m.start_time::date, 'YYYY-MM-DD') AS k, to_char(m.start_time::date, 'YYYY-MM-DD') AS l, COUNT(*)::float AS v")
-	db = applyDept(db, "p.department_id", q.DepartmentID)
+	db = applyDept(db, "p.department_id", q)
 	db = applyRange(db, "m.start_time", q)
 	return scanBuckets(db.Group("k, l").Order("k"))
 }
@@ -39,7 +39,7 @@ func (r *statsRepo) MeetingCalendar(ctx context.Context, q Query) ([]Bucket, err
 func (r *statsRepo) TaskByStatus(ctx context.Context, q Query) ([]Bucket, error) {
 	db := r.db.WithContext(ctx).Table("tasks").
 		Select("status::text AS k, CASE status WHEN 0 THEN '待处理' WHEN 1 THEN '进行中' WHEN 2 THEN '已完成' WHEN 3 THEN '已取消' WHEN 4 THEN '已挂起' ELSE status::text END AS l, COUNT(*)::float AS v")
-	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyDept(db, "department_id", q)
 	db = applyRange(db, "created_at", q)
 	return scanBuckets(db.Group("status").Order("status"))
 }
@@ -51,7 +51,7 @@ func (r *statsRepo) TaskOnTimeRate(ctx context.Context, q Query) (float64, error
 	}
 	var row agg
 	db := r.db.WithContext(ctx).Table("tasks").Where("status = 2")
-	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyDept(db, "department_id", q)
 	db = applyRange(db, "created_at", q)
 	err := db.Select("COUNT(*) AS done, COUNT(*) FILTER (WHERE due_date IS NULL OR completed_at IS NULL OR completed_at <= due_date) AS on_time").Scan(&row).Error
 	if err != nil || row.Done == 0 {
@@ -64,7 +64,7 @@ func (r *statsRepo) TaskTrend(ctx context.Context, q Query) ([]string, map[strin
 	expr := truncExpr("created_at", q.Granularity)
 	db := r.db.WithContext(ctx).Table("tasks").
 		Select(expr + " AS k, " + expr + " AS l, status::text AS s, COUNT(*)::float AS v")
-	db = applyDept(db, "department_id", q.DepartmentID)
+	db = applyDept(db, "department_id", q)
 	db = applyRange(db, "created_at", q)
 	var rows []struct {
 		K string  `gorm:"column:k"`

--- a/backend/internal/stats/repo/query_test.go
+++ b/backend/internal/stats/repo/query_test.go
@@ -92,4 +92,8 @@ func TestRepoQueries(t *testing.T) {
 	require.NoError(t, err)
 	_, err = r.Overview(ctx, uuid.New())
 	require.NoError(t, err)
+	_, err = r.RankingHidden(ctx)
+	require.NoError(t, err)
+	_, err = r.InternshipRanking(ctx, Query{HideRanking: true})
+	require.NoError(t, err)
 }

--- a/backend/internal/stats/repo/query_test.go
+++ b/backend/internal/stats/repo/query_test.go
@@ -1,0 +1,95 @@
+package repo
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupRepo(t *testing.T) StatsRepo {
+	t.Helper()
+	candidates := []string{
+		os.Getenv("STATS_TEST_DSN"),
+		"host=localhost user=starbyte password=starbyte dbname=starbyte_dev port=5432 sslmode=disable",
+		"host=localhost user=starbyte password=starbyte dbname=starbyte_test port=5432 sslmode=disable",
+		"host=localhost user=postgres password=postgres dbname=starbyte_dev port=5432 sslmode=disable",
+	}
+	var last error
+	for _, dsn := range candidates {
+		if dsn == "" {
+			continue
+		}
+		db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+		if err != nil {
+			last = err
+			continue
+		}
+		sqlDB, err := db.DB()
+		if err != nil {
+			last = err
+			continue
+		}
+		if err := sqlDB.Ping(); err != nil {
+			last = err
+			continue
+		}
+		return NewStatsRepo(db)
+	}
+	t.Skipf("skipping stats repo DB test: %v", last)
+	return nil
+}
+
+func TestRepoQueries(t *testing.T) {
+	r := setupRepo(t)
+	ctx := context.Background()
+	end := time.Now()
+	start := end.AddDate(0, -6, 0)
+	dept := uuid.MustParse("00000000-0000-0000-0000-000000000000")
+	q := Query{Start: &start, End: &end, Granularity: "month", DepartmentID: &dept}
+
+	_, _, _, err := r.MemberSummary(ctx, q)
+	require.NoError(t, err)
+	_, err = r.MemberByDepartment(ctx, q)
+	require.NoError(t, err)
+	_, err = r.MemberByGrade(ctx, q)
+	require.NoError(t, err)
+	_, err = r.MemberTrend(ctx, Query{Granularity: "day"})
+	require.NoError(t, err)
+	_, _, _, err = r.InterviewSummary(ctx, Query{Granularity: "week"})
+	require.NoError(t, err)
+	_, err = r.InterviewByDepartment(ctx, q)
+	require.NoError(t, err)
+	_, err = r.InterviewTrend(ctx, q)
+	require.NoError(t, err)
+	_, err = r.InterviewScoreHist(ctx, q)
+	require.NoError(t, err)
+	_, err = r.MeetingAttendanceTrend(ctx, q)
+	require.NoError(t, err)
+	_, err = r.MeetingByDepartment(ctx, q)
+	require.NoError(t, err)
+	_, err = r.MeetingCalendar(ctx, q)
+	require.NoError(t, err)
+	_, err = r.TaskByStatus(ctx, q)
+	require.NoError(t, err)
+	_, err = r.TaskOnTimeRate(ctx, q)
+	require.NoError(t, err)
+	_, _, err = r.TaskTrend(ctx, q)
+	require.NoError(t, err)
+	_, err = r.InternshipRanking(ctx, q)
+	require.NoError(t, err)
+	_, err = r.InternshipDeptAvg(ctx, q)
+	require.NoError(t, err)
+	_, err = r.InternshipTrend(ctx, q)
+	require.NoError(t, err)
+	_, err = r.Overview(ctx, uuid.Nil)
+	require.NoError(t, err)
+	_, err = r.Overview(ctx, uuid.New())
+	require.NoError(t, err)
+}

--- a/backend/internal/stats/repo/repo.go
+++ b/backend/internal/stats/repo/repo.go
@@ -1,0 +1,40 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// StatsRepo 统计只读查询。
+type StatsRepo interface {
+	MemberSummary(ctx context.Context, q Query) (total, active, newMonth int64, err error)
+	MemberByDepartment(ctx context.Context, q Query) ([]Bucket, error)
+	MemberByGrade(ctx context.Context, q Query) ([]Bucket, error)
+	MemberTrend(ctx context.Context, q Query) ([]Bucket, error)
+	InterviewSummary(ctx context.Context, q Query) (total int64, passRate, avgScore float64, err error)
+	InterviewByDepartment(ctx context.Context, q Query) ([]Bucket, error)
+	InterviewTrend(ctx context.Context, q Query) ([]Bucket, error)
+	InterviewScoreHist(ctx context.Context, q Query) ([]Bucket, error)
+	MeetingAttendanceTrend(ctx context.Context, q Query) ([]Bucket, error)
+	MeetingByDepartment(ctx context.Context, q Query) ([]Bucket, error)
+	MeetingCalendar(ctx context.Context, q Query) ([]Bucket, error)
+	TaskByStatus(ctx context.Context, q Query) ([]Bucket, error)
+	TaskOnTimeRate(ctx context.Context, q Query) (float64, error)
+	TaskTrend(ctx context.Context, q Query) (statuses []string, points map[string][]Bucket, err error)
+	InternshipRanking(ctx context.Context, q Query) ([]Bucket, error)
+	InternshipDeptAvg(ctx context.Context, q Query) ([]Bucket, error)
+	InternshipTrend(ctx context.Context, q Query) ([]Bucket, error)
+	Overview(ctx context.Context, userID uuid.UUID) (*dto.OverviewResponse, error)
+}
+
+type statsRepo struct {
+	db *gorm.DB
+}
+
+// NewStatsRepo 创建仓储。
+func NewStatsRepo(db *gorm.DB) StatsRepo {
+	return &statsRepo{db: db}
+}

--- a/backend/internal/stats/repo/repo.go
+++ b/backend/internal/stats/repo/repo.go
@@ -27,6 +27,7 @@ type StatsRepo interface {
 	InternshipRanking(ctx context.Context, q Query) ([]Bucket, error)
 	InternshipDeptAvg(ctx context.Context, q Query) ([]Bucket, error)
 	InternshipTrend(ctx context.Context, q Query) ([]Bucket, error)
+	RankingHidden(ctx context.Context) (bool, error)
 	Overview(ctx context.Context, userID uuid.UUID) (*dto.OverviewResponse, error)
 }
 

--- a/backend/internal/stats/service/helpers.go
+++ b/backend/internal/stats/service/helpers.go
@@ -16,7 +16,46 @@ func toQuery(p *dto.StatsQuery) repo.Query {
 	if g == "" {
 		g = "month"
 	}
-	return repo.Query{Start: p.StartDate, End: p.EndDate, DepartmentID: p.DepartmentID, Granularity: g}
+	return repo.Query{
+		Start: p.StartDate, End: p.EndDate, DepartmentID: p.DepartmentID,
+		DeptIDs: p.ScopeDeptIDs, Granularity: g, Denied: p.Denied, AllScope: p.AllScope,
+	}
+}
+
+func filterSeries(groupBy string, series []dto.DataSeries) []dto.DataSeries {
+	g := strings.ToLower(strings.TrimSpace(groupBy))
+	if g == "" || len(series) == 0 {
+		return series
+	}
+	out := make([]dto.DataSeries, 0, len(series))
+	for _, s := range series {
+		switch g {
+		case "department":
+			if strings.Contains(s.Name, "部门") {
+				out = append(out, s)
+			}
+		case "grade":
+			if strings.Contains(s.Name, "年级") {
+				out = append(out, s)
+			}
+		case "date":
+			if s.Type == "line" || s.Type == "calendar" {
+				out = append(out, s)
+			}
+		case "status":
+			if strings.Contains(s.Name, "状态") || s.Name == "待处理" || s.Name == "进行中" || s.Name == "已完成" || s.Name == "已取消" || s.Name == "已挂起" {
+				out = append(out, s)
+			}
+		case "type":
+			if strings.Contains(s.Name, "类型") {
+				out = append(out, s)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return series
+	}
+	return out
 }
 
 func toSeries(name, typ string, buckets []repo.Bucket) dto.DataSeries {

--- a/backend/internal/stats/service/helpers.go
+++ b/backend/internal/stats/service/helpers.go
@@ -22,42 +22,6 @@ func toQuery(p *dto.StatsQuery) repo.Query {
 	}
 }
 
-func filterSeries(groupBy string, series []dto.DataSeries) []dto.DataSeries {
-	g := strings.ToLower(strings.TrimSpace(groupBy))
-	if g == "" || len(series) == 0 {
-		return series
-	}
-	out := make([]dto.DataSeries, 0, len(series))
-	for _, s := range series {
-		switch g {
-		case "department":
-			if strings.Contains(s.Name, "部门") {
-				out = append(out, s)
-			}
-		case "grade":
-			if strings.Contains(s.Name, "年级") {
-				out = append(out, s)
-			}
-		case "date":
-			if s.Type == "line" || s.Type == "calendar" {
-				out = append(out, s)
-			}
-		case "status":
-			if strings.Contains(s.Name, "状态") || s.Name == "待处理" || s.Name == "进行中" || s.Name == "已完成" || s.Name == "已取消" || s.Name == "已挂起" {
-				out = append(out, s)
-			}
-		case "type":
-			if strings.Contains(s.Name, "类型") {
-				out = append(out, s)
-			}
-		}
-	}
-	if len(out) == 0 {
-		return series
-	}
-	return out
-}
-
 func toSeries(name, typ string, buckets []repo.Bucket) dto.DataSeries {
 	data := make([]dto.DataPoint, 0, len(buckets))
 	x := make([]string, 0, len(buckets))

--- a/backend/internal/stats/service/helpers.go
+++ b/backend/internal/stats/service/helpers.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/stats/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+)
+
+func toQuery(p *dto.StatsQuery) repo.Query {
+	if p == nil {
+		return repo.Query{}
+	}
+	g := p.Granularity
+	if g == "" {
+		g = "month"
+	}
+	return repo.Query{Start: p.StartDate, End: p.EndDate, DepartmentID: p.DepartmentID, Granularity: g}
+}
+
+func toSeries(name, typ string, buckets []repo.Bucket) dto.DataSeries {
+	data := make([]dto.DataPoint, 0, len(buckets))
+	x := make([]string, 0, len(buckets))
+	for _, b := range buckets {
+		label := b.Label
+		if label == "" {
+			label = b.Key
+		}
+		data = append(data, dto.DataPoint{Label: label, Value: b.Value})
+		x = append(x, label)
+	}
+	return dto.DataSeries{Name: name, Type: typ, Data: data, XAxis: x}
+}
+
+func round4(v float64) float64 {
+	return float64(int(v*10000+0.5)) / 10000
+}
+
+func validateQuery(q *dto.StatsQuery) error {
+	if q == nil {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(q.Granularity)) {
+	case "", "day", "week", "month":
+	default:
+		return response.NewError(response.CodeStatsInvalidParam, "查询参数无效")
+	}
+	switch strings.ToLower(strings.TrimSpace(q.GroupBy)) {
+	case "", "date", "department", "type", "status", "grade":
+	default:
+		return response.NewError(response.CodeStatsInvalidParam, "查询参数无效")
+	}
+	if q.StartDate != nil && q.EndDate != nil && q.EndDate.Before(*q.StartDate) {
+		return response.NewError(response.CodeStatsInvalidParam, "查询参数无效")
+	}
+	return nil
+}

--- a/backend/internal/stats/service/member.go
+++ b/backend/internal/stats/service/member.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/stats/repo"
+)
+
+type memberProvider struct{ repo repo.StatsRepo }
+
+func (p *memberProvider) Name() string        { return "member-distribution" }
+func (p *memberProvider) DisplayName() string { return "会员分布统计" }
+func (p *memberProvider) GetChartConfig() *dto.ChartConfig {
+	return &dto.ChartConfig{ChartType: "pie", Title: "会员分布"}
+}
+
+func (p *memberProvider) GetStats(ctx context.Context, params *dto.StatsQuery) (*dto.StatsResult, error) {
+	q := toQuery(params)
+	total, active, neu, err := p.repo.MemberSummary(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	dept, err := p.repo.MemberByDepartment(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	grade, err := p.repo.MemberByGrade(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	trend, err := p.repo.MemberTrend(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return &dto.StatsResult{
+		Provider: p.Name(),
+		Summary: map[string]any{
+			"total_members":  total,
+			"active_members": active,
+			"new_this_month": neu,
+		},
+		Series: []dto.DataSeries{
+			toSeries("部门分布", "pie", dept),
+			toSeries("年级分布", "bar", grade),
+			toSeries("增长趋势", "line", trend),
+		},
+		ChartConfig: p.GetChartConfig(),
+	}, nil
+}
+
+type interviewProvider struct{ repo repo.StatsRepo }
+
+func (p *interviewProvider) Name() string        { return "interview-data" }
+func (p *interviewProvider) DisplayName() string { return "面试数据统计" }
+func (p *interviewProvider) GetChartConfig() *dto.ChartConfig {
+	return &dto.ChartConfig{ChartType: "bar", Title: "面试数据"}
+}
+
+func (p *interviewProvider) GetStats(ctx context.Context, params *dto.StatsQuery) (*dto.StatsResult, error) {
+	q := toQuery(params)
+	total, pass, avg, err := p.repo.InterviewSummary(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	dept, err := p.repo.InterviewByDepartment(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	trend, err := p.repo.InterviewTrend(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	hist, err := p.repo.InterviewScoreHist(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return &dto.StatsResult{
+		Provider: p.Name(),
+		Summary: map[string]any{
+			"total_interviews": total,
+			"pass_rate":        round4(pass),
+			"avg_score":        round4(avg),
+		},
+		Series: []dto.DataSeries{
+			{Name: "通过率", Type: "gauge", Data: []dto.DataPoint{{Label: "通过率", Value: round4(pass * 100)}}, XAxis: []string{"通过率"}},
+			toSeries("各部门面试人数", "bar", dept),
+			toSeries("评分分布", "bar", hist),
+			toSeries("面试趋势", "line", trend),
+		},
+		ChartConfig: p.GetChartConfig(),
+	}, nil
+}

--- a/backend/internal/stats/service/ops.go
+++ b/backend/internal/stats/service/ops.go
@@ -118,6 +118,11 @@ func (p *internshipProvider) GetChartConfig() *dto.ChartConfig {
 
 func (p *internshipProvider) GetStats(ctx context.Context, params *dto.StatsQuery) (*dto.StatsResult, error) {
 	q := toQuery(params)
+	hidden, err := p.repo.RankingHidden(ctx)
+	if err != nil {
+		return nil, err
+	}
+	q.HideRanking = hidden && !q.AllScope
 	rank, err := p.repo.InternshipRanking(ctx, q)
 	if err != nil {
 		return nil, err

--- a/backend/internal/stats/service/ops.go
+++ b/backend/internal/stats/service/ops.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/stats/repo"
+)
+
+type meetingProvider struct{ repo repo.StatsRepo }
+
+func (p *meetingProvider) Name() string        { return "meeting-attendance" }
+func (p *meetingProvider) DisplayName() string { return "会议出席统计" }
+func (p *meetingProvider) GetChartConfig() *dto.ChartConfig {
+	return &dto.ChartConfig{ChartType: "line", Title: "会议出席"}
+}
+
+func (p *meetingProvider) GetStats(ctx context.Context, params *dto.StatsQuery) (*dto.StatsResult, error) {
+	q := toQuery(params)
+	trend, err := p.repo.MeetingAttendanceTrend(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	dept, err := p.repo.MeetingByDepartment(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	cal, err := p.repo.MeetingCalendar(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	avg := 0.0
+	if len(trend) > 0 {
+		sum := 0.0
+		for _, b := range trend {
+			sum += b.Value
+		}
+		avg = round4(sum / float64(len(trend)))
+	}
+	return &dto.StatsResult{
+		Provider: p.Name(),
+		Summary:  map[string]any{"avg_attendance_rate": avg, "meeting_days": int64(len(cal))},
+		Series: []dto.DataSeries{
+			toSeries("出席率", "line", trend),
+			toSeries("各部门会议数", "bar", dept),
+			toSeries("会议频率", "calendar", cal),
+		},
+		ChartConfig: p.GetChartConfig(),
+	}, nil
+}
+
+type taskProvider struct{ repo repo.StatsRepo }
+
+func (p *taskProvider) Name() string        { return "task-progress" }
+func (p *taskProvider) DisplayName() string { return "任务进度统计" }
+func (p *taskProvider) GetChartConfig() *dto.ChartConfig {
+	return &dto.ChartConfig{ChartType: "pie", Title: "任务进度", Stack: true}
+}
+
+func (p *taskProvider) GetStats(ctx context.Context, params *dto.StatsQuery) (*dto.StatsResult, error) {
+	q := toQuery(params)
+	byStatus, err := p.repo.TaskByStatus(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	onTime, err := p.repo.TaskOnTimeRate(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	statuses, points, err := p.repo.TaskTrend(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(statuses)
+	labels := map[string]string{"0": "待处理", "1": "进行中", "2": "已完成", "3": "已取消", "4": "已挂起"}
+	series := []dto.DataSeries{toSeries("任务状态", "pie", byStatus)}
+	for _, st := range statuses {
+		name := labels[st]
+		if name == "" {
+			name = st
+		}
+		s := toSeries(name, "bar", points[st])
+		series = append(series, s)
+	}
+	var total float64
+	for _, b := range byStatus {
+		total += b.Value
+	}
+	return &dto.StatsResult{
+		Provider: p.Name(),
+		Summary: map[string]any{
+			"total_tasks":  total,
+			"on_time_rate": round4(onTime),
+			"in_progress":  statusValue(byStatus, "1"),
+		},
+		Series:      series,
+		ChartConfig: p.GetChartConfig(),
+	}, nil
+}
+
+func statusValue(buckets []repo.Bucket, key string) float64 {
+	for _, b := range buckets {
+		if b.Key == key {
+			return b.Value
+		}
+	}
+	return 0
+}
+
+type internshipProvider struct{ repo repo.StatsRepo }
+
+func (p *internshipProvider) Name() string        { return "internship-duration" }
+func (p *internshipProvider) DisplayName() string { return "实习时长统计" }
+func (p *internshipProvider) GetChartConfig() *dto.ChartConfig {
+	return &dto.ChartConfig{ChartType: "bar", Title: "实习时长", Horizontal: true}
+}
+
+func (p *internshipProvider) GetStats(ctx context.Context, params *dto.StatsQuery) (*dto.StatsResult, error) {
+	q := toQuery(params)
+	rank, err := p.repo.InternshipRanking(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	dept, err := p.repo.InternshipDeptAvg(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	trend, err := p.repo.InternshipTrend(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return &dto.StatsResult{
+		Provider: p.Name(),
+		Summary:  map[string]any{"ranked_users": int64(len(rank))},
+		Series: []dto.DataSeries{
+			toSeries("时长排行", "bar", rank),
+			toSeries("部门平均时长", "bar", dept),
+			toSeries("时长趋势", "line", trend),
+		},
+		ChartConfig: p.GetChartConfig(),
+	}, nil
+}

--- a/backend/internal/stats/service/registry.go
+++ b/backend/internal/stats/service/registry.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+)
+
+// StatsProvider 可插拔统计提供者。
+type StatsProvider interface {
+	Name() string
+	DisplayName() string
+	GetStats(ctx context.Context, params *dto.StatsQuery) (*dto.StatsResult, error)
+	GetChartConfig() *dto.ChartConfig
+}
+
+// StatsRegistry 统计注册中心。
+type StatsRegistry struct {
+	mu        sync.RWMutex
+	providers map[string]StatsProvider
+}
+
+// NewRegistry 创建空注册中心。
+func NewRegistry() *StatsRegistry {
+	return &StatsRegistry{providers: map[string]StatsProvider{}}
+}
+
+// Register 注册提供者。同名覆盖。
+func (r *StatsRegistry) Register(provider StatsProvider) {
+	if provider == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.providers[provider.Name()] = provider
+}
+
+// ListProviders 按名称排序返回。
+func (r *StatsRegistry) ListProviders() []dto.ProviderInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.providers))
+	for n := range r.providers {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]dto.ProviderInfo, 0, len(names))
+	for _, n := range names {
+		p := r.providers[n]
+		out = append(out, dto.ProviderInfo{Name: p.Name(), DisplayName: p.DisplayName(), ChartConfig: p.GetChartConfig()})
+	}
+	return out
+}
+
+// GetStats 按名称查询。
+func (r *StatsRegistry) GetStats(ctx context.Context, provider string, params *dto.StatsQuery) (*dto.StatsResult, error) {
+	r.mu.RLock()
+	p, ok := r.providers[provider]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, response.NewError(response.CodeStatsProviderNotFound, "统计提供者不存在")
+	}
+	if params == nil {
+		params = &dto.StatsQuery{}
+	}
+	return p.GetStats(ctx, params)
+}

--- a/backend/internal/stats/service/registry.go
+++ b/backend/internal/stats/service/registry.go
@@ -66,5 +66,12 @@ func (r *StatsRegistry) GetStats(ctx context.Context, provider string, params *d
 	if params == nil {
 		params = &dto.StatsQuery{}
 	}
-	return p.GetStats(ctx, params)
+	res, err := p.GetStats(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	if res != nil {
+		res.Series = filterSeries(params.GroupBy, res.Series)
+	}
+	return res, nil
 }

--- a/backend/internal/stats/service/registry.go
+++ b/backend/internal/stats/service/registry.go
@@ -66,12 +66,5 @@ func (r *StatsRegistry) GetStats(ctx context.Context, provider string, params *d
 	if params == nil {
 		params = &dto.StatsQuery{}
 	}
-	res, err := p.GetStats(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	if res != nil {
-		res.Series = filterSeries(params.GroupBy, res.Series)
-	}
-	return res, nil
+	return p.GetStats(ctx, params)
 }

--- a/backend/internal/stats/service/service.go
+++ b/backend/internal/stats/service/service.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	exportDTO "github.com/Yogdunana/StarByte/backend/internal/export/dto"
+	exportSvc "github.com/Yogdunana/StarByte/backend/internal/export/service"
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/stats/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+const maxExportPoints = 5000
+
+// StatsService 统一入口。
+type StatsService interface {
+	ListProviders() []dto.ProviderInfo
+	GetStats(ctx context.Context, provider string, q *dto.StatsQuery) (*dto.StatsResult, error)
+	Overview(ctx context.Context, userID uuid.UUID) (*dto.OverviewResponse, error)
+	Export(ctx context.Context, provider, format string, q *dto.StatsQuery) ([]byte, string, error)
+}
+
+type statsService struct {
+	reg  *StatsRegistry
+	repo repo.StatsRepo
+}
+
+// NewStatsService 注册一期 5 个提供者。
+func NewStatsService(r repo.StatsRepo) StatsService {
+	reg := NewRegistry()
+	reg.Register(&memberProvider{repo: r})
+	reg.Register(&interviewProvider{repo: r})
+	reg.Register(&meetingProvider{repo: r})
+	reg.Register(&taskProvider{repo: r})
+	reg.Register(&internshipProvider{repo: r})
+	return &statsService{reg: reg, repo: r}
+}
+
+func (s *statsService) ListProviders() []dto.ProviderInfo {
+	return s.reg.ListProviders()
+}
+
+func (s *statsService) GetStats(ctx context.Context, provider string, q *dto.StatsQuery) (*dto.StatsResult, error) {
+	if err := validateQuery(q); err != nil {
+		return nil, err
+	}
+	return s.reg.GetStats(ctx, provider, q)
+}
+
+func (s *statsService) Overview(ctx context.Context, userID uuid.UUID) (*dto.OverviewResponse, error) {
+	return s.repo.Overview(ctx, userID)
+}
+
+func (s *statsService) Export(ctx context.Context, provider, format string, q *dto.StatsQuery) ([]byte, string, error) {
+	format = strings.ToLower(strings.TrimSpace(format))
+	if format == "" {
+		format = "csv"
+	}
+	if format != "csv" && format != "excel" {
+		return nil, "", response.NewError(response.CodeStatsExportFormat, "导出格式不支持")
+	}
+	res, err := s.GetStats(ctx, provider, q)
+	if err != nil {
+		return nil, "", err
+	}
+	rows := make([][]string, 0)
+	for _, series := range res.Series {
+		for _, pt := range series.Data {
+			rows = append(rows, []string{series.Name, pt.Label, fmt.Sprintf("%g", pt.Value)})
+			if len(rows) > maxExportPoints {
+				return nil, "", response.NewError(response.CodeStatsTooLarge, "数据量过大")
+			}
+		}
+	}
+	if len(rows) == 0 {
+		rows = append(rows, []string{"summary", "empty", "0"})
+	}
+	title := provider
+	if res.ChartConfig != nil && res.ChartConfig.Title != "" {
+		title = res.ChartConfig.Title
+	}
+	data, filename, err := exportSvc.RenderTable(format, &exportDTO.TableExportRequest{
+		Filename: "stats_" + provider,
+		Title:    title,
+		Columns:  []string{"系列", "标签", "数值"},
+		Rows:     rows,
+		Sheet:    "stats",
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return data, filename, nil
+}

--- a/backend/internal/stats/service/service_test.go
+++ b/backend/internal/stats/service/service_test.go
@@ -190,29 +190,6 @@ func TestRegistryRegisterNil(t *testing.T) {
 	assert.Empty(t, r.ListProviders())
 }
 
-func TestFilterSeriesGroupBy(t *testing.T) {
-	series := []dto.DataSeries{
-		{Name: "部门分布", Type: "pie"},
-		{Name: "年级分布", Type: "bar"},
-		{Name: "增长趋势", Type: "line"},
-		{Name: "待处理", Type: "bar"},
-	}
-	dept := filterSeries("department", series)
-	require.Len(t, dept, 1)
-	assert.Equal(t, "部门分布", dept[0].Name)
-	grade := filterSeries("grade", series)
-	require.Len(t, grade, 1)
-	assert.Equal(t, "年级分布", grade[0].Name)
-	date := filterSeries("date", series)
-	require.Len(t, date, 1)
-	assert.Equal(t, "增长趋势", date[0].Name)
-	status := filterSeries("status", series)
-	require.Len(t, status, 1)
-	assert.Equal(t, "待处理", status[0].Name)
-	assert.Equal(t, series, filterSeries("", series))
-	assert.Equal(t, series, filterSeries("type", series))
-}
-
 func TestInternshipHidesRankingWhenConfigured(t *testing.T) {
 	svc := NewStatsService(hideRankRepo{})
 	res, err := svc.GetStats(context.Background(), "internship-duration", &dto.StatsQuery{})

--- a/backend/internal/stats/service/service_test.go
+++ b/backend/internal/stats/service/service_test.go
@@ -67,6 +67,7 @@ func (stubRepo) InternshipDeptAvg(context.Context, repo.Query) ([]repo.Bucket, e
 func (stubRepo) InternshipTrend(context.Context, repo.Query) ([]repo.Bucket, error) {
 	return []repo.Bucket{{Key: "2026-01", Label: "2026-01", Value: 45}}, nil
 }
+func (stubRepo) RankingHidden(context.Context) (bool, error) { return false, nil }
 func (stubRepo) Overview(context.Context, uuid.UUID) (*dto.OverviewResponse, error) {
 	return &dto.OverviewResponse{TotalMembers: 12, TotalMeetingsThisMonth: 2, TotalTasksInProgress: 3}, nil
 }
@@ -187,4 +188,49 @@ func TestRegistryRegisterNil(t *testing.T) {
 	r := NewRegistry()
 	r.Register(nil)
 	assert.Empty(t, r.ListProviders())
+}
+
+func TestFilterSeriesGroupBy(t *testing.T) {
+	series := []dto.DataSeries{
+		{Name: "部门分布", Type: "pie"},
+		{Name: "年级分布", Type: "bar"},
+		{Name: "增长趋势", Type: "line"},
+		{Name: "待处理", Type: "bar"},
+	}
+	dept := filterSeries("department", series)
+	require.Len(t, dept, 1)
+	assert.Equal(t, "部门分布", dept[0].Name)
+	grade := filterSeries("grade", series)
+	require.Len(t, grade, 1)
+	assert.Equal(t, "年级分布", grade[0].Name)
+	date := filterSeries("date", series)
+	require.Len(t, date, 1)
+	assert.Equal(t, "增长趋势", date[0].Name)
+	status := filterSeries("status", series)
+	require.Len(t, status, 1)
+	assert.Equal(t, "待处理", status[0].Name)
+	assert.Equal(t, series, filterSeries("", series))
+	assert.Equal(t, series, filterSeries("type", series))
+}
+
+func TestInternshipHidesRankingWhenConfigured(t *testing.T) {
+	svc := NewStatsService(hideRankRepo{})
+	res, err := svc.GetStats(context.Background(), "internship-duration", &dto.StatsQuery{})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Series)
+	assert.Empty(t, res.Series[0].Data)
+
+	res, err = svc.GetStats(context.Background(), "internship-duration", &dto.StatsQuery{AllScope: true})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Series[0].Data)
+}
+
+type hideRankRepo struct{ stubRepo }
+
+func (hideRankRepo) RankingHidden(context.Context) (bool, error) { return true, nil }
+func (hideRankRepo) InternshipRanking(_ context.Context, q repo.Query) ([]repo.Bucket, error) {
+	if q.HideRanking {
+		return []repo.Bucket{}, nil
+	}
+	return []repo.Bucket{{Key: "u1", Label: "张三", Value: 90}}, nil
 }

--- a/backend/internal/stats/service/service_test.go
+++ b/backend/internal/stats/service/service_test.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/stats/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/stats/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubRepo struct{}
+
+func (stubRepo) MemberSummary(context.Context, repo.Query) (int64, int64, int64, error) {
+	return 12, 10, 2, nil
+}
+func (stubRepo) MemberByDepartment(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "d1", Label: "技术研发部", Value: 7}, {Key: "d2", Label: "人力资源部", Value: 5}}, nil
+}
+func (stubRepo) MemberByGrade(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "2023", Label: "2023", Value: 6}}, nil
+}
+func (stubRepo) MemberTrend(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "2026-01", Label: "2026-01", Value: 3}}, nil
+}
+func (stubRepo) InterviewSummary(context.Context, repo.Query) (int64, float64, float64, error) {
+	return 8, 0.625, 82.5, nil
+}
+func (stubRepo) InterviewByDepartment(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "d1", Label: "技术研发部", Value: 4}}, nil
+}
+func (stubRepo) InterviewTrend(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "2026-01", Label: "2026-01", Value: 2}}, nil
+}
+func (stubRepo) InterviewScoreHist(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "80", Label: "80-89", Value: 3}}, nil
+}
+func (stubRepo) MeetingAttendanceTrend(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "2026-01", Label: "2026-01", Value: 90}}, nil
+}
+func (stubRepo) MeetingByDepartment(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "d1", Label: "技术研发部", Value: 2}}, nil
+}
+func (stubRepo) MeetingCalendar(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "2026-01-15", Label: "2026-01-15", Value: 1}}, nil
+}
+func (stubRepo) TaskByStatus(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "0", Label: "待处理", Value: 1}, {Key: "2", Label: "已完成", Value: 4}}, nil
+}
+func (stubRepo) TaskOnTimeRate(context.Context, repo.Query) (float64, error) { return 0.8, nil }
+func (stubRepo) TaskTrend(context.Context, repo.Query) ([]string, map[string][]repo.Bucket, error) {
+	return []string{"0", "2"}, map[string][]repo.Bucket{
+		"0": {{Key: "2026-01", Label: "2026-01", Value: 1}},
+		"2": {{Key: "2026-01", Label: "2026-01", Value: 2}},
+	}, nil
+}
+func (stubRepo) InternshipRanking(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "u1", Label: "张三", Value: 90}}, nil
+}
+func (stubRepo) InternshipDeptAvg(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "d1", Label: "技术研发部", Value: 60}}, nil
+}
+func (stubRepo) InternshipTrend(context.Context, repo.Query) ([]repo.Bucket, error) {
+	return []repo.Bucket{{Key: "2026-01", Label: "2026-01", Value: 45}}, nil
+}
+func (stubRepo) Overview(context.Context, uuid.UUID) (*dto.OverviewResponse, error) {
+	return &dto.OverviewResponse{TotalMembers: 12, TotalMeetingsThisMonth: 2, TotalTasksInProgress: 3}, nil
+}
+
+func TestRegistryListAndMissing(t *testing.T) {
+	svc := NewStatsService(stubRepo{})
+	list := svc.ListProviders()
+	require.Len(t, list, 5)
+	_, err := svc.GetStats(context.Background(), "nope", nil)
+	require.Error(t, err)
+	app, ok := err.(*response.AppError)
+	require.True(t, ok)
+	assert.Equal(t, response.CodeStatsProviderNotFound, app.Code)
+}
+
+func TestProvidersAll(t *testing.T) {
+	svc := NewStatsService(stubRepo{})
+	codes := []string{"member-distribution", "interview-data", "meeting-attendance", "task-progress", "internship-duration"}
+	for _, code := range codes {
+		res, err := svc.GetStats(context.Background(), code, &dto.StatsQuery{Granularity: "month", GroupBy: "department"})
+		require.NoError(t, err, code)
+		require.NotNil(t, res)
+		assert.Equal(t, code, res.Provider)
+		assert.NotEmpty(t, res.Series)
+		assert.NotNil(t, res.ChartConfig)
+	}
+}
+
+func TestMemberSummaryFields(t *testing.T) {
+	svc := NewStatsService(stubRepo{})
+	res, err := svc.GetStats(context.Background(), "member-distribution", nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(12), res.Summary["total_members"])
+	assert.Equal(t, "pie", res.Series[0].Type)
+	assert.Equal(t, "bar", res.Series[1].Type)
+	assert.Equal(t, "line", res.Series[2].Type)
+}
+
+func TestInterviewGauge(t *testing.T) {
+	svc := NewStatsService(stubRepo{})
+	res, err := svc.GetStats(context.Background(), "interview-data", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "gauge", res.Series[0].Type)
+	assert.InDelta(t, 0.625, res.Summary["pass_rate"], 0.0001)
+}
+
+func TestInvalidQuery(t *testing.T) {
+	svc := NewStatsService(stubRepo{})
+	_, err := svc.GetStats(context.Background(), "task-progress", &dto.StatsQuery{Granularity: "year"})
+	require.Error(t, err)
+	_, err = svc.GetStats(context.Background(), "task-progress", &dto.StatsQuery{GroupBy: "unknown"})
+	require.Error(t, err)
+}
+
+func TestOverviewAndExport(t *testing.T) {
+	svc := NewStatsService(stubRepo{})
+	ov, err := svc.Overview(context.Background(), uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, int64(12), ov.TotalMembers)
+
+	_, _, err = svc.Export(context.Background(), "member-distribution", "pdf", nil)
+	require.Error(t, err)
+
+	data, name, err := svc.Export(context.Background(), "member-distribution", "csv", nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+	assert.Contains(t, name, "csv")
+
+	data, name, err = svc.Export(context.Background(), "interview-data", "excel", nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+	assert.Contains(t, name, "xlsx")
+}
+
+func TestExportUnknownProvider(t *testing.T) {
+	svc := NewStatsService(stubRepo{})
+	_, _, err := svc.Export(context.Background(), "ghost", "csv", nil)
+	require.Error(t, err)
+}
+
+func TestExportTooLarge(t *testing.T) {
+	svc := NewStatsService(hugeRepo{})
+	_, _, err := svc.Export(context.Background(), "member-distribution", "csv", nil)
+	require.Error(t, err)
+	app, ok := err.(*response.AppError)
+	require.True(t, ok)
+	assert.Equal(t, response.CodeStatsTooLarge, app.Code)
+}
+
+func TestValidateQueryRange(t *testing.T) {
+	start := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	err := validateQuery(&dto.StatsQuery{StartDate: &start, EndDate: &end})
+	require.Error(t, err)
+}
+
+type hugeRepo struct{ stubRepo }
+
+func (hugeRepo) MemberByDepartment(context.Context, repo.Query) ([]repo.Bucket, error) {
+	out := make([]repo.Bucket, 5001)
+	for i := range out {
+		out[i] = repo.Bucket{Key: "k", Label: "l", Value: 1}
+	}
+	return out, nil
+}
+
+func TestRound4(t *testing.T) {
+	assert.Equal(t, 1.2346, round4(1.23455))
+}
+
+func TestToSeriesEmptyLabel(t *testing.T) {
+	s := toSeries("x", "bar", []repo.Bucket{{Key: "k", Value: 1}})
+	assert.Equal(t, "k", s.Data[0].Label)
+	assert.Equal(t, []string{"k"}, s.XAxis)
+}
+
+func TestRegistryRegisterNil(t *testing.T) {
+	r := NewRegistry()
+	r.Register(nil)
+	assert.Empty(t, r.ListProviders())
+}

--- a/backend/migrations/000030_stats_export_perm.down.sql
+++ b/backend/migrations/000030_stats_export_perm.down.sql
@@ -1,0 +1,3 @@
+DELETE FROM role_permissions
+WHERE permission_id IN (SELECT id FROM permissions WHERE code = 'stats:export');
+DELETE FROM permissions WHERE code = 'stats:export';

--- a/backend/migrations/000030_stats_export_perm.up.sql
+++ b/backend/migrations/000030_stats_export_perm.up.sql
@@ -9,3 +9,11 @@ CROSS JOIN permissions p
 WHERE r.code IN ('president', 'super_admin')
   AND p.code = 'stats:export'
 ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+INSERT INTO role_permissions (id, role_id, permission_id, data_scope)
+SELECT uuid_generate_v4(), r.id, p.id, 'department'
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.code = 'minister'
+  AND p.code = 'stats:export'
+ON CONFLICT (role_id, permission_id) DO NOTHING;

--- a/backend/migrations/000030_stats_export_perm.up.sql
+++ b/backend/migrations/000030_stats_export_perm.up.sql
@@ -1,0 +1,11 @@
+INSERT INTO permissions (id, name, code, resource, action, description, type, is_system, status)
+VALUES (uuid_generate_v4(), '统计导出', 'stats:export', 'stats', 'export', '统计导出', 3, true, 0)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO role_permissions (id, role_id, permission_id, data_scope)
+SELECT uuid_generate_v4(), r.id, p.id, 'all'
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.code IN ('president', 'super_admin')
+  AND p.code = 'stats:export'
+ON CONFLICT (role_id, permission_id) DO NOTHING;

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -148,6 +148,8 @@ const (
 	// ===== Statistics module (11000-11999) =====
 	CodeStatsProviderNotFound = 11001 // 数据提供者不存在
 	CodeStatsInvalidParam     = 11002 // 统计参数无效
+	CodeStatsExportFormat     = 11003 // 导出格式不支持
+	CodeStatsTooLarge         = 11004 // 数据量过大
 
 	// ===== Notification module (12000-12999) =====
 	CodeNotificationNotFound    = 12001 // 通知不存在

--- a/backend/scripts/seed_rbac.go
+++ b/backend/scripts/seed_rbac.go
@@ -80,6 +80,7 @@ func allSeedPermissions() []seedPerm {
 	perms = append(perms,
 		seedPerm{Name: "权限查看", Code: "permission:read", Resource: "permission", Action: "read"},
 		seedPerm{Name: "统计查看", Code: "stats:read", Resource: "stats", Action: "read"},
+		seedPerm{Name: "统计导出", Code: "stats:export", Resource: "stats", Action: "export"},
 		seedPerm{Name: "系统配置", Code: "system:config", Resource: "system", Action: "config"},
 		seedPerm{Name: "通知模板查看", Code: "notification:template:read", Resource: "notification", Action: "read"},
 		seedPerm{Name: "发送通知", Code: "notification:send", Resource: "notification", Action: "create"},
@@ -211,6 +212,7 @@ func seedRolePermissions(db *gorm.DB) error {
 			OR (p.resource = 'task' AND p.action IN ('assign','transfer','comment'))
 			OR (p.resource = 'internship' AND p.action = 'evaluate')
 			OR (p.resource = 'export' AND p.action IN ('excel','csv','pdf','json','template','download'))
+			OR (p.resource = 'stats' AND p.action = 'export')
 		)
 		ON CONFLICT (role_id, permission_id) DO NOTHING
 	`).Error; err != nil {

--- a/frontend/src/api/request.ts
+++ b/frontend/src/api/request.ts
@@ -51,6 +51,9 @@ const RETRY_DELAY = 500;
 function shouldRetry(config: InternalAxiosRequestConfig, status?: number): boolean {
   if (config.method?.toUpperCase() !== 'GET') return false;
   const retryCount = (config as { _retryCount?: number })._retryCount ?? 0;
+  if (status === 429) {
+    return retryCount < 2;
+  }
   if (retryCount >= GET_RETRY_COUNT) return false;
   // 网络错误（无 status）或 5xx 服务端错误时重试
   return !status || status >= 500;
@@ -154,7 +157,8 @@ request.interceptors.response.use(
     if (shouldRetry(originalRequest, error.response?.status)) {
       const retryCount = (originalRequest as { _retryCount?: number })._retryCount ?? 0;
       (originalRequest as { _retryCount?: number })._retryCount = retryCount + 1;
-      await delay(RETRY_DELAY);
+      const wait = error.response?.status === 429 ? 1000 : RETRY_DELAY;
+      await delay(wait);
       return request(originalRequest);
     }
 

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -1,51 +1,102 @@
 import request from './request';
-import type { DashboardStats, ChartDataPoint, PieChartData } from '@/types/api';
+import type { AxiosResponse } from 'axios';
+import { downloadBlob } from '@/utils/download';
 
-// 获取仪表盘统计
-export function getDashboardStats(): Promise<DashboardStats> {
-  return request.get('/stats/dashboard');
-}
-
-// 获取用户增长趋势
-export function getUserGrowth(params: { start_date: string; end_date: string }): Promise<ChartDataPoint[]> {
-  return request.get('/stats/user-growth', { params });
-}
-
-// 获取会员分布（按部门）
-export function getMemberByDepartment(): Promise<PieChartData[]> {
-  return request.get('/stats/members/by-department');
-}
-
-// 获取任务统计
-export function getTaskStats(params?: { department_id?: string }): Promise<{
-  total: number;
-  pending: number;
-  in_progress: number;
-  completed: number;
-  cancelled: number;
-}> {
-  return request.get('/stats/tasks', { params });
-}
-
-// 获取实习统计排名
-export function getInternshipRanking(params: {
-  top?: number;
+export interface StatsQuery {
+  start_date?: string;
+  end_date?: string;
   department_id?: string;
-  start_date?: string;
-  end_date?: string;
-}): Promise<Array<{ user_id: string; username: string; real_name: string; total_hours: number; rank: number }>> {
-  return request.get('/stats/internships/ranking', { params });
+  group_by?: string;
+  granularity?: string;
 }
 
-// 获取面试通过率统计
-export function getInterviewStats(params?: {
-  start_date?: string;
-  end_date?: string;
-}): Promise<{
-  total: number;
-  passed: number;
-  rejected: number;
-  pass_rate: number;
-}> {
-  return request.get('/stats/interviews', { params });
+export interface StatsDataPoint {
+  label: string;
+  value: number;
+}
+
+export interface StatsSeries {
+  name: string;
+  type: string;
+  data: StatsDataPoint[];
+  x_axis: string[];
+}
+
+export interface StatsChartConfig {
+  chart_type: string;
+  title: string;
+  stack?: boolean;
+  horizontal?: boolean;
+}
+
+export interface StatsResult {
+  provider: string;
+  summary: Record<string, number>;
+  series: StatsSeries[];
+  chart_config: StatsChartConfig | null;
+}
+
+export interface ProviderInfo {
+  name: string;
+  display_name: string;
+  chart_config: StatsChartConfig | null;
+}
+
+export interface OverviewMeeting {
+  id: string;
+  title: string;
+  start_time: string;
+}
+
+export interface OverviewResponse {
+  total_members: number;
+  total_meetings_this_month: number;
+  total_tasks_in_progress: number;
+  total_internships_active: number;
+  pending_approvals: number;
+  today_meetings: OverviewMeeting[];
+  my_tasks: { todo: number; overdue: number };
+  notifications_unread: number;
+}
+
+export type StatsProviderCode =
+  | 'member-distribution'
+  | 'interview-data'
+  | 'meeting-attendance'
+  | 'task-progress'
+  | 'internship-duration';
+
+export function listStatsProviders(): Promise<ProviderInfo[]> {
+  return request.get('/stats/providers');
+}
+
+export function getStatsOverview(): Promise<OverviewResponse> {
+  return request.get('/stats/overview');
+}
+
+export function getStats(provider: string, params?: StatsQuery): Promise<StatsResult> {
+  return request.get(`/stats/${provider}`, { params });
+}
+
+function filenameFromDisposition(header: string | undefined, fallback: string): string {
+  if (!header) return fallback;
+  const match = /filename\*=UTF-8''([^;]+)|filename="?([^"]+)"?/i.exec(header);
+  const raw = match?.[1] || match?.[2];
+  return raw ? decodeURIComponent(raw) : fallback;
+}
+
+export async function exportStats(
+  provider: string,
+  format: 'csv' | 'excel',
+  params?: StatsQuery,
+): Promise<void> {
+  const response: AxiosResponse = await request.get(`/stats/export/${provider}`, {
+    params: { ...params, format },
+    responseType: 'blob',
+  });
+  const fallback = format === 'excel' ? `stats_${provider}.xlsx` : `stats_${provider}.csv`;
+  downloadBlob(
+    response.data as Blob,
+    filenameFromDisposition(response.headers['content-disposition'] as string | undefined, fallback),
+  );
 }

--- a/frontend/src/components/Chart/ChartCard.tsx
+++ b/frontend/src/components/Chart/ChartCard.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Alert, Button, Card, Dropdown, Empty, Space } from 'antd';
+import { DownloadOutlined } from '@ant-design/icons';
+import type { EChartsOption } from 'echarts';
+import { useECharts } from './useECharts';
+
+export interface ChartCardProps {
+  title: string;
+  loading?: boolean;
+  error?: string;
+  option?: EChartsOption;
+  empty?: boolean;
+  height?: number;
+  onExport?: (format: 'csv' | 'excel') => void;
+  actions?: React.ReactNode;
+}
+
+const ChartCard: React.FC<ChartCardProps> = ({
+  title,
+  loading = false,
+  error,
+  option,
+  empty,
+  height = 300,
+  onExport,
+  actions,
+}) => {
+  const hideChart = !!error || (!!empty && !loading);
+  const { ref, chart } = useECharts(hideChart ? undefined : option, loading && !error);
+
+  const extra = (
+    <Space size={8}>
+      {actions}
+      <Button
+        size="small"
+        icon={<DownloadOutlined />}
+        onClick={() => {
+          const inst = chart.current;
+          if (!inst) return;
+          const url = inst.getDataURL({ type: 'png', pixelRatio: 2, backgroundColor: '#fff' });
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = `${title}.png`;
+          a.click();
+        }}
+        disabled={hideChart || loading}
+      >
+        PNG
+      </Button>
+      {onExport ? (
+        <Dropdown
+          menu={{
+            items: [
+              { key: 'excel', label: 'Excel' },
+              { key: 'csv', label: 'CSV' },
+            ],
+            onClick: ({ key }) => onExport(key === 'csv' ? 'csv' : 'excel'),
+          }}
+        >
+          <Button size="small" disabled={loading}>导出</Button>
+        </Dropdown>
+      ) : null}
+    </Space>
+  );
+
+  return (
+    <Card title={title} extra={extra} size="small">
+      {error ? <Alert type="error" message={error} showIcon style={{ marginBottom: 12 }} /> : null}
+      {empty && !loading && !error ? <Empty description="暂无数据" /> : null}
+      <div
+        ref={ref}
+        style={{ width: '100%', height, display: hideChart ? 'none' : 'block' }}
+      />
+    </Card>
+  );
+};
+
+export default ChartCard;

--- a/frontend/src/components/Chart/ChartCard.tsx
+++ b/frontend/src/components/Chart/ChartCard.tsx
@@ -66,11 +66,14 @@ const ChartCard: React.FC<ChartCardProps> = ({
   return (
     <Card title={title} extra={extra} size="small">
       {error ? <Alert type="error" message={error} showIcon style={{ marginBottom: 12 }} /> : null}
-      {empty && !loading && !error ? <Empty description="暂无数据" /> : null}
-      <div
-        ref={ref}
-        style={{ width: '100%', height, display: hideChart ? 'none' : 'block' }}
-      />
+      <div style={{ position: 'relative', height }}>
+        {empty && !loading && !error ? (
+          <div style={{ position: 'absolute', inset: 0, zIndex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#fff' }}>
+            <Empty description="暂无数据" />
+          </div>
+        ) : null}
+        <div ref={ref} style={{ width: '100%', height, visibility: error ? 'hidden' : 'visible' }} />
+      </div>
     </Card>
   );
 };

--- a/frontend/src/components/Chart/useECharts.ts
+++ b/frontend/src/components/Chart/useECharts.ts
@@ -36,6 +36,9 @@ export function useECharts(option: EChartsOption | undefined, loading: boolean) 
     chart.hideLoading();
     if (option) {
       chart.setOption(option, true);
+      requestAnimationFrame(() => {
+        chart.resize();
+      });
     }
   }, [option, loading]);
 

--- a/frontend/src/components/Chart/useECharts.ts
+++ b/frontend/src/components/Chart/useECharts.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import * as echarts from 'echarts';
+import type { EChartsOption } from 'echarts';
+
+export function useECharts(option: EChartsOption | undefined, loading: boolean) {
+  const ref = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<echarts.ECharts | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return undefined;
+    }
+    const chart = echarts.init(el);
+    chartRef.current = chart;
+    const onResize = () => {
+      chart.resize();
+    };
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      chart.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) {
+      return;
+    }
+    if (loading) {
+      chart.showLoading();
+      return;
+    }
+    chart.hideLoading();
+    if (option) {
+      chart.setOption(option, true);
+    }
+  }, [option, loading]);
+
+  return { ref, chart: chartRef };
+}

--- a/frontend/src/pages/stats/OverviewPage.tsx
+++ b/frontend/src/pages/stats/OverviewPage.tsx
@@ -1,0 +1,156 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Card, Col, Row, Select, Space, Statistic, Typography, message } from 'antd';
+import {
+  exportStats,
+  getStats,
+  getStatsOverview,
+  type OverviewResponse,
+  type StatsProviderCode,
+  type StatsQuery,
+  type StatsResult,
+} from '@/api/stats';
+import { getMemberDepartments } from '@/api/member';
+import type { MemberDepartmentOption } from '@/types/api';
+import { usePermission } from '@/hooks/usePermission';
+import TimeRangeSelect, { resolveTimeRange, type TimeRangeValue } from './TimeRangeSelect';
+import ProviderCharts from './ProviderCharts';
+import './stats.css';
+
+const PROVIDERS: Array<{ code: StatsProviderCode; title: string }> = [
+  { code: 'member-distribution', title: '会员分布' },
+  { code: 'interview-data', title: '面试数据统计' },
+  { code: 'meeting-attendance', title: '会议出席统计' },
+  { code: 'task-progress', title: '任务进度统计' },
+  { code: 'internship-duration', title: '实习时长统计' },
+];
+
+const OverviewPage: React.FC = () => {
+  const canExport = usePermission('stats:export');
+  const [range, setRange] = useState<TimeRangeValue>({ preset: 'month' });
+  const [departmentId, setDepartmentId] = useState<string>();
+  const [groupBy, setGroupBy] = useState<string | undefined>();
+  const [granularity, setGranularity] = useState('month');
+  const [departments, setDepartments] = useState<MemberDepartmentOption[]>([]);
+  const [overview, setOverview] = useState<OverviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [results, setResults] = useState<Partial<Record<StatsProviderCode, StatsResult>>>({});
+  const [errors, setErrors] = useState<Partial<Record<StatsProviderCode, string>>>({});
+
+  const query = useMemo<StatsQuery>(() => {
+    const dates = resolveTimeRange(range);
+    return {
+      ...dates,
+      department_id: departmentId,
+      group_by: groupBy,
+      granularity,
+    };
+  }, [range, departmentId, groupBy, granularity]);
+
+  useEffect(() => {
+    void getMemberDepartments().then(setDepartments).catch(() => undefined);
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const ov = await getStatsOverview();
+      setOverview(ov);
+    } catch {
+      setOverview(null);
+    }
+    const next: Partial<Record<StatsProviderCode, StatsResult>> = {};
+    const errs: Partial<Record<StatsProviderCode, string>> = {};
+    await Promise.all(
+      PROVIDERS.map(async (p) => {
+        try {
+          next[p.code] = await getStats(p.code, query);
+        } catch (e) {
+          errs[p.code] = e instanceof Error ? e.message : '加载失败';
+        }
+      }),
+    );
+    setResults(next);
+    setErrors(errs);
+    setLoading(false);
+  }, [query]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleExport = async (code: StatsProviderCode, format: 'csv' | 'excel') => {
+    try {
+      await exportStats(code, format, query);
+    } catch {
+      message.error('导出失败');
+    }
+  };
+
+  return (
+    <div className="stats-page">
+      <div className="stats-hero">
+        <div>
+          <Typography.Title level={3} style={{ color: '#fff', margin: 0 }}>统计概览</Typography.Title>
+          <Typography.Paragraph style={{ color: 'rgba(255,255,255,.85)', margin: '6px 0 0' }}>
+            会员 / 面试 / 会议 / 任务 / 实习 一期五组图表
+          </Typography.Paragraph>
+        </div>
+        <Space wrap size={12}>
+          <TimeRangeSelect value={range} onChange={setRange} />
+          <Select
+            allowClear
+            placeholder="部门"
+            style={{ minWidth: 160 }}
+            value={departmentId}
+            onChange={setDepartmentId}
+            options={departments.map((d) => ({ value: d.id, label: d.name }))}
+          />
+          <Select
+            value={granularity}
+            style={{ width: 110 }}
+            onChange={setGranularity}
+            options={[
+              { value: 'day', label: '按日' },
+              { value: 'week', label: '按周' },
+              { value: 'month', label: '按月' },
+            ]}
+          />
+          <Select
+            allowClear
+            placeholder="分组"
+            style={{ width: 120 }}
+            value={groupBy}
+            onChange={setGroupBy}
+            options={[
+              { value: 'department', label: '部门' },
+              { value: 'date', label: '日期' },
+              { value: 'status', label: '状态' },
+              { value: 'grade', label: '年级' },
+              { value: 'type', label: '类型' },
+            ]}
+          />
+        </Space>
+      </div>
+
+      <Row gutter={[16, 16]} className="stats-kpis">
+        <Col xs={12} md={6}><Card><Statistic title="会员总数" value={overview?.total_members ?? 0} /></Card></Col>
+        <Col xs={12} md={6}><Card><Statistic title="本月会议" value={overview?.total_meetings_this_month ?? 0} /></Card></Col>
+        <Col xs={12} md={6}><Card><Statistic title="进行中任务" value={overview?.total_tasks_in_progress ?? 0} /></Card></Col>
+        <Col xs={12} md={6}><Card><Statistic title="活跃实习" value={overview?.total_internships_active ?? 0} /></Card></Col>
+      </Row>
+
+      {PROVIDERS.map((p) => (
+        <Card key={p.code} className="stats-section" title={p.title}>
+          <ProviderCharts
+            result={results[p.code]}
+            loading={loading}
+            error={errors[p.code]}
+            onExport={canExport ? (format) => { void handleExport(p.code, format); } : undefined}
+          />
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default OverviewPage;

--- a/frontend/src/pages/stats/OverviewPage.tsx
+++ b/frontend/src/pages/stats/OverviewPage.tsx
@@ -28,7 +28,6 @@ const OverviewPage: React.FC = () => {
   const canExport = usePermission('stats:export');
   const [range, setRange] = useState<TimeRangeValue>({ preset: 'month' });
   const [departmentId, setDepartmentId] = useState<string>();
-  const [groupBy, setGroupBy] = useState<string | undefined>();
   const [granularity, setGranularity] = useState('month');
   const [departments, setDepartments] = useState<MemberDepartmentOption[]>([]);
   const [overview, setOverview] = useState<OverviewResponse | null>(null);
@@ -41,10 +40,9 @@ const OverviewPage: React.FC = () => {
     return {
       ...dates,
       department_id: departmentId,
-      group_by: groupBy,
       granularity,
     };
-  }, [range, departmentId, groupBy, granularity]);
+  }, [range, departmentId, granularity]);
 
   useEffect(() => {
     void getMemberDepartments().then(setDepartments).catch(() => undefined);
@@ -111,20 +109,6 @@ const OverviewPage: React.FC = () => {
               { value: 'day', label: '按日' },
               { value: 'week', label: '按周' },
               { value: 'month', label: '按月' },
-            ]}
-          />
-          <Select
-            allowClear
-            placeholder="分组"
-            style={{ width: 120 }}
-            value={groupBy}
-            onChange={setGroupBy}
-            options={[
-              { value: 'department', label: '部门' },
-              { value: 'date', label: '日期' },
-              { value: 'status', label: '状态' },
-              { value: 'grade', label: '年级' },
-              { value: 'type', label: '类型' },
             ]}
           />
         </Space>

--- a/frontend/src/pages/stats/OverviewPage.tsx
+++ b/frontend/src/pages/stats/OverviewPage.tsx
@@ -52,23 +52,21 @@ const OverviewPage: React.FC = () => {
 
   const load = useCallback(async () => {
     setLoading(true);
+    const next: Partial<Record<StatsProviderCode, StatsResult>> = {};
+    const errs: Partial<Record<StatsProviderCode, string>> = {};
     try {
       const ov = await getStatsOverview();
       setOverview(ov);
     } catch {
       setOverview(null);
     }
-    const next: Partial<Record<StatsProviderCode, StatsResult>> = {};
-    const errs: Partial<Record<StatsProviderCode, string>> = {};
-    await Promise.all(
-      PROVIDERS.map(async (p) => {
-        try {
-          next[p.code] = await getStats(p.code, query);
-        } catch (e) {
-          errs[p.code] = e instanceof Error ? e.message : '加载失败';
-        }
-      }),
-    );
+    for (const p of PROVIDERS) {
+      try {
+        next[p.code] = await getStats(p.code, query);
+      } catch (e) {
+        errs[p.code] = e instanceof Error ? e.message : '加载失败';
+      }
+    }
     setResults(next);
     setErrors(errs);
     setLoading(false);

--- a/frontend/src/pages/stats/ProviderCharts.tsx
+++ b/frontend/src/pages/stats/ProviderCharts.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Col, Row, Statistic } from 'antd';
+import ChartCard from '@/components/Chart/ChartCard';
+import type { StatsResult } from '@/api/stats';
+import {
+  barOption,
+  calendarOption,
+  gaugeOption,
+  lineOption,
+  pieOption,
+  seriesEmpty,
+  stackedBarOption,
+} from './chartOptions';
+
+interface ProviderChartsProps {
+  result: StatsResult | undefined;
+  loading: boolean;
+  error?: string;
+  onExport?: (format: 'csv' | 'excel') => void;
+}
+
+const ProviderCharts: React.FC<ProviderChartsProps> = ({ result, loading, error, onExport }) => {
+  const series = result?.series || [];
+  const summary = result?.summary || {};
+
+  if (result?.provider === 'member-distribution') {
+    return (
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <ChartCard title="部门分布" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? pieOption(series[0]) : undefined} height={280} onExport={onExport} />
+        </Col>
+        <Col xs={24} md={8}>
+          <ChartCard title="年级分布" loading={loading} error={error} empty={seriesEmpty(series[1])} option={series[1] ? barOption(series[1]) : undefined} height={280} />
+        </Col>
+        <Col xs={24} md={8}>
+          <ChartCard title="增长趋势" loading={loading} error={error} empty={seriesEmpty(series[2])} option={series[2] ? lineOption(series[2]) : undefined} height={280} />
+        </Col>
+      </Row>
+    );
+  }
+
+  if (result?.provider === 'interview-data') {
+    return (
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={6}>
+          <ChartCard title="通过率" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? gaugeOption(series[0]) : undefined} height={280} onExport={onExport} />
+        </Col>
+        <Col xs={24} md={6}>
+          <ChartCard title="各部门面试人数" loading={loading} error={error} empty={seriesEmpty(series[1])} option={series[1] ? barOption(series[1]) : undefined} height={280} />
+        </Col>
+        <Col xs={24} md={6}>
+          <ChartCard title="评分分布" loading={loading} error={error} empty={seriesEmpty(series[2])} option={series[2] ? barOption(series[2]) : undefined} height={280} />
+        </Col>
+        <Col xs={24} md={6}>
+          <ChartCard title="面试趋势" loading={loading} error={error} empty={seriesEmpty(series[3])} option={series[3] ? lineOption(series[3]) : undefined} height={280} />
+        </Col>
+      </Row>
+    );
+  }
+
+  if (result?.provider === 'meeting-attendance') {
+    return (
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <ChartCard title="出席率" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? lineOption(series[0]) : undefined} height={280} onExport={onExport} />
+        </Col>
+        <Col xs={24} md={8}>
+          <ChartCard title="各部门会议数" loading={loading} error={error} empty={seriesEmpty(series[1])} option={series[1] ? barOption(series[1]) : undefined} height={280} />
+        </Col>
+        <Col xs={24} md={8}>
+          <ChartCard title="会议频率" loading={loading} error={error} empty={seriesEmpty(series[2])} option={series[2] ? calendarOption(series[2]) : undefined} height={280} />
+        </Col>
+      </Row>
+    );
+  }
+
+  if (result?.provider === 'task-progress') {
+    const stacked = series.slice(1);
+    return (
+      <>
+        <Row gutter={16} style={{ marginBottom: 12 }}>
+          <Col span={8}><Statistic title="任务总数" value={summary.total_tasks || 0} /></Col>
+          <Col span={8}><Statistic title="按时完成率" value={Number(((summary.on_time_rate || 0) * 100).toFixed(1))} suffix="%" /></Col>
+          <Col span={8}><Statistic title="进行中" value={summary.in_progress || 0} /></Col>
+        </Row>
+        <Row gutter={[16, 16]}>
+          <Col xs={24} md={10}>
+            <ChartCard title="任务状态" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? pieOption(series[0]) : undefined} height={280} onExport={onExport} />
+          </Col>
+          <Col xs={24} md={14}>
+            <ChartCard title="状态趋势" loading={loading} error={error} empty={stacked.every(seriesEmpty)} option={stacked.length ? stackedBarOption(stacked) : undefined} height={280} />
+          </Col>
+        </Row>
+      </>
+    );
+  }
+
+  if (result?.provider === 'internship-duration') {
+    return (
+      <Row gutter={[16, 16]}>
+        <Col xs={24} md={8}>
+          <ChartCard title="时长排行" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? barOption(series[0], true) : undefined} height={320} onExport={onExport} />
+        </Col>
+        <Col xs={24} md={8}>
+          <ChartCard title="部门平均时长" loading={loading} error={error} empty={seriesEmpty(series[1])} option={series[1] ? barOption(series[1]) : undefined} height={320} />
+        </Col>
+        <Col xs={24} md={8}>
+          <ChartCard title="时长趋势" loading={loading} error={error} empty={seriesEmpty(series[2])} option={series[2] ? lineOption(series[2]) : undefined} height={320} />
+        </Col>
+      </Row>
+    );
+  }
+
+  return (
+    <ChartCard title={result?.chart_config?.title || '统计'} loading={loading} error={error} empty={!series.length} option={series[0] ? barOption(series[0]) : undefined} onExport={onExport} />
+  );
+};
+
+export default ProviderCharts;

--- a/frontend/src/pages/stats/ProviderCharts.tsx
+++ b/frontend/src/pages/stats/ProviderCharts.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Col, Row, Statistic } from 'antd';
 import ChartCard from '@/components/Chart/ChartCard';
-import type { StatsResult } from '@/api/stats';
+import type { StatsResult, StatsSeries } from '@/api/stats';
 import {
   barOption,
   calendarOption,
@@ -19,63 +19,78 @@ interface ProviderChartsProps {
   onExport?: (format: 'csv' | 'excel') => void;
 }
 
+function byName(series: StatsSeries[], name: string): StatsSeries | undefined {
+  return series.find((s) => s.name === name);
+}
+
 const ProviderCharts: React.FC<ProviderChartsProps> = ({ result, loading, error, onExport }) => {
   const series = result?.series || [];
   const summary = result?.summary || {};
 
   if (result?.provider === 'member-distribution') {
+    const dept = byName(series, '部门分布');
+    const grade = byName(series, '年级分布');
+    const trend = byName(series, '增长趋势');
     return (
       <Row gutter={[16, 16]}>
         <Col xs={24} md={8}>
-          <ChartCard title="部门分布" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? pieOption(series[0]) : undefined} height={280} onExport={onExport} />
+          <ChartCard title="部门分布" loading={loading} error={error} empty={seriesEmpty(dept)} option={dept ? pieOption(dept) : undefined} height={280} onExport={onExport} />
         </Col>
         <Col xs={24} md={8}>
-          <ChartCard title="年级分布" loading={loading} error={error} empty={seriesEmpty(series[1])} option={series[1] ? barOption(series[1]) : undefined} height={280} />
+          <ChartCard title="年级分布" loading={loading} error={error} empty={seriesEmpty(grade)} option={grade ? barOption(grade) : undefined} height={280} />
         </Col>
         <Col xs={24} md={8}>
-          <ChartCard title="增长趋势" loading={loading} error={error} empty={seriesEmpty(series[2])} option={series[2] ? lineOption(series[2]) : undefined} height={280} />
+          <ChartCard title="增长趋势" loading={loading} error={error} empty={seriesEmpty(trend)} option={trend ? lineOption(trend) : undefined} height={280} />
         </Col>
       </Row>
     );
   }
 
   if (result?.provider === 'interview-data') {
+    const gauge = byName(series, '通过率');
+    const dept = byName(series, '各部门面试人数');
+    const hist = byName(series, '评分分布');
+    const trend = byName(series, '面试趋势');
     return (
       <Row gutter={[16, 16]}>
         <Col xs={24} md={6}>
-          <ChartCard title="通过率" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? gaugeOption(series[0]) : undefined} height={280} onExport={onExport} />
+          <ChartCard title="通过率" loading={loading} error={error} empty={seriesEmpty(gauge)} option={gauge ? gaugeOption(gauge) : undefined} height={280} onExport={onExport} />
         </Col>
         <Col xs={24} md={6}>
-          <ChartCard title="各部门面试人数" loading={loading} error={error} empty={seriesEmpty(series[1])} option={series[1] ? barOption(series[1]) : undefined} height={280} />
+          <ChartCard title="各部门面试人数" loading={loading} error={error} empty={seriesEmpty(dept)} option={dept ? barOption(dept) : undefined} height={280} />
         </Col>
         <Col xs={24} md={6}>
-          <ChartCard title="评分分布" loading={loading} error={error} empty={seriesEmpty(series[2])} option={series[2] ? barOption(series[2]) : undefined} height={280} />
+          <ChartCard title="评分分布" loading={loading} error={error} empty={seriesEmpty(hist)} option={hist ? barOption(hist) : undefined} height={280} />
         </Col>
         <Col xs={24} md={6}>
-          <ChartCard title="面试趋势" loading={loading} error={error} empty={seriesEmpty(series[3])} option={series[3] ? lineOption(series[3]) : undefined} height={280} />
+          <ChartCard title="面试趋势" loading={loading} error={error} empty={seriesEmpty(trend)} option={trend ? lineOption(trend) : undefined} height={280} />
         </Col>
       </Row>
     );
   }
 
   if (result?.provider === 'meeting-attendance') {
+    const rate = byName(series, '出席率');
+    const dept = byName(series, '各部门会议数');
+    const cal = byName(series, '会议频率');
     return (
       <Row gutter={[16, 16]}>
         <Col xs={24} md={8}>
-          <ChartCard title="出席率" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? lineOption(series[0]) : undefined} height={280} onExport={onExport} />
+          <ChartCard title="出席率" loading={loading} error={error} empty={seriesEmpty(rate)} option={rate ? lineOption(rate) : undefined} height={280} onExport={onExport} />
         </Col>
         <Col xs={24} md={8}>
-          <ChartCard title="各部门会议数" loading={loading} error={error} empty={seriesEmpty(series[1])} option={series[1] ? barOption(series[1]) : undefined} height={280} />
+          <ChartCard title="各部门会议数" loading={loading} error={error} empty={seriesEmpty(dept)} option={dept ? barOption(dept) : undefined} height={280} />
         </Col>
         <Col xs={24} md={8}>
-          <ChartCard title="会议频率" loading={loading} error={error} empty={seriesEmpty(series[2])} option={series[2] ? calendarOption(series[2]) : undefined} height={280} />
+          <ChartCard title="会议频率" loading={loading} error={error} empty={seriesEmpty(cal)} option={cal ? calendarOption(cal) : undefined} height={280} />
         </Col>
       </Row>
     );
   }
 
   if (result?.provider === 'task-progress') {
-    const stacked = series.slice(1);
+    const pie = byName(series, '任务状态');
+    const stacked = series.filter((s) => s.name !== '任务状态' && s.type === 'bar');
     return (
       <>
         <Row gutter={16} style={{ marginBottom: 12 }}>
@@ -85,7 +100,7 @@ const ProviderCharts: React.FC<ProviderChartsProps> = ({ result, loading, error,
         </Row>
         <Row gutter={[16, 16]}>
           <Col xs={24} md={10}>
-            <ChartCard title="任务状态" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? pieOption(series[0]) : undefined} height={280} onExport={onExport} />
+            <ChartCard title="任务状态" loading={loading} error={error} empty={seriesEmpty(pie)} option={pie ? pieOption(pie) : undefined} height={280} onExport={onExport} />
           </Col>
           <Col xs={24} md={14}>
             <ChartCard title="状态趋势" loading={loading} error={error} empty={stacked.every(seriesEmpty)} option={stacked.length ? stackedBarOption(stacked) : undefined} height={280} />
@@ -96,16 +111,19 @@ const ProviderCharts: React.FC<ProviderChartsProps> = ({ result, loading, error,
   }
 
   if (result?.provider === 'internship-duration') {
+    const rank = byName(series, '时长排行');
+    const dept = byName(series, '部门平均时长');
+    const trend = byName(series, '时长趋势');
     return (
       <Row gutter={[16, 16]}>
         <Col xs={24} md={8}>
-          <ChartCard title="时长排行" loading={loading} error={error} empty={seriesEmpty(series[0])} option={series[0] ? barOption(series[0], true) : undefined} height={320} onExport={onExport} />
+          <ChartCard title="时长排行" loading={loading} error={error} empty={seriesEmpty(rank)} option={rank ? barOption(rank, true) : undefined} height={320} onExport={onExport} />
         </Col>
         <Col xs={24} md={8}>
-          <ChartCard title="部门平均时长" loading={loading} error={error} empty={seriesEmpty(series[1])} option={series[1] ? barOption(series[1]) : undefined} height={320} />
+          <ChartCard title="部门平均时长" loading={loading} error={error} empty={seriesEmpty(dept)} option={dept ? barOption(dept) : undefined} height={320} />
         </Col>
         <Col xs={24} md={8}>
-          <ChartCard title="时长趋势" loading={loading} error={error} empty={seriesEmpty(series[2])} option={series[2] ? lineOption(series[2]) : undefined} height={320} />
+          <ChartCard title="时长趋势" loading={loading} error={error} empty={seriesEmpty(trend)} option={trend ? lineOption(trend) : undefined} height={320} />
         </Col>
       </Row>
     );

--- a/frontend/src/pages/stats/TimeRangeSelect.tsx
+++ b/frontend/src/pages/stats/TimeRangeSelect.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { DatePicker, Radio, Space } from 'antd';
+import type { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+
+export type TimePreset = 'today' | 'week' | 'month' | 'semester' | 'custom';
+
+export interface TimeRangeValue {
+  preset: TimePreset;
+  start?: string;
+  end?: string;
+}
+
+interface TimeRangeSelectProps {
+  value: TimeRangeValue;
+  onChange: (next: TimeRangeValue) => void;
+}
+
+function semesterRange(now: Dayjs): [Dayjs, Dayjs] {
+  if (now.month() >= 7) {
+    return [now.month(7).date(1).startOf('day'), now.add(1, 'year').month(0).date(31).endOf('day')];
+  }
+  return [now.month(1).date(1).startOf('day'), now.month(6).date(31).endOf('day')];
+}
+
+export function resolveTimeRange(value: TimeRangeValue): { start_date?: string; end_date?: string } {
+  const now = dayjs();
+  let start = value.start ? dayjs(value.start) : undefined;
+  let end = value.end ? dayjs(value.end) : undefined;
+  switch (value.preset) {
+    case 'today':
+      start = now.startOf('day');
+      end = now.endOf('day');
+      break;
+    case 'week':
+      start = now.startOf('week');
+      end = now.endOf('week');
+      break;
+    case 'month':
+      start = now.startOf('month');
+      end = now.endOf('month');
+      break;
+    case 'semester': {
+      const range = semesterRange(now);
+      start = range[0];
+      end = range[1];
+      break;
+    }
+    default:
+      break;
+  }
+  return {
+    start_date: start ? start.format('YYYY-MM-DD') : undefined,
+    end_date: end ? end.format('YYYY-MM-DD') : undefined,
+  };
+}
+
+const TimeRangeSelect: React.FC<TimeRangeSelectProps> = ({ value, onChange }) => (
+  <Space wrap>
+    <Radio.Group
+      value={value.preset}
+      onChange={(e) => onChange({ ...value, preset: e.target.value as TimePreset })}
+    >
+      <Radio.Button value="today">今天</Radio.Button>
+      <Radio.Button value="week">本周</Radio.Button>
+      <Radio.Button value="month">本月</Radio.Button>
+      <Radio.Button value="semester">本学期</Radio.Button>
+      <Radio.Button value="custom">自定义</Radio.Button>
+    </Radio.Group>
+    {value.preset === 'custom' ? (
+      <DatePicker.RangePicker
+        value={value.start && value.end ? [dayjs(value.start), dayjs(value.end)] : null}
+        onChange={(dates) => {
+          onChange({
+            preset: 'custom',
+            start: dates?.[0]?.format('YYYY-MM-DD'),
+            end: dates?.[1]?.format('YYYY-MM-DD'),
+          });
+        }}
+      />
+    ) : null}
+  </Space>
+);
+
+export default TimeRangeSelect;

--- a/frontend/src/pages/stats/TimeRangeSelect.tsx
+++ b/frontend/src/pages/stats/TimeRangeSelect.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { DatePicker, Radio, Space } from 'antd';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
+import 'dayjs/locale/zh-cn';
+
+dayjs.locale('zh-cn');
 
 export type TimePreset = 'today' | 'week' | 'month' | 'semester' | 'custom';
 
@@ -17,8 +20,12 @@ interface TimeRangeSelectProps {
 }
 
 function semesterRange(now: Dayjs): [Dayjs, Dayjs] {
-  if (now.month() >= 7) {
+  const month = now.month();
+  if (month >= 7) {
     return [now.month(7).date(1).startOf('day'), now.add(1, 'year').month(0).date(31).endOf('day')];
+  }
+  if (month === 0) {
+    return [now.subtract(1, 'year').month(7).date(1).startOf('day'), now.month(0).date(31).endOf('day')];
   }
   return [now.month(1).date(1).startOf('day'), now.month(6).date(31).endOf('day')];
 }

--- a/frontend/src/pages/stats/chartOptions.ts
+++ b/frontend/src/pages/stats/chartOptions.ts
@@ -71,8 +71,13 @@ export function gaugeOption(series: StatsSeries): EChartsOption {
 export function calendarOption(series: StatsSeries): EChartsOption {
   const values = series.data.map((d) => d.value);
   const max = values.length ? Math.max(...values) : 1;
-  const years = series.data.map((d) => d.label.slice(0, 4)).filter(Boolean);
-  const year = years[0] || String(new Date().getFullYear());
+  const labels = series.data.map((d) => d.label).filter(Boolean).sort();
+  const year = String(new Date().getFullYear());
+  const calRange: string | [string, string] = labels.length
+    ? (labels[0].slice(0, 4) === labels[labels.length - 1].slice(0, 4)
+      ? labels[0].slice(0, 4)
+      : [labels[0], labels[labels.length - 1]])
+    : year;
   return {
     tooltip: {
       formatter: (params: unknown) => {
@@ -81,7 +86,7 @@ export function calendarOption(series: StatsSeries): EChartsOption {
       },
     },
     visualMap: { min: 0, max, orient: 'horizontal', left: 'center', bottom: 0, calculable: true },
-    calendar: { range: year, left: 48, right: 16, top: 32, bottom: 48, cellSize: ['auto', 16] },
+    calendar: { range: calRange, left: 48, right: 16, top: 32, bottom: 48, cellSize: ['auto', 16] },
     series: [
       {
         type: 'heatmap',

--- a/frontend/src/pages/stats/chartOptions.ts
+++ b/frontend/src/pages/stats/chartOptions.ts
@@ -29,7 +29,7 @@ export function barOption(series: StatsSeries, horizontal = false): EChartsOptio
       grid: { left: 80, right: 24, top: 24, bottom: 24 },
       xAxis: { type: 'value', minInterval: 1 },
       yAxis: { type: 'category', data: cats },
-      series: [{ name: series.name, type: 'bar', data: values }],
+      series: [{ name: series.name, type: 'bar', data: values, barMaxWidth: 48 }],
     };
   }
   return {
@@ -37,7 +37,7 @@ export function barOption(series: StatsSeries, horizontal = false): EChartsOptio
     grid: { left: 40, right: 16, top: 24, bottom: 32 },
     xAxis: { type: 'category', data: cats },
     yAxis: { type: 'value', minInterval: 1 },
-    series: [{ name: series.name, type: 'bar', data: values }],
+    series: [{ name: series.name, type: 'bar', data: values, barMaxWidth: 48 }],
   };
 }
 
@@ -109,6 +109,7 @@ export function stackedBarOption(seriesList: StatsSeries[]): EChartsOption {
       name: s.name,
       type: 'bar' as const,
       stack: 'status',
+      barMaxWidth: 48,
       data: cats.map((cat) => s.data.find((d) => d.label === cat)?.value ?? 0),
     })),
   };

--- a/frontend/src/pages/stats/chartOptions.ts
+++ b/frontend/src/pages/stats/chartOptions.ts
@@ -1,0 +1,115 @@
+import type { EChartsOption } from 'echarts';
+import type { StatsSeries } from '@/api/stats';
+
+export function seriesEmpty(series: StatsSeries | undefined): boolean {
+  return !series || !series.data || series.data.length === 0;
+}
+
+export function pieOption(series: StatsSeries): EChartsOption {
+  return {
+    tooltip: { trigger: 'item' },
+    legend: { bottom: 0 },
+    series: [
+      {
+        name: series.name,
+        type: 'pie',
+        radius: ['36%', '64%'],
+        data: series.data.map((d) => ({ name: d.label, value: d.value })),
+      },
+    ],
+  };
+}
+
+export function barOption(series: StatsSeries, horizontal = false): EChartsOption {
+  const cats = series.x_axis?.length ? series.x_axis : series.data.map((d) => d.label);
+  const values = series.data.map((d) => d.value);
+  if (horizontal) {
+    return {
+      tooltip: { trigger: 'axis' },
+      grid: { left: 80, right: 24, top: 24, bottom: 24 },
+      xAxis: { type: 'value', minInterval: 1 },
+      yAxis: { type: 'category', data: cats },
+      series: [{ name: series.name, type: 'bar', data: values }],
+    };
+  }
+  return {
+    tooltip: { trigger: 'axis' },
+    grid: { left: 40, right: 16, top: 24, bottom: 32 },
+    xAxis: { type: 'category', data: cats },
+    yAxis: { type: 'value', minInterval: 1 },
+    series: [{ name: series.name, type: 'bar', data: values }],
+  };
+}
+
+export function lineOption(series: StatsSeries): EChartsOption {
+  const cats = series.x_axis?.length ? series.x_axis : series.data.map((d) => d.label);
+  return {
+    tooltip: { trigger: 'axis' },
+    grid: { left: 40, right: 16, top: 24, bottom: 32 },
+    xAxis: { type: 'category', data: cats },
+    yAxis: { type: 'value' },
+    series: [{ name: series.name, type: 'line', smooth: true, data: series.data.map((d) => d.value) }],
+  };
+}
+
+export function gaugeOption(series: StatsSeries): EChartsOption {
+  const value = series.data[0]?.value ?? 0;
+  return {
+    series: [
+      {
+        type: 'gauge',
+        min: 0,
+        max: 100,
+        progress: { show: true },
+        detail: { formatter: '{value}%', fontSize: 16 },
+        data: [{ value: Number(value.toFixed(1)), name: series.name }],
+      },
+    ],
+  };
+}
+
+export function calendarOption(series: StatsSeries): EChartsOption {
+  const values = series.data.map((d) => d.value);
+  const max = values.length ? Math.max(...values) : 1;
+  const years = series.data.map((d) => d.label.slice(0, 4)).filter(Boolean);
+  const year = years[0] || String(new Date().getFullYear());
+  return {
+    tooltip: {
+      formatter: (params: unknown) => {
+        const p = params as { value?: [string, number] };
+        return `${p.value?.[0] || ''}：${p.value?.[1] ?? 0}`;
+      },
+    },
+    visualMap: { min: 0, max, orient: 'horizontal', left: 'center', bottom: 0, calculable: true },
+    calendar: { range: year, left: 48, right: 16, top: 32, bottom: 48, cellSize: ['auto', 16] },
+    series: [
+      {
+        type: 'heatmap',
+        coordinateSystem: 'calendar',
+        data: series.data.map((d) => [d.label, d.value]),
+      },
+    ],
+  };
+}
+
+export function stackedBarOption(seriesList: StatsSeries[]): EChartsOption {
+  const cats: string[] = [];
+  seriesList.forEach((s) => {
+    (s.x_axis?.length ? s.x_axis : s.data.map((d) => d.label)).forEach((c) => {
+      if (!cats.includes(c)) cats.push(c);
+    });
+  });
+  return {
+    tooltip: { trigger: 'axis' },
+    legend: { bottom: 0 },
+    grid: { left: 40, right: 16, top: 24, bottom: 48 },
+    xAxis: { type: 'category', data: cats },
+    yAxis: { type: 'value', minInterval: 1 },
+    series: seriesList.map((s) => ({
+      name: s.name,
+      type: 'bar' as const,
+      stack: 'status',
+      data: cats.map((cat) => s.data.find((d) => d.label === cat)?.value ?? 0),
+    })),
+  };
+}

--- a/frontend/src/pages/stats/stats.css
+++ b/frontend/src/pages/stats/stats.css
@@ -1,0 +1,26 @@
+.stats-page {
+  padding: 0 0 24px;
+}
+
+.stats-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 20px 24px;
+  margin-bottom: 16px;
+  border-radius: 16px;
+  color: #fff;
+  background: linear-gradient(135deg, #1d4ed8 0%, #7c3aed 55%, #0f766e 100%);
+  box-shadow: 0 12px 32px rgba(29, 78, 216, 0.18);
+}
+
+.stats-kpis {
+  margin-bottom: 16px;
+}
+
+.stats-section {
+  margin-bottom: 16px;
+  border-radius: 12px !important;
+}

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -43,6 +43,7 @@ const InternshipListPage = lazy(() => import('@/pages/internship/ListPage'));
 const InternshipMyPage = lazy(() => import('@/pages/internship/MyPage'));
 const InternshipStatsPage = lazy(() => import('@/pages/internship/StatsPage'));
 const WorkflowDesigner = lazy(() => import('@/pages/workflow/designer/DesignerPage'));
+const StatsOverviewPage = lazy(() => import('@/pages/stats/OverviewPage'));
 const Forbidden = lazy(() => import('@/pages/error/Forbidden'));
 const NotFound = lazy(() => import('@/pages/error/NotFound'));
 
@@ -286,8 +287,8 @@ const routes: AppRouteObject[] = [
         children: [
           {
             path: 'overview',
-            element: <div style={{ padding: 24 }}>统计概览（开发中）</div>,
-            meta: { title: '统计概览' },
+            element: lazyGuarded(StatsOverviewPage, 'stats:read'),
+            meta: { title: '统计概览', permission: 'stats:read' },
           },
         ],
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 Issue #11 一期数据统计模块：插件化 `StatsProvider` + `StatsRegistry`，五个核心提供者（会员分布、面试数据、会议出席、任务进度、实习时长），以及前端统计概览页（ChartCard / useECharts / 时间范围快捷选项 / PNG 与 CSV·Excel 导出）。

已在本分支自行修复 Bugbot 审查意见（未合 Autofix 旁路）：

- 统计读写/导出挂 `RequireDataScope("stats")`，按部门范围过滤
- 实习排行尊重 `RankingVisible`（全范围角色仍可见）
- 实习按区间重叠过滤；排行/均值/趋势只统计窗口内天数，结束日按包含截取（「今天」不为 0）
- 会员部门/年级分布不再被入会 `created_at` 时间窗裁剪
- 本月会议有上界；本周按中文周一起始
- 迁移给部长 `stats:export`（department 范围）
- 热力图按数据年份跨度；ChartCard 空态用 overlay，避免 0 宽
- 概览去掉「分组」下拉；图表按系列名绑图，避免 group_by 错位

首页 Dashboard 仍保持 mock，留给 #26 接入 `/stats/overview`。

## 关联 Issue

Closes #11

## 测试方式

1. 执行迁移 `000030` 并 `APP_ENV=dev make seed`，重新登录以拿到 `stats:export`
2. 登录后打开 `/stats/overview`，切换今天/本周/本月/本学期/自定义与部门筛选
3. 五个 provider API 与快捷路径返回图表数据；导出 CSV/Excel；图表 PNG 下载
4. `cd backend && go test ./internal/stats/...`

本地已验证：`GET /api/v1/stats/providers|overview|五个 provider|export csv/excel` 正常；浏览器走完概览页、时间范围、部门下拉（章程七部）、PNG/Excel 导出。本轮修复后已重跑 `go test ./internal/stats/...` 与 `golangci-lint run ./internal/stats/...`。

## 截图 / GIF

[stats_overview_clean.mp4](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstats_overview_clean.mp4)

| 页面/功能 | 截图 |
|----------|------|
| 统计概览 KPI + 会员分布 | [统计概览](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstats_overview_layout.webp) |
| 部门下拉（章程七部） | [部门下拉](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstats_department_dropdown.webp) |
| PNG 下载 | [PNG 下载](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstats_png_download.webp) |

## 注意事项

- 导出复用 #71 `export.RenderTable`，未另写 Excel/CSV 引擎
- 部门名称查 `departments` 表，不写死旧四部
- 错误码 11001–11004；`stats:export` 赋给社长/超管，部长也可导出
- 概览页串行拉取图表，GET 遇 429 自动重试，避免打满用户令牌桶
- 未实现 #26 全屏数据大屏
- 已应用 `000030` 的环境需补一次部长 `stats:export`（新环境直接 migrate 即可）
- 不要合入 Bugbot Autofix 旁路分支

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测
- [ ] 已添加/更新必要的文档
- [x] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

