### PR TITLE
feat(notification): 邮件附件、批量限流、重试与发送记录 (#25)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -193,17 +193,38 @@ func main() {
 	// 工作流引擎模块
 	wfHandlers := workflow.Init(database.DB(), eventBus, logger.GetLogger())
 
+	// 对象存储（MinIO）：bucket 不存在则创建；失败只告警，避免拖垮其他模块
+	var objectStore storage.ObjectStorage
+	minioStore, err := storage.NewMinIO(cfg.MinIO)
+	if err != nil {
+		logger.Error("init MinIO client failed", zap.Error(err))
+	} else {
+		objectStore = minioStore
+		if err := objectStore.EnsureBucket(context.Background()); err != nil {
+			logger.Error("ensure MinIO bucket failed", zap.Error(err))
+		}
+	}
+
 	// 通知模块
 	notifR := notifRepo.NewNotificationRepo(database.DB())
 	tplRepo := notifRepo.NewTemplateRepo(database.DB())
 
 	hub := notifService.NewHub()
-	channelRegistry := notifService.NewChannelRegistry()
-	channelRegistry.Register(notifService.NewInAppChannel(notifR))
-	channelRegistry.Register(notifService.NewEmailChannel(
+	emailLogs := notifRepo.NewEmailLogRepo(database.DB())
+	emailCh := notifService.NewEmailChannel(
 		cfg.Email.SMTPHost, cfg.Email.SMTPPort,
 		cfg.Email.Username, cfg.Email.Password, cfg.Email.From,
-	))
+	)
+	emailWorker := notifService.NewEmailWorker(
+		emailCh, emailLogs,
+		notifService.NewAttachmentLoader(database.DB(), objectStore),
+		notifService.NewMinuteLimiter(50, nil),
+	)
+	emailWorker.Start(context.Background())
+	emailCh.WithDispatcher(emailWorker)
+	channelRegistry := notifService.NewChannelRegistry()
+	channelRegistry.Register(notifService.NewInAppChannel(notifR))
+	channelRegistry.Register(emailCh)
 	channelRegistry.Register(notifService.NewWebSocketChannel(hub))
 
 	tplEngine := notifService.NewTemplateEngine(tplRepo)
@@ -218,18 +239,8 @@ func main() {
 	notificationHandler := notifHandler.NewNotificationHandler(notifSvc, hub)
 	templateHandler := notifHandler.NewTemplateHandler(tplSvc)
 	wsHandler := notifHandler.NewWSHandler(hub, &cfg.JWT, cfg.CORS.AllowedOrigins)
-
-	// 对象存储（MinIO）：bucket 不存在则创建；失败只告警，避免拖垮其他模块
-	var objectStore storage.ObjectStorage
-	minioStore, err := storage.NewMinIO(cfg.MinIO)
-	if err != nil {
-		logger.Error("init MinIO client failed", zap.Error(err))
-	} else {
-		objectStore = minioStore
-		if err := objectStore.EnsureBucket(context.Background()); err != nil {
-			logger.Error("ensure MinIO bucket failed", zap.Error(err))
-		}
-	}
+	emailSvc := notifService.NewEmailService(emailWorker, tplEngine, emailLogs)
+	emailHandler := notifHandler.NewEmailHandler(emailSvc)
 
 	// 文件管理模块
 	fileR := fileRepo.NewFileRepo(database.DB())
@@ -354,7 +365,7 @@ func main() {
 		wfHandler.RegisterRoutes(protected, wfHandlers.Definition, wfHandlers.Instance, wfHandlers.Task)
 
 		// 通知模块路由
-		notifHandler.RegisterRoutes(protected, protected, notificationHandler, templateHandler, wsHandler)
+		notifHandler.RegisterRoutes(protected, protected, notificationHandler, templateHandler, wsHandler, emailHandler, cacheService)
 
 		// 文件管理模块（/files，file:read / file:create；删除由服务层校验上传者或 file:delete）
 		fileHandler.RegisterRoutes(protected, fileH, cacheService)

--- a/backend/internal/notification/dto/email.go
+++ b/backend/internal/notification/dto/email.go
@@ -1,0 +1,92 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type SendEmailRequest struct {
+	To             []string `json:"to" binding:"required,min=1,dive,email"`
+	CC             []string `json:"cc" binding:"omitempty,dive,email"`
+	Subject        string   `json:"subject" binding:"required,max=200"`
+	Body           string   `json:"body" binding:"required"`
+	IsHTML         bool     `json:"is_html"`
+	AttachmentIDs  []string `json:"attachment_ids"`
+	TemplateCode   string   `json:"template_code"`
+	NotificationID *string  `json:"notification_id"`
+}
+
+type SendEmailResponse struct {
+	MessageID      string `json:"message_id"`
+	Status         string `json:"status"`
+	RecipientCount int    `json:"recipient_count"`
+}
+
+type BatchRecipient struct {
+	Email string            `json:"email" binding:"required,email"`
+	Data  map[string]string `json:"data"`
+}
+
+type BatchSendEmailRequest struct {
+	Recipients   []BatchRecipient `json:"recipients" binding:"required,min=1,max=50"`
+	TemplateCode string           `json:"template_code"`
+	Subject      string           `json:"subject" binding:"omitempty,max=200"`
+	Body         string           `json:"body"`
+	IsHTML       bool             `json:"is_html"`
+}
+
+type BatchSendEmailResponse struct {
+	Total  int `json:"total"`
+	Queued int `json:"queued"`
+	Failed int `json:"failed"`
+}
+
+type ListEmailLogsRequest struct {
+	Page      int    `form:"page"`
+	PageSize  int    `form:"page_size"`
+	Status    string `form:"status"`
+	StartDate string `form:"start_date"`
+	EndDate   string `form:"end_date"`
+}
+
+type EmailLogResponse struct {
+	ID           string     `json:"id"`
+	To           string     `json:"to"`
+	CC           string     `json:"cc,omitempty"`
+	Subject      string     `json:"subject"`
+	TemplateCode string     `json:"template_code,omitempty"`
+	Status       string     `json:"status"`
+	ErrorMessage string     `json:"error_message,omitempty"`
+	RetryCount   int16      `json:"retry_count"`
+	SentAt       *time.Time `json:"sent_at"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+func ParseLogStatus(name string) (int16, bool) {
+	switch name {
+	case "", "all":
+		return -1, true
+	case "queued":
+		return 0, true
+	case "sent":
+		return 1, true
+	case "failed":
+		return 2, true
+	case "retrying":
+		return 3, true
+	default:
+		return 0, false
+	}
+}
+
+func ParseOptionalUUID(raw string) (*uuid.UUID, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &id, nil
+}

--- a/backend/internal/notification/handler/email_handler.go
+++ b/backend/internal/notification/handler/email_handler.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+type EmailHandler struct {
+	svc service.EmailService
+}
+
+func NewEmailHandler(svc service.EmailService) *EmailHandler {
+	return &EmailHandler{svc: svc}
+}
+
+// SendEmail POST /api/v1/notifications/email/send
+// @Summary 发送邮件
+// @Tags 通知
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param request body dto.SendEmailRequest true "发送参数"
+// @Success 200 {object} response.Response{data=dto.SendEmailResponse}
+// @Router /notifications/email/send [post]
+func (h *EmailHandler) SendEmail(c *gin.Context) {
+	var req dto.SendEmailRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, response.NewError(response.CodeNotificationEmailInvalid, "邮件参数无效"))
+		return
+	}
+	res, err := h.svc.Send(c.Request.Context(), &req, getUserID(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, res)
+}
+
+// SendEmailBatch POST /api/v1/notifications/email/batch
+// @Summary 批量发送邮件
+// @Tags 通知
+// @Accept json
+// @Produce json
+// @Security Bearer
+// @Param request body dto.BatchSendEmailRequest true "批量发送"
+// @Success 200 {object} response.Response{data=dto.BatchSendEmailResponse}
+// @Router /notifications/email/batch [post]
+func (h *EmailHandler) SendEmailBatch(c *gin.Context) {
+	var req dto.BatchSendEmailRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, response.NewError(response.CodeNotificationEmailInvalid, "邮件参数无效"))
+		return
+	}
+	res, err := h.svc.SendBatch(c.Request.Context(), &req, getUserID(c))
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, res)
+}
+
+// ListEmailLogs GET /api/v1/notifications/email/logs
+// @Summary 邮件发送记录
+// @Tags 通知
+// @Produce json
+// @Security Bearer
+// @Param page query int false "页码"
+// @Param page_size query int false "每页条数"
+// @Param status query string false "queued/sent/failed/retrying"
+// @Success 200 {object} response.Response
+// @Router /notifications/email/logs [get]
+func (h *EmailHandler) ListEmailLogs(c *gin.Context) {
+	var req dto.ListEmailLogsRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.Error(c, response.NewError(response.CodeNotificationEmailInvalid, "邮件参数无效"))
+		return
+	}
+	list, total, err := h.svc.ListLogs(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.Page(c, list, total, req.Page, req.PageSize)
+}

--- a/backend/internal/notification/handler/email_handler_test.go
+++ b/backend/internal/notification/handler/email_handler_test.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+type stubEmailSvc struct {
+	send  *dto.SendEmailResponse
+	batch *dto.BatchSendEmailResponse
+	logs  []*dto.EmailLogResponse
+	err   error
+}
+
+func (s *stubEmailSvc) Send(context.Context, *dto.SendEmailRequest, uuid.UUID) (*dto.SendEmailResponse, error) {
+	return s.send, s.err
+}
+func (s *stubEmailSvc) SendBatch(context.Context, *dto.BatchSendEmailRequest, uuid.UUID) (*dto.BatchSendEmailResponse, error) {
+	return s.batch, s.err
+}
+func (s *stubEmailSvc) ListLogs(context.Context, *dto.ListEmailLogsRequest) ([]*dto.EmailLogResponse, int64, error) {
+	return s.logs, int64(len(s.logs)), s.err
+}
+
+func TestSendEmailOK(t *testing.T) {
+	h := NewEmailHandler(&stubEmailSvc{send: &dto.SendEmailResponse{MessageID: "m1", Status: "queued", RecipientCount: 1}})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	body, _ := json.Marshal(dto.SendEmailRequest{To: []string{"a@b.c"}, Subject: "s", Body: "b"})
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/notifications/email/send", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user_id", uuid.New().String())
+	h.SendEmail(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSendEmailInvalidJSON(t *testing.T) {
+	h := NewEmailHandler(&stubEmailSvc{})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/notifications/email/send", bytes.NewReader([]byte(`{}`)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.SendEmail(c)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRegisterRoutesWithEmail(t *testing.T) {
+	assert.NotPanics(t, func() {
+		RegisterRoutes(gin.New().Group("/api/v1"), gin.New().Group("/api/v1"),
+			NewNotificationHandler(nil, nil), NewTemplateHandler(nil), nil,
+			NewEmailHandler(&stubEmailSvc{}), nil)
+	})
+}
+
+func TestListEmailLogsOK(t *testing.T) {
+	h := NewEmailHandler(&stubEmailSvc{logs: []*dto.EmailLogResponse{{ID: "1", Status: "sent"}}})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/notifications/email/logs", nil)
+	h.ListEmailLogs(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSendBatchOK(t *testing.T) {
+	h := NewEmailHandler(&stubEmailSvc{batch: &dto.BatchSendEmailResponse{Total: 1, Queued: 1}})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	body, _ := json.Marshal(dto.BatchSendEmailRequest{
+		Recipients: []dto.BatchRecipient{{Email: "a@b.c"}}, Subject: "s", Body: "b",
+	})
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/notifications/email/batch", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user_id", uuid.New().String())
+	h.SendEmailBatch(c)
+	require.Equal(t, http.StatusOK, w.Code)
+}

--- a/backend/internal/notification/handler/routes.go
+++ b/backend/internal/notification/handler/routes.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
 	"github.com/gin-gonic/gin"
 )
 
@@ -14,6 +16,8 @@ func RegisterRoutes(
 	notificationHandler *NotificationHandler,
 	templateHandler *TemplateHandler,
 	wsHandler *WSHandler,
+	emailHandler *EmailHandler,
+	cacheService rbacService.PermissionCacheService,
 ) {
 	// 用户通知路由（登录即可访问）
 	if protected != nil {
@@ -24,6 +28,12 @@ func RegisterRoutes(
 			notifications.POST("/:id/read", notificationHandler.MarkAsRead)
 			notifications.POST("/read-all", notificationHandler.MarkAllAsRead)
 			notifications.DELETE("/:id", notificationHandler.Delete)
+		}
+		if emailHandler != nil {
+			email := withPermission(protected.Group("/notifications/email"), "notification:send", cacheService)
+			email.POST("/send", emailHandler.SendEmail)
+			email.POST("/batch", emailHandler.SendEmailBatch)
+			email.GET("/logs", emailHandler.ListEmailLogs)
 		}
 	}
 
@@ -54,4 +64,11 @@ func RegisterRoutes(
 // RegisterWSRoute 在根路由组注册 WebSocket 路由
 func RegisterWSRoute(r *gin.Engine, wsHandler *WSHandler) {
 	r.GET("/ws/notifications", wsHandler.HandleConnection)
+}
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
 }

--- a/backend/internal/notification/model/email_log.go
+++ b/backend/internal/notification/model/email_log.go
@@ -17,7 +17,7 @@ const (
 type EmailLog struct {
 	ID             uuid.UUID  `gorm:"type:uuid;primaryKey"`
 	UserID         *uuid.UUID `gorm:"type:uuid"`
-	ToAddress      string     `gorm:"type:varchar(200);not null"`
+	ToAddress      string     `gorm:"type:text;not null"`
 	Subject        string     `gorm:"type:varchar(500);not null"`
 	TemplateCode   string     `gorm:"type:varchar(100)"`
 	Status         int16      `gorm:"type:smallint;not null;default:0"`
@@ -26,7 +26,7 @@ type EmailLog struct {
 	CreatedAt      time.Time
 	NotificationID *uuid.UUID `gorm:"type:uuid"`
 	RetryCount     int16      `gorm:"type:smallint;not null;default:0"`
-	CC             string     `gorm:"type:varchar(1000)"`
+	CC             string     `gorm:"type:text"`
 	IsHTML         bool       `gorm:"not null;default:false"`
 }
 

--- a/backend/internal/notification/model/email_log.go
+++ b/backend/internal/notification/model/email_log.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	EmailQueued   int16 = 0
+	EmailSent     int16 = 1
+	EmailFailed   int16 = 2
+	EmailRetrying int16 = 3
+)
+
+// EmailLog 对应 email_logs（000016 + 000031）。
+type EmailLog struct {
+	ID             uuid.UUID  `gorm:"type:uuid;primaryKey"`
+	UserID         *uuid.UUID `gorm:"type:uuid"`
+	ToAddress      string     `gorm:"type:varchar(200);not null"`
+	Subject        string     `gorm:"type:varchar(500);not null"`
+	TemplateCode   string     `gorm:"type:varchar(100)"`
+	Status         int16      `gorm:"type:smallint;not null;default:0"`
+	ErrorMessage   string     `gorm:"type:text"`
+	SentAt         *time.Time
+	CreatedAt      time.Time
+	NotificationID *uuid.UUID `gorm:"type:uuid"`
+	RetryCount     int16      `gorm:"type:smallint;not null;default:0"`
+	CC             string     `gorm:"type:varchar(1000)"`
+	IsHTML         bool       `gorm:"not null;default:false"`
+}
+
+func (EmailLog) TableName() string { return "email_logs" }
+
+func EmailStatusName(s int16) string {
+	switch s {
+	case EmailSent:
+		return "sent"
+	case EmailFailed:
+		return "failed"
+	case EmailRetrying:
+		return "retrying"
+	default:
+		return "queued"
+	}
+}

--- a/backend/internal/notification/repo/email_log_repo.go
+++ b/backend/internal/notification/repo/email_log_repo.go
@@ -1,0 +1,65 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type EmailLogRepo interface {
+	Create(ctx context.Context, row *model.EmailLog) error
+	Update(ctx context.Context, row *model.EmailLog) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.EmailLog, error)
+	List(ctx context.Context, status int16, start, end *time.Time, page, pageSize int) ([]*model.EmailLog, int64, error)
+}
+
+type emailLogRepo struct{ db *gorm.DB }
+
+func NewEmailLogRepo(db *gorm.DB) EmailLogRepo {
+	return &emailLogRepo{db: db}
+}
+
+func (r *emailLogRepo) Create(ctx context.Context, row *model.EmailLog) error {
+	return r.db.WithContext(ctx).Create(row).Error
+}
+
+func (r *emailLogRepo) Update(ctx context.Context, row *model.EmailLog) error {
+	return r.db.WithContext(ctx).Save(row).Error
+}
+
+func (r *emailLogRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.EmailLog, error) {
+	var row model.EmailLog
+	if err := r.db.WithContext(ctx).First(&row, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *emailLogRepo) List(ctx context.Context, status int16, start, end *time.Time, page, pageSize int) ([]*model.EmailLog, int64, error) {
+	if page <= 0 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 10
+	}
+	q := r.db.WithContext(ctx).Model(&model.EmailLog{})
+	if status >= 0 {
+		q = q.Where("status = ?", status)
+	}
+	if start != nil {
+		q = q.Where("created_at >= ?", *start)
+	}
+	if end != nil {
+		q = q.Where("created_at <= ?", *end)
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var list []*model.EmailLog
+	err := q.Order("created_at DESC").Offset((page - 1) * pageSize).Limit(pageSize).Find(&list).Error
+	return list, total, err
+}

--- a/backend/internal/notification/service/channel.go
+++ b/backend/internal/notification/service/channel.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
 	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
 	"github.com/Yogdunana/StarByte/backend/pkg/logger"
-	"github.com/go-mail/mail"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
@@ -71,6 +70,7 @@ type EmailChannel struct {
 	username string
 	password string
 	from     string
+	dispatch MailDispatcher
 }
 
 // NewEmailChannel 创建邮件渠道
@@ -94,18 +94,14 @@ func (c *EmailChannel) Send(ctx context.Context, msg *NotificationMessage) error
 	if msg.Email == "" {
 		return fmt.Errorf("email address is empty for user %s", msg.UserID)
 	}
-
-	m := mail.NewMessage()
-	m.SetHeader("From", c.from)
-	m.SetHeader("To", msg.Email)
-	m.SetHeader("Subject", msg.Title)
-	m.SetBody("text/plain", msg.Content)
-
-	d := mail.NewDialer(c.smtpHost, c.smtpPort, c.username, c.password)
-	if err := d.DialAndSend(m); err != nil {
-		return fmt.Errorf("send email: %w", err)
+	job := MailJob{
+		To: []string{msg.Email}, Subject: msg.Title, Body: msg.Content, UserID: &msg.UserID,
 	}
-	return nil
+	if c.dispatch != nil {
+		_, err := c.dispatch.Enqueue(ctx, job)
+		return err
+	}
+	return c.SendMIME(ctx, job, nil)
 }
 
 // WebSocketChannel WebSocket 实时推送渠道

--- a/backend/internal/notification/service/email_limiter.go
+++ b/backend/internal/notification/service/email_limiter.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"sync"
+	"time"
+)
+
+const emailPerMinute = 50
+
+type minuteLimiter struct {
+	mu     sync.Mutex
+	stamps []time.Time
+	limit  int
+	window time.Duration
+	now    func() time.Time
+}
+
+func NewMinuteLimiter(limit int, now func() time.Time) *minuteLimiter {
+	return newMinuteLimiter(limit, now)
+}
+
+func newMinuteLimiter(limit int, now func() time.Time) *minuteLimiter {
+	if now == nil {
+		now = time.Now
+	}
+	if limit <= 0 {
+		limit = emailPerMinute
+	}
+	return &minuteLimiter{limit: limit, window: time.Minute, now: now}
+}
+
+func (l *minuteLimiter) Allow() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	cut := now.Add(-l.window)
+	kept := l.stamps[:0]
+	for _, t := range l.stamps {
+		if t.After(cut) {
+			kept = append(kept, t)
+		}
+	}
+	l.stamps = kept
+	if len(l.stamps) >= l.limit {
+		return false
+	}
+	l.stamps = append(l.stamps, now)
+	return true
+}

--- a/backend/internal/notification/service/email_mail.go
+++ b/backend/internal/notification/service/email_mail.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Yogdunana/StarByte/backend/pkg/storage"
+	"github.com/go-mail/mail"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const maxEmailAttachmentBytes = 8 << 20
+const maxEmailAttachments = 5
+
+type MailAttachment struct {
+	Name        string
+	ContentType string
+	Data        []byte
+}
+
+type MailJob struct {
+	To             []string
+	CC             []string
+	Subject        string
+	Body           string
+	IsHTML         bool
+	AttachmentIDs  []uuid.UUID
+	NotificationID *uuid.UUID
+	TemplateCode   string
+	UserID         *uuid.UUID
+	LogID          uuid.UUID
+}
+
+type MailDispatcher interface {
+	Enqueue(ctx context.Context, job MailJob) (uuid.UUID, error)
+}
+
+type MIMESender interface {
+	SendMIME(ctx context.Context, job MailJob, files []MailAttachment) error
+}
+
+func (c *EmailChannel) WithDispatcher(d MailDispatcher) *EmailChannel {
+	c.dispatch = d
+	return c
+}
+
+func (c *EmailChannel) SendMIME(_ context.Context, job MailJob, files []MailAttachment) error {
+	if !c.IsAvailable() {
+		return fmt.Errorf("smtp is not configured")
+	}
+	m := mail.NewMessage()
+	m.SetHeader("From", c.from)
+	m.SetHeader("To", job.To...)
+	if len(job.CC) > 0 {
+		m.SetHeader("Cc", job.CC...)
+	}
+	m.SetHeader("Subject", job.Subject)
+	if job.IsHTML {
+		m.SetBody("text/html", job.Body)
+	} else {
+		m.SetBody("text/plain", job.Body)
+	}
+	for _, f := range files {
+		name := f.Name
+		data := f.Data
+		m.AttachReader(name, bytes.NewReader(data))
+	}
+	d := mail.NewDialer(c.smtpHost, c.smtpPort, c.username, c.password)
+	if err := d.DialAndSend(m); err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+	return nil
+}
+
+type attachmentLoader struct {
+	db    *gorm.DB
+	store storage.ObjectStorage
+}
+
+func NewAttachmentLoader(db *gorm.DB, store storage.ObjectStorage) *attachmentLoader {
+	return &attachmentLoader{db: db, store: store}
+}
+
+func (l *attachmentLoader) Load(ctx context.Context, ids []uuid.UUID) ([]MailAttachment, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if len(ids) > maxEmailAttachments {
+		return nil, fmt.Errorf("too many attachments")
+	}
+	if l.store == nil || l.db == nil {
+		return nil, fmt.Errorf("attachment storage unavailable")
+	}
+	var rows []struct {
+		ID           uuid.UUID
+		OriginalName string
+		Name         string
+		Path         string
+		MimeType     string
+		Size         int64
+	}
+	if err := l.db.WithContext(ctx).Table("files").Select("id, original_name, name, path, mime_type, size").
+		Where("id IN ?", ids).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	if len(rows) != len(ids) {
+		return nil, fmt.Errorf("attachment not found")
+	}
+	out := make([]MailAttachment, 0, len(rows))
+	for _, row := range rows {
+		if row.Size > maxEmailAttachmentBytes {
+			return nil, fmt.Errorf("attachment too large")
+		}
+		rc, ctype, err := l.store.Download(ctx, row.Path)
+		if err != nil {
+			return nil, err
+		}
+		data, err := io.ReadAll(io.LimitReader(rc, maxEmailAttachmentBytes+1))
+		_ = rc.Close()
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(data)) > maxEmailAttachmentBytes {
+			return nil, fmt.Errorf("attachment too large")
+		}
+		name := row.OriginalName
+		if strings.TrimSpace(name) == "" {
+			name = row.Name
+		}
+		if ctype == "" {
+			ctype = row.MimeType
+		}
+		out = append(out, MailAttachment{Name: name, ContentType: ctype, Data: data})
+	}
+	return out, nil
+}

--- a/backend/internal/notification/service/email_mail.go
+++ b/backend/internal/notification/service/email_mail.go
@@ -33,6 +33,7 @@ type MailJob struct {
 	TemplateCode   string
 	UserID         *uuid.UUID
 	LogID          uuid.UUID
+	Attempts       int
 }
 
 type MailDispatcher interface {

--- a/backend/internal/notification/service/email_service.go
+++ b/backend/internal/notification/service/email_service.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+)
+
+type EmailService interface {
+	Send(ctx context.Context, req *dto.SendEmailRequest, operator uuid.UUID) (*dto.SendEmailResponse, error)
+	SendBatch(ctx context.Context, req *dto.BatchSendEmailRequest, operator uuid.UUID) (*dto.BatchSendEmailResponse, error)
+	ListLogs(ctx context.Context, req *dto.ListEmailLogsRequest) ([]*dto.EmailLogResponse, int64, error)
+}
+
+type emailService struct {
+	dispatch MailDispatcher
+	engine   TemplateEngine
+	logs     repo.EmailLogRepo
+}
+
+func NewEmailService(dispatch MailDispatcher, engine TemplateEngine, logs repo.EmailLogRepo) EmailService {
+	return &emailService{dispatch: dispatch, engine: engine, logs: logs}
+}
+
+func (s *emailService) Send(ctx context.Context, req *dto.SendEmailRequest, operator uuid.UUID) (*dto.SendEmailResponse, error) {
+	ids, err := parseAttachmentIDs(req.AttachmentIDs)
+	if err != nil {
+		return nil, response.NewError(response.CodeNotificationEmailInvalid, "邮件参数无效")
+	}
+	nid, err := dto.ParseOptionalUUID(stringOrEmpty(req.NotificationID))
+	if err != nil {
+		return nil, response.NewError(response.CodeNotificationEmailInvalid, "邮件参数无效")
+	}
+	job := MailJob{
+		To: req.To, CC: req.CC, Subject: req.Subject, Body: req.Body, IsHTML: req.IsHTML,
+		AttachmentIDs: ids, NotificationID: nid, TemplateCode: strings.TrimSpace(req.TemplateCode), UserID: &operator,
+	}
+	if job.TemplateCode != "" && job.Body == "" {
+		rendered, rerr := s.engine.Render(ctx, job.TemplateCode, map[string]any{})
+		if rerr != nil {
+			return nil, rerr
+		}
+		job.Subject = rendered.Title
+		job.Body = rendered.Content
+	}
+	id, err := s.dispatch.Enqueue(ctx, job)
+	if err != nil {
+		if err == errEmailQueueFull {
+			return nil, response.NewError(response.CodeNotificationEmailRate, "邮件队列已满")
+		}
+		return nil, err
+	}
+	return &dto.SendEmailResponse{MessageID: id.String(), Status: "queued", RecipientCount: len(job.To)}, nil
+}
+
+func (s *emailService) SendBatch(ctx context.Context, req *dto.BatchSendEmailRequest, operator uuid.UUID) (*dto.BatchSendEmailResponse, error) {
+	if len(req.Recipients) > emailPerMinute {
+		return nil, response.NewError(response.CodeNotificationEmailRate, "批量发送超出每分钟 50 封限制")
+	}
+	out := &dto.BatchSendEmailResponse{Total: len(req.Recipients)}
+	for _, r := range req.Recipients {
+		subject, body := req.Subject, req.Body
+		if strings.TrimSpace(req.TemplateCode) != "" {
+			vars := map[string]any{}
+			for k, v := range r.Data {
+				vars[k] = v
+			}
+			rendered, err := s.engine.Render(ctx, req.TemplateCode, vars)
+			if err != nil {
+				out.Failed++
+				continue
+			}
+			subject, body = rendered.Title, rendered.Content
+		}
+		if strings.TrimSpace(subject) == "" || strings.TrimSpace(body) == "" {
+			out.Failed++
+			continue
+		}
+		job := MailJob{
+			To: []string{r.Email}, Subject: subject, Body: body, IsHTML: req.IsHTML,
+			TemplateCode: req.TemplateCode, UserID: &operator,
+		}
+		if _, err := s.dispatch.Enqueue(ctx, job); err != nil {
+			out.Failed++
+			continue
+		}
+		out.Queued++
+	}
+	return out, nil
+}
+
+func (s *emailService) ListLogs(ctx context.Context, req *dto.ListEmailLogsRequest) ([]*dto.EmailLogResponse, int64, error) {
+	status, ok := dto.ParseLogStatus(req.Status)
+	if !ok {
+		return nil, 0, response.NewError(response.CodeNotificationEmailInvalid, "邮件参数无效")
+	}
+	start, err := parseLogDate(req.StartDate, false)
+	if err != nil {
+		return nil, 0, response.NewError(response.CodeNotificationEmailInvalid, "邮件参数无效")
+	}
+	end, err := parseLogDate(req.EndDate, true)
+	if err != nil {
+		return nil, 0, response.NewError(response.CodeNotificationEmailInvalid, "邮件参数无效")
+	}
+	list, total, err := s.logs.List(ctx, status, start, end, req.Page, req.PageSize)
+	if err != nil {
+		return nil, 0, err
+	}
+	out := make([]*dto.EmailLogResponse, 0, len(list))
+	for _, row := range list {
+		out = append(out, &dto.EmailLogResponse{
+			ID: row.ID.String(), To: row.ToAddress, CC: row.CC, Subject: row.Subject,
+			TemplateCode: row.TemplateCode, Status: model.EmailStatusName(row.Status),
+			ErrorMessage: row.ErrorMessage, RetryCount: row.RetryCount, SentAt: row.SentAt, CreatedAt: row.CreatedAt,
+		})
+	}
+	return out, total, nil
+}
+
+func parseAttachmentIDs(raw []string) ([]uuid.UUID, error) {
+	out := make([]uuid.UUID, 0, len(raw))
+	for _, s := range raw {
+		id, err := uuid.Parse(strings.TrimSpace(s))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+func stringOrEmpty(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func parseLogDate(raw string, endOfDay bool) (*time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	t, err := time.ParseInLocation("2006-01-02", raw, time.Local)
+	if err != nil {
+		return nil, err
+	}
+	if endOfDay {
+		t = t.Add(24*time.Hour - time.Nanosecond)
+	}
+	return &t, nil
+}

--- a/backend/internal/notification/service/email_worker.go
+++ b/backend/internal/notification/service/email_worker.go
@@ -35,7 +35,8 @@ type EmailWorker struct {
 	backoff []time.Duration
 	jobs    chan MailJob
 	now     func() time.Time
-	delayMu sync.Mutex
+	mu      sync.Mutex
+	queued  int
 	delayed []delayedJob
 }
 
@@ -88,35 +89,67 @@ func (w *EmailWorker) Enqueue(ctx context.Context, job MailJob) (uuid.UUID, erro
 		}
 		job.LogID = row.ID
 	}
-	if err := w.push(ctx, job); err != nil {
+	if !w.reserve() {
+		_ = w.mark(ctx, job.LogID, model.EmailFailed, "queue is full", int16(job.Attempts))
+		return job.LogID, errEmailQueueFull
+	}
+	if err := w.offer(job); err != nil {
+		w.release()
+		_ = w.mark(ctx, job.LogID, model.EmailFailed, "queue is full", int16(job.Attempts))
 		return job.LogID, err
 	}
 	return job.LogID, nil
 }
 
-func (w *EmailWorker) push(ctx context.Context, job MailJob) error {
+func (w *EmailWorker) reserve() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.queued >= emailQueueSize {
+		return false
+	}
+	w.queued++
+	return true
+}
+
+func (w *EmailWorker) release() {
+	w.mu.Lock()
+	if w.queued > 0 {
+		w.queued--
+	}
+	w.mu.Unlock()
+}
+
+func (w *EmailWorker) offer(job MailJob) error {
 	select {
 	case w.jobs <- job:
 		return nil
 	default:
-		_ = w.mark(ctx, job.LogID, model.EmailFailed, "queue is full", int16(job.Attempts))
 		return errEmailQueueFull
 	}
 }
 
+func (w *EmailWorker) park(job MailJob, d time.Duration) {
+	if d < 0 {
+		d = 0
+	}
+	w.mu.Lock()
+	w.delayed = append(w.delayed, delayedJob{job: job, at: w.now().Add(d)})
+	w.mu.Unlock()
+}
+
 func (w *EmailWorker) schedule(job MailJob, d time.Duration) {
 	if d <= 0 {
-		_ = w.push(context.Background(), job)
-		return
+		if err := w.offer(job); err == nil {
+			return
+		}
+		d = rateRetryDelay
 	}
-	w.delayMu.Lock()
-	w.delayed = append(w.delayed, delayedJob{job: job, at: w.now().Add(d)})
-	w.delayMu.Unlock()
+	w.park(job, d)
 }
 
 func (w *EmailWorker) flushDue() {
 	now := w.now()
-	w.delayMu.Lock()
+	w.mu.Lock()
 	keep := w.delayed[:0]
 	due := make([]MailJob, 0)
 	for _, item := range w.delayed {
@@ -127,9 +160,11 @@ func (w *EmailWorker) flushDue() {
 		}
 	}
 	w.delayed = keep
-	w.delayMu.Unlock()
+	w.mu.Unlock()
 	for _, job := range due {
-		_ = w.push(context.Background(), job)
+		if err := w.offer(job); err != nil {
+			w.park(job, rateRetryDelay)
+		}
 	}
 }
 
@@ -143,18 +178,18 @@ func (w *EmailWorker) process(ctx context.Context, job MailJob) {
 	if len(job.AttachmentIDs) > 0 && w.attach != nil {
 		files, err = w.attach.Load(ctx, job.AttachmentIDs)
 		if err != nil {
-			_ = w.mark(ctx, job.LogID, model.EmailFailed, err.Error(), int16(job.Attempts))
+			w.finish(ctx, job, model.EmailFailed, err.Error())
 			return
 		}
 	}
 	err = w.sender.SendMIME(ctx, job, files)
 	if err == nil {
-		_ = w.mark(ctx, job.LogID, model.EmailSent, "", int16(job.Attempts))
+		w.finish(ctx, job, model.EmailSent, "")
 		return
 	}
 	job.Attempts++
 	if job.Attempts >= emailMaxAttempts {
-		_ = w.mark(ctx, job.LogID, model.EmailFailed, err.Error(), int16(job.Attempts))
+		w.finish(ctx, job, model.EmailFailed, err.Error())
 		return
 	}
 	_ = w.mark(ctx, job.LogID, model.EmailRetrying, err.Error(), int16(job.Attempts))
@@ -163,6 +198,11 @@ func (w *EmailWorker) process(ctx context.Context, job MailJob) {
 		wait = w.backoff[i]
 	}
 	w.schedule(job, wait)
+}
+
+func (w *EmailWorker) finish(ctx context.Context, job MailJob, status int16, errMsg string) {
+	_ = w.mark(ctx, job.LogID, status, errMsg, int16(job.Attempts))
+	w.release()
 }
 
 func (w *EmailWorker) newLog(job MailJob) *model.EmailLog {

--- a/backend/internal/notification/service/email_worker.go
+++ b/backend/internal/notification/service/email_worker.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+var errEmailQueueFull = errors.New("email queue is full")
+
+const emailQueueSize = 64
+const emailMaxAttempts = 3
+
+var defaultEmailBackoff = []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute}
+
+type EmailWorker struct {
+	sender  MIMESender
+	logs    repo.EmailLogRepo
+	attach  *attachmentLoader
+	limiter *minuteLimiter
+	backoff []time.Duration
+	sleep   func(time.Duration)
+	jobs    chan MailJob
+	now     func() time.Time
+}
+
+func NewEmailWorker(sender MIMESender, logs repo.EmailLogRepo, attach *attachmentLoader, limiter *minuteLimiter) *EmailWorker {
+	return &EmailWorker{
+		sender:  sender,
+		logs:    logs,
+		attach:  attach,
+		limiter: limiter,
+		backoff: defaultEmailBackoff,
+		sleep:   time.Sleep,
+		jobs:    make(chan MailJob, emailQueueSize),
+		now:     time.Now,
+	}
+}
+
+func (w *EmailWorker) Start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case job := <-w.jobs:
+				w.process(ctx, job)
+			}
+		}
+	}()
+}
+
+func (w *EmailWorker) Enqueue(ctx context.Context, job MailJob) (uuid.UUID, error) {
+	if job.LogID == uuid.Nil {
+		row := w.newLog(job)
+		if err := w.logs.Create(ctx, row); err != nil {
+			return uuid.Nil, err
+		}
+		job.LogID = row.ID
+	}
+	select {
+	case w.jobs <- job:
+		return job.LogID, nil
+	default:
+		_ = w.mark(ctx, job.LogID, model.EmailFailed, "queue is full", 0)
+		return job.LogID, errEmailQueueFull
+	}
+}
+
+func (w *EmailWorker) process(ctx context.Context, job MailJob) {
+	var files []MailAttachment
+	var err error
+	if len(job.AttachmentIDs) > 0 && w.attach != nil {
+		files, err = w.attach.Load(ctx, job.AttachmentIDs)
+		if err != nil {
+			_ = w.mark(ctx, job.LogID, model.EmailFailed, err.Error(), 0)
+			return
+		}
+	}
+	for attempt := 1; attempt <= emailMaxAttempts; attempt++ {
+		for w.limiter != nil && !w.limiter.Allow() {
+			w.sleep(200 * time.Millisecond)
+			if ctx.Err() != nil {
+				return
+			}
+		}
+		err = w.sender.SendMIME(ctx, job, files)
+		if err == nil {
+			_ = w.mark(ctx, job.LogID, model.EmailSent, "", int16(attempt-1))
+			return
+		}
+		status := model.EmailRetrying
+		if attempt == emailMaxAttempts {
+			status = model.EmailFailed
+		}
+		_ = w.mark(ctx, job.LogID, status, err.Error(), int16(attempt))
+		if attempt == emailMaxAttempts {
+			return
+		}
+		wait := w.backoff[attempt-1]
+		if wait > 0 {
+			w.sleep(wait)
+		}
+	}
+}
+
+func (w *EmailWorker) newLog(job MailJob) *model.EmailLog {
+	return &model.EmailLog{
+		ID:             uuid.New(),
+		UserID:         job.UserID,
+		ToAddress:      strings.Join(job.To, ","),
+		Subject:        job.Subject,
+		TemplateCode:   job.TemplateCode,
+		Status:         model.EmailQueued,
+		NotificationID: job.NotificationID,
+		CC:             strings.Join(job.CC, ","),
+		IsHTML:         job.IsHTML,
+		CreatedAt:      w.now(),
+	}
+}
+
+func (w *EmailWorker) mark(ctx context.Context, id uuid.UUID, status int16, errMsg string, retries int16) error {
+	row, err := w.logs.GetByID(ctx, id)
+	if err != nil {
+		logger.Error("email log update skipped", zap.Error(err))
+		return err
+	}
+	row.Status = status
+	row.ErrorMessage = errMsg
+	row.RetryCount = retries
+	if status == model.EmailSent {
+		now := w.now()
+		row.SentAt = &now
+	}
+	return w.logs.Update(ctx, row)
+}

--- a/backend/internal/notification/service/email_worker.go
+++ b/backend/internal/notification/service/email_worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
@@ -17,8 +18,14 @@ var errEmailQueueFull = errors.New("email queue is full")
 
 const emailQueueSize = 64
 const emailMaxAttempts = 3
+const rateRetryDelay = 200 * time.Millisecond
 
 var defaultEmailBackoff = []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute}
+
+type delayedJob struct {
+	job MailJob
+	at  time.Time
+}
 
 type EmailWorker struct {
 	sender  MIMESender
@@ -26,9 +33,10 @@ type EmailWorker struct {
 	attach  *attachmentLoader
 	limiter *minuteLimiter
 	backoff []time.Duration
-	sleep   func(time.Duration)
 	jobs    chan MailJob
 	now     func() time.Time
+	delayMu sync.Mutex
+	delayed []delayedJob
 }
 
 func NewEmailWorker(sender MIMESender, logs repo.EmailLogRepo, attach *attachmentLoader, limiter *minuteLimiter) *EmailWorker {
@@ -38,23 +46,38 @@ func NewEmailWorker(sender MIMESender, logs repo.EmailLogRepo, attach *attachmen
 		attach:  attach,
 		limiter: limiter,
 		backoff: defaultEmailBackoff,
-		sleep:   time.Sleep,
 		jobs:    make(chan MailJob, emailQueueSize),
 		now:     time.Now,
 	}
 }
 
 func (w *EmailWorker) Start(ctx context.Context) {
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case job := <-w.jobs:
-				w.process(ctx, job)
-			}
+	go w.loop(ctx)
+	go w.delayLoop(ctx)
+}
+
+func (w *EmailWorker) loop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job := <-w.jobs:
+			w.process(ctx, job)
 		}
-	}()
+	}
+}
+
+func (w *EmailWorker) delayLoop(ctx context.Context) {
+	tick := time.NewTicker(rateRetryDelay)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			w.flushDue()
+		}
+	}
 }
 
 func (w *EmailWorker) Enqueue(ctx context.Context, job MailJob) (uuid.UUID, error) {
@@ -65,50 +88,81 @@ func (w *EmailWorker) Enqueue(ctx context.Context, job MailJob) (uuid.UUID, erro
 		}
 		job.LogID = row.ID
 	}
+	if err := w.push(ctx, job); err != nil {
+		return job.LogID, err
+	}
+	return job.LogID, nil
+}
+
+func (w *EmailWorker) push(ctx context.Context, job MailJob) error {
 	select {
 	case w.jobs <- job:
-		return job.LogID, nil
+		return nil
 	default:
-		_ = w.mark(ctx, job.LogID, model.EmailFailed, "queue is full", 0)
-		return job.LogID, errEmailQueueFull
+		_ = w.mark(ctx, job.LogID, model.EmailFailed, "queue is full", int16(job.Attempts))
+		return errEmailQueueFull
+	}
+}
+
+func (w *EmailWorker) schedule(job MailJob, d time.Duration) {
+	if d <= 0 {
+		_ = w.push(context.Background(), job)
+		return
+	}
+	w.delayMu.Lock()
+	w.delayed = append(w.delayed, delayedJob{job: job, at: w.now().Add(d)})
+	w.delayMu.Unlock()
+}
+
+func (w *EmailWorker) flushDue() {
+	now := w.now()
+	w.delayMu.Lock()
+	keep := w.delayed[:0]
+	due := make([]MailJob, 0)
+	for _, item := range w.delayed {
+		if !item.at.After(now) {
+			due = append(due, item.job)
+		} else {
+			keep = append(keep, item)
+		}
+	}
+	w.delayed = keep
+	w.delayMu.Unlock()
+	for _, job := range due {
+		_ = w.push(context.Background(), job)
 	}
 }
 
 func (w *EmailWorker) process(ctx context.Context, job MailJob) {
+	if w.limiter != nil && !w.limiter.Allow() {
+		w.schedule(job, rateRetryDelay)
+		return
+	}
 	var files []MailAttachment
 	var err error
 	if len(job.AttachmentIDs) > 0 && w.attach != nil {
 		files, err = w.attach.Load(ctx, job.AttachmentIDs)
 		if err != nil {
-			_ = w.mark(ctx, job.LogID, model.EmailFailed, err.Error(), 0)
+			_ = w.mark(ctx, job.LogID, model.EmailFailed, err.Error(), int16(job.Attempts))
 			return
 		}
 	}
-	for attempt := 1; attempt <= emailMaxAttempts; attempt++ {
-		for w.limiter != nil && !w.limiter.Allow() {
-			w.sleep(200 * time.Millisecond)
-			if ctx.Err() != nil {
-				return
-			}
-		}
-		err = w.sender.SendMIME(ctx, job, files)
-		if err == nil {
-			_ = w.mark(ctx, job.LogID, model.EmailSent, "", int16(attempt-1))
-			return
-		}
-		status := model.EmailRetrying
-		if attempt == emailMaxAttempts {
-			status = model.EmailFailed
-		}
-		_ = w.mark(ctx, job.LogID, status, err.Error(), int16(attempt))
-		if attempt == emailMaxAttempts {
-			return
-		}
-		wait := w.backoff[attempt-1]
-		if wait > 0 {
-			w.sleep(wait)
-		}
+	err = w.sender.SendMIME(ctx, job, files)
+	if err == nil {
+		_ = w.mark(ctx, job.LogID, model.EmailSent, "", int16(job.Attempts))
+		return
 	}
+	job.Attempts++
+	if job.Attempts >= emailMaxAttempts {
+		_ = w.mark(ctx, job.LogID, model.EmailFailed, err.Error(), int16(job.Attempts))
+		return
+	}
+	_ = w.mark(ctx, job.LogID, model.EmailRetrying, err.Error(), int16(job.Attempts))
+	wait := rateRetryDelay
+	if i := job.Attempts - 1; i >= 0 && i < len(w.backoff) {
+		wait = w.backoff[i]
+	}
+	w.schedule(job, wait)
 }
 
 func (w *EmailWorker) newLog(job MailJob) *model.EmailLog {

--- a/backend/internal/notification/service/email_worker_test.go
+++ b/backend/internal/notification/service/email_worker_test.go
@@ -87,17 +87,27 @@ func TestMinuteLimiterCapsAt50(t *testing.T) {
 	assert.True(t, l.Allow())
 }
 
+func processQueued(t *testing.T, w *EmailWorker, ctx context.Context) {
+	t.Helper()
+	select {
+	case job := <-w.jobs:
+		w.process(ctx, job)
+	default:
+		t.Fatal("email queue empty")
+	}
+}
+
 func TestEmailWorkerRetriesThenFails(t *testing.T) {
 	sender := &stubMIME{fail: 5}
 	logs := newMemLogs()
 	w := NewEmailWorker(sender, logs, nil, newMinuteLimiter(50, time.Now))
 	w.backoff = []time.Duration{0, 0, 0}
-	w.sleep = func(time.Duration) {}
 	ctx := context.Background()
 	id, err := w.Enqueue(ctx, MailJob{To: []string{"a@b.c"}, Subject: "s", Body: "b"})
 	require.NoError(t, err)
-	job := <-w.jobs
-	w.process(ctx, job)
+	for i := 0; i < emailMaxAttempts; i++ {
+		processQueued(t, w, ctx)
+	}
 	row, err := logs.GetByID(ctx, id)
 	require.NoError(t, err)
 	assert.Equal(t, model.EmailFailed, row.Status)
@@ -110,16 +120,73 @@ func TestEmailWorkerSucceedsAfterRetry(t *testing.T) {
 	logs := newMemLogs()
 	w := NewEmailWorker(sender, logs, nil, newMinuteLimiter(50, time.Now))
 	w.backoff = []time.Duration{0, 0, 0}
-	w.sleep = func(time.Duration) {}
 	ctx := context.Background()
 	id, err := w.Enqueue(ctx, MailJob{To: []string{"a@b.c"}, Subject: "s", Body: "b"})
 	require.NoError(t, err)
-	job := <-w.jobs
-	w.process(ctx, job)
+	processQueued(t, w, ctx)
+	processQueued(t, w, ctx)
 	row, err := logs.GetByID(ctx, id)
 	require.NoError(t, err)
 	assert.Equal(t, model.EmailSent, row.Status)
 	assert.Equal(t, 2, sender.calls)
+}
+
+type failToMIME struct {
+	mu    sync.Mutex
+	fail  map[string]bool
+	order []string
+}
+
+func (s *failToMIME) SendMIME(_ context.Context, job MailJob, _ []MailAttachment) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	to := ""
+	if len(job.To) > 0 {
+		to = job.To[0]
+	}
+	s.order = append(s.order, to)
+	if s.fail[to] {
+		return fmt.Errorf("smtp down")
+	}
+	return nil
+}
+
+func TestEmailWorkerDoesNotBlockOnRetryBackoff(t *testing.T) {
+	sender := &failToMIME{fail: map[string]bool{"fail@x.test": true}}
+	logs := newMemLogs()
+	w := NewEmailWorker(sender, logs, nil, newMinuteLimiter(50, time.Now))
+	w.backoff = []time.Duration{time.Hour, time.Hour, time.Hour}
+	ctx := context.Background()
+	failID, err := w.Enqueue(ctx, MailJob{To: []string{"fail@x.test"}, Subject: "s", Body: "b"})
+	require.NoError(t, err)
+	okID, err := w.Enqueue(ctx, MailJob{To: []string{"ok@x.test"}, Subject: "s", Body: "b"})
+	require.NoError(t, err)
+	processQueued(t, w, ctx)
+	processQueued(t, w, ctx)
+	assert.Equal(t, []string{"fail@x.test", "ok@x.test"}, sender.order)
+	failed, err := logs.GetByID(ctx, failID)
+	require.NoError(t, err)
+	ok, err := logs.GetByID(ctx, okID)
+	require.NoError(t, err)
+	assert.Equal(t, model.EmailRetrying, failed.Status)
+	assert.Equal(t, model.EmailSent, ok.Status)
+	assert.Len(t, w.delayed, 1)
+}
+
+func TestEmailWorkerStoresLongRecipientList(t *testing.T) {
+	logs := newMemLogs()
+	w := NewEmailWorker(&stubMIME{}, logs, nil, newMinuteLimiter(50, time.Now))
+	to := make([]string, 20)
+	for i := range to {
+		to[i] = fmt.Sprintf("user%02d@example.test", i)
+	}
+	ctx := context.Background()
+	id, err := w.Enqueue(ctx, MailJob{To: to, Subject: "s", Body: "b"})
+	require.NoError(t, err)
+	row, err := logs.GetByID(ctx, id)
+	require.NoError(t, err)
+	assert.Greater(t, len(row.ToAddress), 200)
+	assert.Contains(t, row.ToAddress, "user19@example.test")
 }
 
 type stubEngine struct{}
@@ -135,7 +202,6 @@ func (stubEngine) Validate(context.Context, string, map[string]interface{}) erro
 func TestEmailServiceBatchLimit(t *testing.T) {
 	logs := newMemLogs()
 	w := NewEmailWorker(&stubMIME{}, logs, nil, newMinuteLimiter(50, time.Now))
-	w.sleep = func(time.Duration) {}
 	svc := NewEmailService(w, stubEngine{}, logs)
 	recs := make([]dto.BatchRecipient, 51)
 	for i := range recs {
@@ -148,7 +214,6 @@ func TestEmailServiceBatchLimit(t *testing.T) {
 func TestEmailServiceSendQueues(t *testing.T) {
 	logs := newMemLogs()
 	w := NewEmailWorker(&stubMIME{}, logs, nil, newMinuteLimiter(50, time.Now))
-	w.sleep = func(time.Duration) {}
 	svc := NewEmailService(w, stubEngine{}, logs)
 	res, err := svc.Send(context.Background(), &dto.SendEmailRequest{
 		To: []string{"a@b.c"}, Subject: "hello", Body: "world",

--- a/backend/internal/notification/service/email_worker_test.go
+++ b/backend/internal/notification/service/email_worker_test.go
@@ -173,6 +173,50 @@ func TestEmailWorkerDoesNotBlockOnRetryBackoff(t *testing.T) {
 	assert.Len(t, w.delayed, 1)
 }
 
+func TestEmailWorkerQueueBoundIncludesDelayed(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	l := newMinuteLimiter(50, func() time.Time { return now })
+	for i := 0; i < 50; i++ {
+		require.True(t, l.Allow())
+	}
+	logs := newMemLogs()
+	w := NewEmailWorker(&stubMIME{}, logs, nil, l)
+	ctx := context.Background()
+	for i := 0; i < emailQueueSize; i++ {
+		_, err := w.Enqueue(ctx, MailJob{To: []string{"a@b.c"}, Subject: "s", Body: "b"})
+		require.NoError(t, err)
+	}
+	for i := 0; i < emailQueueSize; i++ {
+		processQueued(t, w, ctx)
+	}
+	_, err := w.Enqueue(ctx, MailJob{To: []string{"overflow@x.test"}, Subject: "s", Body: "b"})
+	require.ErrorIs(t, err, errEmailQueueFull)
+	assert.Equal(t, emailQueueSize, w.queued)
+	assert.Len(t, w.delayed, emailQueueSize)
+}
+
+func TestFlushDueKeepsRetryWhenQueueFull(t *testing.T) {
+	logs := newMemLogs()
+	w := NewEmailWorker(&stubMIME{}, logs, nil, newMinuteLimiter(50, time.Now))
+	ctx := context.Background()
+	for i := 0; i < emailQueueSize; i++ {
+		_, err := w.Enqueue(ctx, MailJob{To: []string{"a@b.c"}, Subject: "s", Body: "b"})
+		require.NoError(t, err)
+	}
+	extra := MailJob{To: []string{"retry@x.test"}, Subject: "s", Body: "b", Attempts: 1}
+	row := w.newLog(extra)
+	row.Status = model.EmailRetrying
+	require.NoError(t, logs.Create(ctx, row))
+	extra.LogID = row.ID
+	w.delayed = []delayedJob{{job: extra, at: w.now()}}
+	w.flushDue()
+	got, err := logs.GetByID(ctx, row.ID)
+	require.NoError(t, err)
+	assert.Equal(t, model.EmailRetrying, got.Status)
+	assert.NotEqual(t, "queue is full", got.ErrorMessage)
+	assert.Len(t, w.delayed, 1)
+}
+
 func TestEmailWorkerStoresLongRecipientList(t *testing.T) {
 	logs := newMemLogs()
 	w := NewEmailWorker(&stubMIME{}, logs, nil, newMinuteLimiter(50, time.Now))

--- a/backend/internal/notification/service/email_worker_test.go
+++ b/backend/internal/notification/service/email_worker_test.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/notification/model"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubMIME struct {
+	mu    sync.Mutex
+	fail  int
+	calls int
+	last  MailJob
+}
+
+func (s *stubMIME) SendMIME(_ context.Context, job MailJob, _ []MailAttachment) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.last = job
+	if s.calls <= s.fail {
+		return fmt.Errorf("smtp down")
+	}
+	return nil
+}
+
+type memLogs struct {
+	mu   sync.Mutex
+	rows map[uuid.UUID]*model.EmailLog
+}
+
+func newMemLogs() *memLogs { return &memLogs{rows: map[uuid.UUID]*model.EmailLog{}} }
+
+func (m *memLogs) Create(_ context.Context, row *model.EmailLog) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *row
+	m.rows[row.ID] = &cp
+	return nil
+}
+func (m *memLogs) Update(_ context.Context, row *model.EmailLog) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *row
+	m.rows[row.ID] = &cp
+	return nil
+}
+func (m *memLogs) GetByID(_ context.Context, id uuid.UUID) (*model.EmailLog, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	row, ok := m.rows[id]
+	if !ok {
+		return nil, fmt.Errorf("missing")
+	}
+	cp := *row
+	return &cp, nil
+}
+func (m *memLogs) List(_ context.Context, status int16, _, _ *time.Time, _, _ int) ([]*model.EmailLog, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := []*model.EmailLog{}
+	for _, r := range m.rows {
+		if status < 0 || r.Status == status {
+			cp := *r
+			out = append(out, &cp)
+		}
+	}
+	return out, int64(len(out)), nil
+}
+
+func TestMinuteLimiterCapsAt50(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	l := newMinuteLimiter(50, func() time.Time { return now })
+	for i := 0; i < 50; i++ {
+		require.True(t, l.Allow())
+	}
+	assert.False(t, l.Allow())
+	now = now.Add(time.Minute + time.Second)
+	assert.True(t, l.Allow())
+}
+
+func TestEmailWorkerRetriesThenFails(t *testing.T) {
+	sender := &stubMIME{fail: 5}
+	logs := newMemLogs()
+	w := NewEmailWorker(sender, logs, nil, newMinuteLimiter(50, time.Now))
+	w.backoff = []time.Duration{0, 0, 0}
+	w.sleep = func(time.Duration) {}
+	ctx := context.Background()
+	id, err := w.Enqueue(ctx, MailJob{To: []string{"a@b.c"}, Subject: "s", Body: "b"})
+	require.NoError(t, err)
+	job := <-w.jobs
+	w.process(ctx, job)
+	row, err := logs.GetByID(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, model.EmailFailed, row.Status)
+	assert.Equal(t, int16(3), row.RetryCount)
+	assert.Equal(t, 3, sender.calls)
+}
+
+func TestEmailWorkerSucceedsAfterRetry(t *testing.T) {
+	sender := &stubMIME{fail: 1}
+	logs := newMemLogs()
+	w := NewEmailWorker(sender, logs, nil, newMinuteLimiter(50, time.Now))
+	w.backoff = []time.Duration{0, 0, 0}
+	w.sleep = func(time.Duration) {}
+	ctx := context.Background()
+	id, err := w.Enqueue(ctx, MailJob{To: []string{"a@b.c"}, Subject: "s", Body: "b"})
+	require.NoError(t, err)
+	job := <-w.jobs
+	w.process(ctx, job)
+	row, err := logs.GetByID(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, model.EmailSent, row.Status)
+	assert.Equal(t, 2, sender.calls)
+}
+
+type stubEngine struct{}
+
+func (stubEngine) Render(context.Context, string, map[string]interface{}) (*dto.TestTemplateResponse, error) {
+	return &dto.TestTemplateResponse{Title: "T", Content: "C"}, nil
+}
+func (stubEngine) RenderTemplate(*model.NotificationTemplate, map[string]interface{}) (*dto.TestTemplateResponse, error) {
+	return &dto.TestTemplateResponse{Title: "T", Content: "C"}, nil
+}
+func (stubEngine) Validate(context.Context, string, map[string]interface{}) error { return nil }
+
+func TestEmailServiceBatchLimit(t *testing.T) {
+	logs := newMemLogs()
+	w := NewEmailWorker(&stubMIME{}, logs, nil, newMinuteLimiter(50, time.Now))
+	w.sleep = func(time.Duration) {}
+	svc := NewEmailService(w, stubEngine{}, logs)
+	recs := make([]dto.BatchRecipient, 51)
+	for i := range recs {
+		recs[i] = dto.BatchRecipient{Email: "a@b.c"}
+	}
+	_, err := svc.SendBatch(context.Background(), &dto.BatchSendEmailRequest{Recipients: recs, Subject: "s", Body: "b"}, uuid.New())
+	require.Error(t, err)
+}
+
+func TestEmailServiceSendQueues(t *testing.T) {
+	logs := newMemLogs()
+	w := NewEmailWorker(&stubMIME{}, logs, nil, newMinuteLimiter(50, time.Now))
+	w.sleep = func(time.Duration) {}
+	svc := NewEmailService(w, stubEngine{}, logs)
+	res, err := svc.Send(context.Background(), &dto.SendEmailRequest{
+		To: []string{"a@b.c"}, Subject: "hello", Body: "world",
+	}, uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, "queued", res.Status)
+	assert.NotEmpty(t, res.MessageID)
+}

--- a/backend/migrations/000031_email_logs_enhance.down.sql
+++ b/backend/migrations/000031_email_logs_enhance.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_email_logs_notification_id;
+ALTER TABLE email_logs
+    DROP COLUMN IF EXISTS notification_id,
+    DROP COLUMN IF EXISTS retry_count,
+    DROP COLUMN IF EXISTS cc,
+    DROP COLUMN IF EXISTS is_html;

--- a/backend/migrations/000031_email_logs_enhance.down.sql
+++ b/backend/migrations/000031_email_logs_enhance.down.sql
@@ -4,3 +4,4 @@ ALTER TABLE email_logs
     DROP COLUMN IF EXISTS retry_count,
     DROP COLUMN IF EXISTS cc,
     DROP COLUMN IF EXISTS is_html;
+ALTER TABLE email_logs ALTER COLUMN to_address TYPE VARCHAR(200) USING left(to_address, 200);

--- a/backend/migrations/000031_email_logs_enhance.up.sql
+++ b/backend/migrations/000031_email_logs_enhance.up.sql
@@ -1,0 +1,8 @@
+-- #25 邮件发送记录增强：关联通知、重试次数、抄送
+ALTER TABLE email_logs
+    ADD COLUMN IF NOT EXISTS notification_id UUID REFERENCES notifications(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS retry_count SMALLINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS cc VARCHAR(1000),
+    ADD COLUMN IF NOT EXISTS is_html BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_email_logs_notification_id ON email_logs(notification_id);

--- a/backend/migrations/000031_email_logs_enhance.up.sql
+++ b/backend/migrations/000031_email_logs_enhance.up.sql
@@ -1,8 +1,10 @@
--- #25 邮件发送记录增强：关联通知、重试次数、抄送
+-- #25 邮件发送记录增强：关联通知、重试次数、抄送；收件人改为 text 以支持多人
 ALTER TABLE email_logs
     ADD COLUMN IF NOT EXISTS notification_id UUID REFERENCES notifications(id) ON DELETE SET NULL,
     ADD COLUMN IF NOT EXISTS retry_count SMALLINT NOT NULL DEFAULT 0,
-    ADD COLUMN IF NOT EXISTS cc VARCHAR(1000),
+    ADD COLUMN IF NOT EXISTS cc TEXT,
     ADD COLUMN IF NOT EXISTS is_html BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE email_logs ALTER COLUMN to_address TYPE TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_email_logs_notification_id ON email_logs(notification_id);

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -152,14 +152,17 @@ const (
 	CodeStatsTooLarge         = 11004 // 数据量过大
 
 	// ===== Notification module (12000-12999) =====
-	CodeNotificationNotFound    = 12001 // 通知不存在
-	CodeNotificationTplExists   = 12002 // 通知模板已存在
-	CodeNotificationTplNotFound = 12003 // 通知模板不存在
-	CodeNotificationRenderFail  = 12004 // 模板渲染失败（变量缺失）
-	CodeNotificationWSAuthFail  = 12005 // WebSocket 认证失败
-	CodeNotificationEmailFail   = 12006 // 邮件发送失败
-	CodeNotificationBadChannel  = 12007 // 不支持的通知渠道
-	CodeNotificationNoAccess    = 12008 // 无权操作该通知
+	CodeNotificationNotFound     = 12001 // 通知不存在
+	CodeNotificationTplExists    = 12002 // 通知模板已存在
+	CodeNotificationTplNotFound  = 12003 // 通知模板不存在
+	CodeNotificationRenderFail   = 12004 // 模板渲染失败（变量缺失）
+	CodeNotificationWSAuthFail   = 12005 // WebSocket 认证失败
+	CodeNotificationEmailFail    = 12006 // 邮件发送失败
+	CodeNotificationBadChannel   = 12007 // 不支持的通知渠道
+	CodeNotificationNoAccess     = 12008 // 无权操作该通知
+	CodeNotificationEmailInvalid = 12009 // 邮件参数无效
+	CodeNotificationEmailRate    = 12010 // 邮件批量超出限流
+	CodeNotificationEmailAttach  = 12011 // 邮件附件不存在
 
 	// ===== Runtime configstore (#47, 14000-14999) =====
 	CodeConfigNotFound     = 14001 // 配置不存在


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 Issue #25：在已有 #4 `EmailChannel` 上做邮件增强，**不新建** `internal/email`。

- 附件：按文件 ID 从 MinIO 拉取后挂到 SMTP
- 批量发送：`POST /notifications/email/batch`，单次最多 50，发送端每分钟 50 封限流
- 失败重试：最多 3 次，默认退避 1/5/15 分钟；重试等待走延迟队列，不阻塞后续邮件
- 发送记录：扩展已有 `email_logs`（迁移 000031），`to_address`/`cc` 改为 TEXT 以支持多人收件
- 异步有界队列（容量 64；通道 + 延迟 + 处理中共用），队列满则拒绝新入队，到期回灌满队时保留重试任务

## 关联 Issue

Closes #25

## 测试方式

1. `make migrate-up` 应用 `000031`
2. 登录后调用 `POST /api/v1/notifications/email/send`、`/batch`、`GET /logs`（需 `notification:send`）
3. `cd backend && go test ./internal/notification/...`

## 截图 / GIF

后端 API 增强，无前端页面。

## 注意事项

- 复用 `go-mail` SMTP 客户端与 #4 模板引擎
- 错误码 12009–12011
- 不要合入 Bugbot Autofix 旁路
- 已按 Bugbot 审查修复：worker 重试不 sleep 堵队列；多人 `to_address` 不截断；延迟任务计入 64 上限；满队回灌不丢仍可重试的邮件

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测
- [ ] 已添加/更新必要的文档
- [x] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

