### PR TITLE
feat(frontend): 工作台接统计 API 并增加数据大屏 (#26)

### DIFF
--- a/frontend/src/api/error.ts
+++ b/frontend/src/api/error.ts
@@ -1,4 +1,12 @@
-import type { AxiosError } from 'axios';
+import axios, { type AxiosError } from 'axios';
+
+/** 主动取消（AbortSignal / 卸载）不算失败，拦截器不应弹 toast。 */
+export function isCanceledError(error: unknown): boolean {
+  if (axios.isCancel(error)) return true;
+  if (typeof error !== 'object' || error === null) return false;
+  const e = error as { code?: string; name?: string };
+  return e.code === 'ERR_CANCELED' || e.name === 'CanceledError' || e.name === 'AbortError';
+}
 
 /**
  * 业务错误码到中文消息的映射

--- a/frontend/src/api/request.ts
+++ b/frontend/src/api/request.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosError } from 'axios';
 import { message } from 'antd';
 import { getToken, getRefreshToken, setToken, setRefreshToken, removeToken } from '@/utils/storage';
-import { handleApiError } from './error';
+import { handleApiError, isCanceledError } from './error';
 
 const baseURL = import.meta.env.VITE_API_BASE_URL || '/api/v1';
 
@@ -104,6 +104,11 @@ request.interceptors.response.use(
     return Promise.reject(new Error(msg || '请求失败'));
   },
   async (error: AxiosError) => {
+    // 卸载/切页取消请求：不重试、不弹「网络连接失败」
+    if (isCanceledError(error)) {
+      return Promise.reject(error);
+    }
+
     const originalRequest = error.config as InternalAxiosRequestConfig;
 
     // 处理 401 Token 过期

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -70,12 +70,12 @@ export function listStatsProviders(): Promise<ProviderInfo[]> {
   return request.get('/stats/providers');
 }
 
-export function getStatsOverview(): Promise<OverviewResponse> {
-  return request.get('/stats/overview');
+export function getStatsOverview(signal?: AbortSignal): Promise<OverviewResponse> {
+  return request.get('/stats/overview', { signal });
 }
 
-export function getStats(provider: string, params?: StatsQuery): Promise<StatsResult> {
-  return request.get(`/stats/${provider}`, { params });
+export function getStats(provider: string, params?: StatsQuery, signal?: AbortSignal): Promise<StatsResult> {
+  return request.get(`/stats/${provider}`, { params, signal });
 }
 
 function filenameFromDisposition(header: string | undefined, fallback: string): string {

--- a/frontend/src/components/Chart/BarChart.tsx
+++ b/frontend/src/components/Chart/BarChart.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react';
+import type { EChartsOption } from 'echarts';
+import Chart from './Chart';
+import ChartCard from './ChartCard';
+import { CHART_COLORS } from './palette';
+
+export interface BarChartProps {
+  categories: string[];
+  series: { name: string; data: number[] }[];
+  title?: string;
+  horizontal?: boolean;
+  height?: number | string;
+  loading?: boolean;
+  theme?: 'light' | 'dark';
+}
+
+function buildOption(
+  categories: string[],
+  series: { name: string; data: number[] }[],
+  horizontal: boolean,
+): EChartsOption {
+  const bars = series.map((s) => ({
+    name: s.name,
+    type: 'bar' as const,
+    data: s.data,
+    barMaxWidth: 48,
+  }));
+  if (horizontal) {
+    return {
+      color: CHART_COLORS,
+      tooltip: { trigger: 'axis' },
+      legend: series.length > 1 ? { bottom: 0 } : undefined,
+      grid: { left: 80, right: 24, top: 24, bottom: series.length > 1 ? 48 : 24 },
+      xAxis: { type: 'value', minInterval: 1 },
+      yAxis: { type: 'category', data: categories },
+      series: bars,
+    };
+  }
+  return {
+    color: CHART_COLORS,
+    tooltip: { trigger: 'axis' },
+    legend: series.length > 1 ? { bottom: 0 } : undefined,
+    grid: { left: 40, right: 16, top: 24, bottom: series.length > 1 ? 48 : 32 },
+    xAxis: { type: 'category', data: categories },
+    yAxis: { type: 'value', minInterval: 1 },
+    series: bars,
+  };
+}
+
+const BarChart: React.FC<BarChartProps> = ({
+  categories, series, title, horizontal = false, height = 300, loading, theme,
+}) => {
+  const option = useMemo(
+    () => buildOption(categories, series, horizontal),
+    [categories, series, horizontal],
+  );
+  const empty = !categories.length;
+  const cardHeight = typeof height === 'number' ? height : 300;
+  if (title) {
+    return <ChartCard title={title} option={option} loading={loading} height={cardHeight} empty={empty} />;
+  }
+  return <Chart option={option} loading={loading} height={height} theme={theme} />;
+};
+
+export default BarChart;

--- a/frontend/src/components/Chart/Chart.tsx
+++ b/frontend/src/components/Chart/Chart.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { EChartsOption } from 'echarts';
+import { useSelector } from 'react-redux';
+import { selectTheme } from '@/store/slices/appSlice';
+import { useECharts } from './useECharts';
+
+export interface ChartProps {
+  option?: EChartsOption;
+  loading?: boolean;
+  height?: number | string;
+  autoResize?: boolean;
+  theme?: 'light' | 'dark';
+  className?: string;
+}
+
+const Chart: React.FC<ChartProps> = ({
+  option,
+  loading = false,
+  height = 300,
+  autoResize = true,
+  theme: themeProp,
+  className,
+}) => {
+  const storeTheme = useSelector(selectTheme);
+  const theme = themeProp ?? storeTheme;
+  const { ref } = useECharts(option, loading, theme, autoResize);
+  const h = typeof height === 'number' ? `${height}px` : height;
+  return <div className={className} ref={ref} style={{ width: '100%', height: h }} />;
+};
+
+export default Chart;

--- a/frontend/src/components/Chart/ChartCard.tsx
+++ b/frontend/src/components/Chart/ChartCard.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Alert, Button, Card, Dropdown, Empty, Space } from 'antd';
 import { DownloadOutlined } from '@ant-design/icons';
 import type { EChartsOption } from 'echarts';
+import { useSelector } from 'react-redux';
+import { selectTheme } from '@/store/slices/appSlice';
 import { useECharts } from './useECharts';
 
 export interface ChartCardProps {
@@ -26,7 +28,8 @@ const ChartCard: React.FC<ChartCardProps> = ({
   actions,
 }) => {
   const hideChart = !!error || (!!empty && !loading);
-  const { ref, chart } = useECharts(hideChart ? undefined : option, loading && !error);
+  const theme = useSelector(selectTheme);
+  const { ref, chart } = useECharts(hideChart ? undefined : option, loading && !error, theme);
 
   const extra = (
     <Space size={8}>

--- a/frontend/src/components/Chart/LineChart.tsx
+++ b/frontend/src/components/Chart/LineChart.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react';
+import type { EChartsOption } from 'echarts';
+import Chart from './Chart';
+import ChartCard from './ChartCard';
+import { CHART_COLORS } from './palette';
+
+export interface LineChartProps {
+  categories: string[];
+  series: { name: string; data: number[] }[];
+  title?: string;
+  area?: boolean;
+  height?: number | string;
+  loading?: boolean;
+  theme?: 'light' | 'dark';
+}
+
+function buildOption(
+  categories: string[],
+  series: { name: string; data: number[] }[],
+  area: boolean,
+): EChartsOption {
+  return {
+    color: CHART_COLORS,
+    tooltip: { trigger: 'axis' },
+    legend: series.length > 1 ? { bottom: 0 } : undefined,
+    grid: { left: 40, right: 16, top: 24, bottom: series.length > 1 ? 48 : 32 },
+    xAxis: { type: 'category', data: categories },
+    yAxis: { type: 'value' },
+    series: series.map((s) => ({
+      name: s.name,
+      type: 'line' as const,
+      smooth: true,
+      areaStyle: area ? { opacity: 0.18 } : undefined,
+      data: s.data,
+    })),
+  };
+}
+
+const LineChart: React.FC<LineChartProps> = ({
+  categories, series, title, area = false, height = 300, loading, theme,
+}) => {
+  const option = useMemo(
+    () => buildOption(categories, series, area),
+    [categories, series, area],
+  );
+  if (title) {
+    const cardHeight = typeof height === 'number' ? height : 300;
+    return (
+      <ChartCard
+        title={title}
+        option={option}
+        loading={loading}
+        height={cardHeight}
+        empty={!categories.length}
+      />
+    );
+  }
+  return <Chart option={option} loading={loading} height={height} theme={theme} />;
+};
+
+export default LineChart;

--- a/frontend/src/components/Chart/PieChart.tsx
+++ b/frontend/src/components/Chart/PieChart.tsx
@@ -1,0 +1,47 @@
+import React, { useMemo } from 'react';
+import type { EChartsOption } from 'echarts';
+import Chart from './Chart';
+import ChartCard from './ChartCard';
+import { CHART_COLORS } from './palette';
+
+export interface PieChartProps {
+  data: { name: string; value: number }[];
+  title?: string;
+  height?: number | string;
+  loading?: boolean;
+  theme?: 'light' | 'dark';
+}
+
+function buildOption(data: { name: string; value: number }[]): EChartsOption {
+  return {
+    color: CHART_COLORS,
+    tooltip: { trigger: 'item' },
+    legend: { bottom: 0 },
+    series: [
+      {
+        type: 'pie',
+        radius: ['36%', '64%'],
+        data: data.map((d) => ({ name: d.name, value: d.value })),
+      },
+    ],
+  };
+}
+
+const PieChart: React.FC<PieChartProps> = ({ data, title, height = 300, loading, theme }) => {
+  const option = useMemo(() => buildOption(data), [data]);
+  if (title) {
+    const cardHeight = typeof height === 'number' ? height : 300;
+    return (
+      <ChartCard
+        title={title}
+        option={option}
+        loading={loading}
+        height={cardHeight}
+        empty={!data.length}
+      />
+    );
+  }
+  return <Chart option={option} loading={loading} height={height} theme={theme} />;
+};
+
+export default PieChart;

--- a/frontend/src/components/Chart/index.ts
+++ b/frontend/src/components/Chart/index.ts
@@ -1,0 +1,12 @@
+export { default as Chart } from './Chart';
+export type { ChartProps } from './Chart';
+export { default as ChartCard } from './ChartCard';
+export type { ChartCardProps } from './ChartCard';
+export { default as PieChart } from './PieChart';
+export type { PieChartProps } from './PieChart';
+export { default as BarChart } from './BarChart';
+export type { BarChartProps } from './BarChart';
+export { default as LineChart } from './LineChart';
+export type { LineChartProps } from './LineChart';
+export { useECharts } from './useECharts';
+export { CHART_COLORS } from './palette';

--- a/frontend/src/components/Chart/palette.ts
+++ b/frontend/src/components/Chart/palette.ts
@@ -1,0 +1,9 @@
+export const CHART_COLORS = [
+  '#2563eb',
+  '#52c41a',
+  '#faad14',
+  '#ff4d4f',
+  '#722ed1',
+  '#13c2c2',
+  '#eb2f96',
+];

--- a/frontend/src/components/Chart/useECharts.ts
+++ b/frontend/src/components/Chart/useECharts.ts
@@ -2,7 +2,12 @@ import { useEffect, useRef } from 'react';
 import * as echarts from 'echarts';
 import type { EChartsOption } from 'echarts';
 
-export function useECharts(option: EChartsOption | undefined, loading: boolean) {
+export function useECharts(
+  option: EChartsOption | undefined,
+  loading: boolean,
+  theme: 'light' | 'dark' = 'light',
+  autoResize = true,
+) {
   const ref = useRef<HTMLDivElement>(null);
   const chartRef = useRef<echarts.ECharts | null>(null);
 
@@ -11,18 +16,26 @@ export function useECharts(option: EChartsOption | undefined, loading: boolean) 
     if (!el) {
       return undefined;
     }
-    const chart = echarts.init(el);
+    const chart = echarts.init(el, theme === 'dark' ? 'dark' : undefined);
     chartRef.current = chart;
     const onResize = () => {
       chart.resize();
     };
-    window.addEventListener('resize', onResize);
+    let observer: ResizeObserver | undefined;
+    if (autoResize) {
+      window.addEventListener('resize', onResize);
+      observer = new ResizeObserver(onResize);
+      observer.observe(el);
+    }
     return () => {
-      window.removeEventListener('resize', onResize);
+      observer?.disconnect();
+      if (autoResize) {
+        window.removeEventListener('resize', onResize);
+      }
       chart.dispose();
       chartRef.current = null;
     };
-  }, []);
+  }, [theme, autoResize]);
 
   useEffect(() => {
     const chart = chartRef.current;
@@ -40,7 +53,7 @@ export function useECharts(option: EChartsOption | undefined, loading: boolean) 
         chart.resize();
       });
     }
-  }, [option, loading]);
+  }, [option, loading, theme]);
 
   return { ref, chart: chartRef };
 }

--- a/frontend/src/components/Chart/useECharts.ts
+++ b/frontend/src/components/Chart/useECharts.ts
@@ -16,6 +16,8 @@ export function useECharts(
     if (!el) {
       return undefined;
     }
+    const old = echarts.getInstanceByDom(el);
+    old?.dispose();
     const chart = echarts.init(el, theme === 'dark' ? 'dark' : undefined);
     chartRef.current = chart;
     const onResize = () => {

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -23,3 +23,6 @@ export { default as ErrorBoundary } from './ErrorBoundary';
 
 export { default as FileUpload } from './FileUpload';
 export type { FileUploadProps } from './FileUpload';
+
+export { Chart, ChartCard, PieChart, BarChart, LineChart, useECharts, CHART_COLORS } from './Chart';
+export type { ChartProps, ChartCardProps, PieChartProps, BarChartProps, LineChartProps } from './Chart';

--- a/frontend/src/pages/dashboard/Dashboard.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.tsx
@@ -1,179 +1,94 @@
 import React from 'react';
-import { Row, Col, Card, Statistic, List, Tag, Progress, Button, Space } from 'antd';
+import { Button, Card, Col, Row, Skeleton, Space, Statistic } from 'antd';
 import {
-  UserOutlined,
-  TeamOutlined,
-  ScheduleOutlined,
   CheckCircleOutlined,
+  ExpandOutlined,
+  ScheduleOutlined,
+  TeamOutlined,
+  UserOutlined,
 } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
-import ReactECharts from 'echarts-for-react';
-import '@/pages/internship/internship.css';
+import DashboardPanels from './DashboardPanels';
+import { useDashboardStats } from './useDashboardStats';
+import './dashboard.css';
 
 const Dashboard: React.FC = () => {
-  // 统计卡片数据
-  const stats = [
-    { title: '会员总数', value: 328, icon: <UserOutlined style={{ color: '#1677ff' }} />, color: '#e6f4ff' },
-    { title: '待面试', value: 15, icon: <ScheduleOutlined style={{ color: '#faad14' }} />, color: '#fffbe6' },
-    { title: '进行中任务', value: 23, icon: <CheckCircleOutlined style={{ color: '#52c41a' }} />, color: '#f6ffed' },
-    { title: '本月会议', value: 8, icon: <TeamOutlined style={{ color: '#722ed1' }} />, color: '#f9f0ff' },
-  ];
-
-  // 会员增长趋势图
-  const memberGrowthOption = {
-    title: { text: '会员增长趋势', left: 'center', textStyle: { fontSize: 14 } },
-    tooltip: { trigger: 'axis' },
-    xAxis: {
-      type: 'category',
-      data: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月'],
-    },
-    yAxis: { type: 'value' },
-    series: [
-      {
-        data: [50, 80, 120, 150, 180, 220, 280, 328],
-        type: 'line',
-        smooth: true,
-        areaStyle: { opacity: 0.3 },
-        lineStyle: { color: '#1677ff' },
-        itemStyle: { color: '#1677ff' },
-      },
-    ],
-    grid: { left: 40, right: 20, top: 40, bottom: 30 },
-  };
-
-  // 部门分布饼图
-  const departmentOption = {
-    title: { text: '部门人员分布', left: 'center', textStyle: { fontSize: 14 } },
-    tooltip: { trigger: 'item' },
-    legend: { bottom: 10, left: 'center' },
-    series: [
-      {
-        type: 'pie',
-        radius: ['40%', '65%'],
-        avoidLabelOverlap: false,
-        label: { show: false },
-        data: [
-          { value: 45, name: '技术部' },
-          { value: 38, name: '宣传部' },
-          { value: 32, name: '组织部' },
-          { value: 28, name: '外联部' },
-          { value: 25, name: '办公室' },
-        ],
-      },
-    ],
-  };
-
-  // 最近活动
-  const recentActivities = [
-    { user: '张三', action: '提交了入会申请', time: '10分钟前', type: '申请' },
-    { user: '李四', action: '完成了面试安排', time: '30分钟前', type: '面试' },
-    { user: '王五', action: '发起了新会议', time: '1小时前', type: '会议' },
-    { user: '赵六', action: '更新了任务状态', time: '2小时前', type: '任务' },
-    { user: '孙七', action: '提交了实习报告', time: '3小时前', type: '实习' },
-  ];
-
   const navigate = useNavigate();
+  const { overview, charts, loading, canReadCharts } = useDashboardStats();
 
   return (
-    <div>
-      <div className="recruit-hero">
+    <div className="dash-page">
+      <div className="dash-hero">
         <div>
-          <h2>秋季招新工作台</h2>
-          <p>入会申请、面试安排、任务协同和实习培养都在这里。先把申请入口跑通，再安排一面 / 二面。</p>
+          <h2>协会工作台</h2>
+          <p>会员、面试、会议、任务与实习数据来自统计接口，大屏适合投屏展示。</p>
         </div>
         <Space wrap>
           <Button size="large" onClick={() => navigate('/member/application')}>入会申请</Button>
-          <Button size="large" onClick={() => navigate('/interview/list')}>面试安排</Button>
-          <Button type="primary" size="large" onClick={() => navigate('/internship/my')}>我的实习</Button>
+          <Button size="large" onClick={() => navigate('/stats/overview')}>统计概览</Button>
+          {canReadCharts ? (
+            <Button type="primary" size="large" icon={<ExpandOutlined />} onClick={() => navigate('/dashboard/bigscreen')}>
+              数据大屏
+            </Button>
+          ) : null}
         </Space>
       </div>
-      {/* 统计卡片 */}
-      <Row gutter={16} style={{ marginBottom: 16 }}>
-        {stats.map((stat, index) => (
-          <Col span={6} key={index}>
-            <Card>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <Statistic title={stat.title} value={stat.value} />
-                <div
-                  style={{
-                    width: 48,
-                    height: 48,
-                    borderRadius: 8,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontSize: 24,
-                    background: stat.color,
-                  }}
-                >
-                  {stat.icon}
-                </div>
+
+      <Row gutter={[16, 16]} className="dash-kpis">
+        <Col xs={12} lg={6}>
+          <Card>
+            {loading && !overview ? <Skeleton active paragraph={false} /> : (
+              <div className="dash-kpi">
+                <Statistic title="会员总数" value={overview?.total_members ?? 0} />
+                <span className="dash-kpi-icon" style={{ background: '#e6f4ff', color: '#2563eb' }}><UserOutlined /></span>
               </div>
-            </Card>
-          </Col>
-        ))}
+            )}
+          </Card>
+        </Col>
+        <Col xs={12} lg={6}>
+          <Card>
+            {loading && !overview ? <Skeleton active paragraph={false} /> : (
+              <div className="dash-kpi">
+                <Statistic title="待审批" value={overview?.pending_approvals ?? 0} />
+                <span className="dash-kpi-icon" style={{ background: '#fffbe6', color: '#faad14' }}><ScheduleOutlined /></span>
+              </div>
+            )}
+          </Card>
+        </Col>
+        <Col xs={12} lg={6}>
+          <Card>
+            {loading && !overview ? <Skeleton active paragraph={false} /> : (
+              <div className="dash-kpi">
+                <Statistic title="进行中任务" value={overview?.total_tasks_in_progress ?? 0} />
+                <span className="dash-kpi-icon" style={{ background: '#f6ffed', color: '#52c41a' }}><CheckCircleOutlined /></span>
+              </div>
+            )}
+          </Card>
+        </Col>
+        <Col xs={12} lg={6}>
+          <Card>
+            {loading && !overview ? <Skeleton active paragraph={false} /> : (
+              <div className="dash-kpi">
+                <Statistic title="本月会议" value={overview?.total_meetings_this_month ?? 0} />
+                <span className="dash-kpi-icon" style={{ background: '#f9f0ff', color: '#722ed1' }}><TeamOutlined /></span>
+              </div>
+            )}
+          </Card>
+        </Col>
       </Row>
 
-      {/* 图表区域 */}
-      <Row gutter={16} style={{ marginBottom: 16 }}>
-        <Col span={16}>
-          <Card title="数据概览">
-            <ReactECharts option={memberGrowthOption} style={{ height: 300 }} />
-          </Card>
-        </Col>
-        <Col span={8}>
-          <Card title="部门分布">
-            <ReactECharts option={departmentOption} style={{ height: 300 }} />
-          </Card>
-        </Col>
-      </Row>
-
-      {/* 最近活动 & 待办事项 */}
-      <Row gutter={16}>
-        <Col span={12}>
-          <Card title="最近活动">
-            <List
-              dataSource={recentActivities}
-              renderItem={(item) => (
-                <List.Item>
-                  <List.Item.Meta
-                    title={
-                      <span>
-                        <strong>{item.user}</strong> {item.action}
-                      </span>
-                    }
-                    description={item.time}
-                  />
-                  <Tag color="blue">{item.type}</Tag>
-                </List.Item>
-              )}
-            />
-          </Card>
-        </Col>
-        <Col span={12}>
-          <Card title="任务进度">
-            <List
-              dataSource={[
-                { name: '招新系统开发', progress: 80 },
-                { name: '面试流程优化', progress: 60 },
-                { name: '官网改版', progress: 45 },
-                { name: '培训资料整理', progress: 30 },
-              ]}
-              renderItem={(item) => (
-                <List.Item>
-                  <div style={{ width: '100%' }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-                      <span>{item.name}</span>
-                      <span>{item.progress}%</span>
-                    </div>
-                    <Progress percent={item.progress} size="small" />
-                  </div>
-                </List.Item>
-              )}
-            />
-          </Card>
-        </Col>
-      </Row>
+      <DashboardPanels
+        loading={loading}
+        canReadCharts={canReadCharts}
+        member={charts['member-distribution']}
+        interview={charts['interview-data']}
+        meeting={charts['meeting-attendance']}
+        task={charts['task-progress']}
+        internship={charts['internship-duration']}
+        meetings={overview?.today_meetings ?? []}
+        taskTodo={overview?.my_tasks.todo ?? 0}
+        taskOverdue={overview?.my_tasks.overdue ?? 0}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/dashboard/DashboardPanels.tsx
+++ b/frontend/src/pages/dashboard/DashboardPanels.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Card, Col, List, Progress, Row, Skeleton, Tag, Typography } from 'antd';
+import { BarChart, LineChart, PieChart } from '@/components/Chart';
+import { formatDateTime } from '@/utils/format';
+import type { OverviewMeeting, StatsResult } from '@/api/stats';
+import { findSeries, seriesToPie, seriesToXY } from './useDashboardStats';
+
+interface DashboardPanelsProps {
+  loading: boolean;
+  canReadCharts: boolean;
+  member?: StatsResult;
+  interview?: StatsResult;
+  meeting?: StatsResult;
+  task?: StatsResult;
+  internship?: StatsResult;
+  meetings: OverviewMeeting[];
+  taskTodo: number;
+  taskOverdue: number;
+}
+
+const DashboardPanels: React.FC<DashboardPanelsProps> = ({
+  loading, canReadCharts, member, interview, meeting, task, internship,
+  meetings, taskTodo, taskOverdue,
+}) => {
+  const deptPie = seriesToPie(findSeries(member, '部门分布'));
+  const iv = seriesToXY(findSeries(interview, '各部门面试人数'));
+  const attend = seriesToXY(findSeries(meeting, '出席率'));
+  const rank = seriesToXY(findSeries(internship, '时长排行'));
+  const statusPie = seriesToPie(findSeries(task, '任务状态'));
+  const taskTotal = statusPie.reduce((sum, d) => sum + d.value, 0);
+  const taskDone = statusPie.find((d) => d.name === '已完成')?.value ?? 0;
+  const onTime = Number((((task?.summary.on_time_rate || 0) * 100)).toFixed(1));
+  const completion = taskTotal ? Number(((taskDone / taskTotal) * 100).toFixed(1)) : 0;
+
+  return (
+    <>
+      <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
+        <Col xs={24} lg={8}>
+          {canReadCharts ? (
+            <PieChart title="会员分布" data={deptPie} loading={loading} height={280} />
+          ) : (
+            <Card title="会员分布"><Typography.Text type="secondary">需要 stats:read 查看图表</Typography.Text></Card>
+          )}
+        </Col>
+        <Col xs={24} lg={8}>
+          {canReadCharts ? (
+            <BarChart
+              title="面试数据"
+              categories={iv.categories}
+              series={[{ name: '面试人数', data: iv.values }]}
+              loading={loading}
+              height={280}
+            />
+          ) : (
+            <Card title="面试数据"><Typography.Text type="secondary">需要 stats:read 查看图表</Typography.Text></Card>
+          )}
+        </Col>
+        <Col xs={24} lg={8}>
+          {canReadCharts ? (
+            <LineChart
+              title="会议出席率"
+              categories={attend.categories}
+              series={[{ name: '出席率', data: attend.values }]}
+              area
+              loading={loading}
+              height={280}
+            />
+          ) : (
+            <Card title="会议出席率"><Typography.Text type="secondary">需要 stats:read 查看图表</Typography.Text></Card>
+          )}
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} lg={8}>
+          <Card title="任务进度">
+            {loading ? <Skeleton active paragraph={{ rows: 4 }} /> : (
+              <>
+                <div style={{ marginBottom: 12 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <span>完成进度</span><span>{completion}%</span>
+                  </div>
+                  <Progress percent={completion} size="small" />
+                </div>
+                <div style={{ marginBottom: 12 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <span>按时完成率</span><span>{onTime}%</span>
+                  </div>
+                  <Progress percent={onTime} size="small" status={onTime < 60 ? 'exception' : 'active'} />
+                </div>
+                <Typography.Text type="secondary">待办 {taskTodo} · 逾期 {taskOverdue}</Typography.Text>
+              </>
+            )}
+          </Card>
+        </Col>
+        <Col xs={24} lg={8}>
+          {canReadCharts ? (
+            <BarChart
+              title="实习时长排行"
+              categories={rank.categories}
+              series={[{ name: '时长', data: rank.values }]}
+              horizontal
+              loading={loading}
+              height={280}
+            />
+          ) : (
+            <Card title="实习时长排行"><Typography.Text type="secondary">需要 stats:read 查看图表</Typography.Text></Card>
+          )}
+        </Col>
+        <Col xs={24} lg={8}>
+          <Card title="近期活动">
+            <List
+              loading={loading}
+              dataSource={meetings}
+              locale={{ emptyText: '今日暂无会议' }}
+              renderItem={(item) => (
+                <List.Item>
+                  <List.Item.Meta
+                    title={item.title}
+                    description={formatDateTime(item.start_time, 'YYYY-MM-DD HH:mm')}
+                  />
+                  <Tag color="blue">会议</Tag>
+                </List.Item>
+              )}
+            />
+          </Card>
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default DashboardPanels;

--- a/frontend/src/pages/dashboard/DashboardPanels.tsx
+++ b/frontend/src/pages/dashboard/DashboardPanels.tsx
@@ -74,7 +74,14 @@ const DashboardPanels: React.FC<DashboardPanelsProps> = ({
       <Row gutter={[16, 16]}>
         <Col xs={24} lg={8}>
           <Card title="任务进度">
-            {loading ? <Skeleton active paragraph={{ rows: 4 }} /> : (
+            {!canReadCharts ? (
+              <>
+                <Typography.Text type="secondary">需要 stats:read 查看完成率</Typography.Text>
+                <div style={{ marginTop: 12 }}>
+                  <Typography.Text type="secondary">待办 {taskTodo} · 逾期 {taskOverdue}</Typography.Text>
+                </div>
+              </>
+            ) : loading ? <Skeleton active paragraph={{ rows: 4 }} /> : (
               <>
                 <div style={{ marginBottom: 12 }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between' }}>

--- a/frontend/src/pages/dashboard/bigscreen/BigScreenPage.tsx
+++ b/frontend/src/pages/dashboard/bigscreen/BigScreenPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Space, Typography } from 'antd';
 import { CompressOutlined, ExpandOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
@@ -9,21 +9,33 @@ import './bigscreen.css';
 
 const REFRESH_MS = 5 * 60 * 1000;
 
-const BigScreenPage: React.FC = () => {
-  const navigate = useNavigate();
-  const { overview, charts, loading, updatedAt, reload } = useDashboardStats(REFRESH_MS);
+function BigScreenClock() {
   const [now, setNow] = useState(() => new Date());
-  const [fullscreen, setFullscreen] = useState(false);
-
   useEffect(() => {
     const id = window.setInterval(() => setNow(new Date()), 1000);
     return () => window.clearInterval(id);
   }, []);
+  return <span>{formatDateTime(now)}</span>;
+}
+
+async function leaveFullscreen() {
+  if (document.fullscreenElement) {
+    await document.exitFullscreen();
+  }
+}
+
+const BigScreenPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { overview, charts, loading, updatedAt, reload } = useDashboardStats(REFRESH_MS);
+  const [fullscreen, setFullscreen] = useState(false);
 
   useEffect(() => {
     const onFs = () => setFullscreen(Boolean(document.fullscreenElement));
     document.addEventListener('fullscreenchange', onFs);
-    return () => document.removeEventListener('fullscreenchange', onFs);
+    return () => {
+      document.removeEventListener('fullscreenchange', onFs);
+      void leaveFullscreen();
+    };
   }, []);
 
   const toggleFullscreen = useCallback(() => {
@@ -34,11 +46,18 @@ const BigScreenPage: React.FC = () => {
     void document.documentElement.requestFullscreen();
   }, []);
 
-  const member = seriesToPie(findSeries(charts['member-distribution'], '部门分布'));
-  const interview = seriesToXY(findSeries(charts['interview-data'], '各部门面试人数'));
-  const meeting = seriesToXY(findSeries(charts['meeting-attendance'], '出席率'));
-  const rank = seriesToXY(findSeries(charts['internship-duration'], '时长排行'));
-  const taskPie = seriesToPie(findSeries(charts['task-progress'], '任务状态'));
+  const goDashboard = useCallback(() => {
+    void leaveFullscreen().finally(() => navigate('/dashboard'));
+  }, [navigate]);
+
+  const member = useMemo(() => seriesToPie(findSeries(charts['member-distribution'], '部门分布')), [charts]);
+  const interview = useMemo(() => seriesToXY(findSeries(charts['interview-data'], '各部门面试人数')), [charts]);
+  const meeting = useMemo(() => seriesToXY(findSeries(charts['meeting-attendance'], '出席率')), [charts]);
+  const rank = useMemo(() => seriesToXY(findSeries(charts['internship-duration'], '时长排行')), [charts]);
+  const taskPie = useMemo(() => seriesToPie(findSeries(charts['task-progress'], '任务状态')), [charts]);
+  const interviewSeries = useMemo(() => [{ name: '面试人数', data: interview.values }], [interview]);
+  const meetingSeries = useMemo(() => [{ name: '出席率', data: meeting.values }], [meeting]);
+  const rankSeries = useMemo(() => [{ name: '时长', data: rank.values }], [rank]);
 
   return (
     <div className="bs-root">
@@ -48,13 +67,13 @@ const BigScreenPage: React.FC = () => {
           <p className="bs-sub">协会核心数据 · 每 5 分钟自动刷新 · 支持 F11 / 按钮全屏</p>
         </div>
         <Space wrap size={16} className="bs-meta">
-          <span>{formatDateTime(now)}</span>
+          <BigScreenClock />
           <span>上次刷新 {updatedAt ? formatDateTime(updatedAt, 'HH:mm:ss') : '--'}</span>
           <Button ghost icon={<ReloadOutlined />} onClick={() => { void reload(); }}>刷新</Button>
           <Button ghost icon={fullscreen ? <CompressOutlined /> : <ExpandOutlined />} onClick={toggleFullscreen}>
             {fullscreen ? '退出全屏' : '全屏'}
           </Button>
-          <Button ghost onClick={() => navigate('/dashboard')}>返回工作台</Button>
+          <Button ghost onClick={goDashboard}>返回工作台</Button>
         </Space>
       </header>
 
@@ -76,7 +95,7 @@ const BigScreenPage: React.FC = () => {
           <h4>面试数据</h4>
           <BarChart
             categories={interview.categories}
-            series={[{ name: '面试人数', data: interview.values }]}
+            series={interviewSeries}
             loading={loading}
             height="100%"
             theme="dark"
@@ -86,7 +105,7 @@ const BigScreenPage: React.FC = () => {
           <h4>会议出席率</h4>
           <LineChart
             categories={meeting.categories}
-            series={[{ name: '出席率', data: meeting.values }]}
+            series={meetingSeries}
             area
             loading={loading}
             height="100%"
@@ -101,7 +120,7 @@ const BigScreenPage: React.FC = () => {
           <h4>实习时长排行</h4>
           <BarChart
             categories={rank.categories}
-            series={[{ name: '时长', data: rank.values }]}
+            series={rankSeries}
             horizontal
             loading={loading}
             height="100%"

--- a/frontend/src/pages/dashboard/bigscreen/BigScreenPage.tsx
+++ b/frontend/src/pages/dashboard/bigscreen/BigScreenPage.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, Space, Typography } from 'antd';
+import { CompressOutlined, ExpandOutlined, ReloadOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+import { BarChart, LineChart, PieChart } from '@/components/Chart';
+import { formatDateTime } from '@/utils/format';
+import { findSeries, seriesToPie, seriesToXY, useDashboardStats } from '../useDashboardStats';
+import './bigscreen.css';
+
+const REFRESH_MS = 5 * 60 * 1000;
+
+const BigScreenPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { overview, charts, loading, updatedAt, reload } = useDashboardStats(REFRESH_MS);
+  const [now, setNow] = useState(() => new Date());
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const onFs = () => setFullscreen(Boolean(document.fullscreenElement));
+    document.addEventListener('fullscreenchange', onFs);
+    return () => document.removeEventListener('fullscreenchange', onFs);
+  }, []);
+
+  const toggleFullscreen = useCallback(() => {
+    if (document.fullscreenElement) {
+      void document.exitFullscreen();
+      return;
+    }
+    void document.documentElement.requestFullscreen();
+  }, []);
+
+  const member = seriesToPie(findSeries(charts['member-distribution'], '部门分布'));
+  const interview = seriesToXY(findSeries(charts['interview-data'], '各部门面试人数'));
+  const meeting = seriesToXY(findSeries(charts['meeting-attendance'], '出席率'));
+  const rank = seriesToXY(findSeries(charts['internship-duration'], '时长排行'));
+  const taskPie = seriesToPie(findSeries(charts['task-progress'], '任务状态'));
+
+  return (
+    <div className="bs-root">
+      <header className="bs-header">
+        <div>
+          <Typography.Title level={3} className="bs-title">StarByte 数据大屏</Typography.Title>
+          <p className="bs-sub">协会核心数据 · 每 5 分钟自动刷新 · 支持 F11 / 按钮全屏</p>
+        </div>
+        <Space wrap size={16} className="bs-meta">
+          <span>{formatDateTime(now)}</span>
+          <span>上次刷新 {updatedAt ? formatDateTime(updatedAt, 'HH:mm:ss') : '--'}</span>
+          <Button ghost icon={<ReloadOutlined />} onClick={() => { void reload(); }}>刷新</Button>
+          <Button ghost icon={fullscreen ? <CompressOutlined /> : <ExpandOutlined />} onClick={toggleFullscreen}>
+            {fullscreen ? '退出全屏' : '全屏'}
+          </Button>
+          <Button ghost onClick={() => navigate('/dashboard')}>返回工作台</Button>
+        </Space>
+      </header>
+
+      <section className="bs-kpis">
+        <div className="bs-kpi"><span>会员</span><strong>{overview?.total_members ?? 0}</strong></div>
+        <div className="bs-kpi"><span>待审批</span><strong>{overview?.pending_approvals ?? 0}</strong></div>
+        <div className="bs-kpi"><span>进行中任务</span><strong>{overview?.total_tasks_in_progress ?? 0}</strong></div>
+        <div className="bs-kpi"><span>本月会议</span><strong>{overview?.total_meetings_this_month ?? 0}</strong></div>
+        <div className="bs-kpi"><span>活跃实习</span><strong>{overview?.total_internships_active ?? 0}</strong></div>
+        <div className="bs-kpi"><span>未读通知</span><strong>{overview?.notifications_unread ?? 0}</strong></div>
+      </section>
+
+      <section className="bs-grid">
+        <div className="bs-panel">
+          <h4>会员分布</h4>
+          <PieChart data={member} loading={loading} height="100%" theme="dark" />
+        </div>
+        <div className="bs-panel">
+          <h4>面试数据</h4>
+          <BarChart
+            categories={interview.categories}
+            series={[{ name: '面试人数', data: interview.values }]}
+            loading={loading}
+            height="100%"
+            theme="dark"
+          />
+        </div>
+        <div className="bs-panel">
+          <h4>会议出席率</h4>
+          <LineChart
+            categories={meeting.categories}
+            series={[{ name: '出席率', data: meeting.values }]}
+            area
+            loading={loading}
+            height="100%"
+            theme="dark"
+          />
+        </div>
+        <div className="bs-panel">
+          <h4>任务进度</h4>
+          <PieChart data={taskPie} loading={loading} height="100%" theme="dark" />
+        </div>
+        <div className="bs-panel bs-panel-wide">
+          <h4>实习时长排行</h4>
+          <BarChart
+            categories={rank.categories}
+            series={[{ name: '时长', data: rank.values }]}
+            horizontal
+            loading={loading}
+            height="100%"
+            theme="dark"
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default BigScreenPage;

--- a/frontend/src/pages/dashboard/bigscreen/bigscreen.css
+++ b/frontend/src/pages/dashboard/bigscreen/bigscreen.css
@@ -1,0 +1,118 @@
+.bs-root {
+  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: #d6e4ff;
+  background:
+    radial-gradient(1200px 480px at 10% -10%, rgba(37, 99, 235, 0.28), transparent 55%),
+    radial-gradient(900px 420px at 90% 0%, rgba(14, 116, 144, 0.22), transparent 50%),
+    #06101c;
+}
+
+.bs-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 16px 24px 8px;
+}
+
+.bs-title {
+  color: #e6f4ff !important;
+  margin: 0 !important;
+}
+
+.bs-sub,
+.bs-meta {
+  color: rgba(214, 228, 255, 0.75);
+  margin: 4px 0 0;
+}
+
+.bs-kpis {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 12px;
+  padding: 8px 24px 12px;
+}
+
+.bs-kpi {
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  border-radius: 12px;
+  padding: 12px 16px;
+  background: rgba(8, 24, 48, 0.7);
+}
+
+.bs-kpi span {
+  display: block;
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.bs-kpi strong {
+  font-size: 28px;
+  color: #69b1ff;
+}
+
+.bs-grid {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-rows: 1fr 1fr;
+  gap: 12px;
+  padding: 0 24px 16px;
+}
+
+.bs-panel {
+  grid-column: span 2;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(37, 99, 235, 0.28);
+  border-radius: 12px;
+  padding: 8px 12px 12px;
+  background: rgba(8, 24, 48, 0.65);
+}
+
+.bs-panel h4 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #91caff;
+}
+
+.bs-panel > div {
+  flex: 1;
+  min-height: 0;
+}
+
+.bs-panel-wide {
+  grid-column: span 4;
+}
+
+@media (max-width: 1439px) {
+  .bs-kpis {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .bs-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: none;
+    overflow: auto;
+  }
+
+  .bs-panel,
+  .bs-panel-wide {
+    grid-column: span 1;
+    min-height: 280px;
+  }
+}
+
+@media (min-width: 2560px) {
+  .bs-kpi strong {
+    font-size: 36px;
+  }
+}

--- a/frontend/src/pages/dashboard/dashboard.css
+++ b/frontend/src/pages/dashboard/dashboard.css
@@ -1,0 +1,54 @@
+.dash-page {
+  padding: 0 0 24px;
+}
+
+.dash-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 20px 24px;
+  margin-bottom: 16px;
+  border-radius: 16px;
+  color: #fff;
+  background: linear-gradient(135deg, #1d4ed8 0%, #7c3aed 55%, #0f766e 100%);
+  box-shadow: 0 12px 32px rgba(29, 78, 216, 0.18);
+}
+
+.dash-hero h2 {
+  margin: 0 0 6px;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.dash-hero p {
+  margin: 0;
+  opacity: 0.88;
+}
+
+.dash-kpis {
+  margin-bottom: 16px;
+}
+
+.dash-kpi {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dash-kpi-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+}
+
+@media (max-width: 1279px) {
+  .dash-hero {
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/dashboard/useDashboardStats.ts
+++ b/frontend/src/pages/dashboard/useDashboardStats.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   getStats,
   getStatsOverview,
@@ -55,20 +55,25 @@ export function useDashboardStats(refreshMs?: number): DashboardStatsState {
   const [errors, setErrors] = useState<Partial<Record<StatsProviderCode, string>>>({});
   const [loading, setLoading] = useState(true);
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
+  const loaded = useRef(false);
 
   const reload = useCallback(async (signal?: AbortSignal) => {
-    setLoading(true);
+    if (!loaded.current) {
+      setLoading(true);
+    }
     try {
-      setOverview(await getStatsOverview(signal));
+      const ov = await getStatsOverview(signal);
+      setOverview(ov);
     } catch (e) {
       if (isAbortError(e)) return;
-      setOverview(null);
+      if (!loaded.current) {
+        setOverview(null);
+      }
     }
     if (!canReadCharts) {
-      setCharts({});
-      setErrors({});
       setUpdatedAt(new Date());
       setLoading(false);
+      loaded.current = true;
       return;
     }
     const next: Partial<Record<StatsProviderCode, StatsResult>> = {};
@@ -82,10 +87,18 @@ export function useDashboardStats(refreshMs?: number): DashboardStatsState {
         errs[code] = e instanceof Error ? e.message : '加载失败';
       }
     }
-    setCharts(next);
+    setCharts((prev) => {
+      const merged = { ...prev };
+      DASHBOARD_PROVIDERS.forEach((code) => {
+        const row = next[code];
+        if (row) merged[code] = row;
+      });
+      return merged;
+    });
     setErrors(errs);
     setUpdatedAt(new Date());
     setLoading(false);
+    loaded.current = true;
   }, [canReadCharts]);
 
   useEffect(() => {

--- a/frontend/src/pages/dashboard/useDashboardStats.ts
+++ b/frontend/src/pages/dashboard/useDashboardStats.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getStats,
+  getStatsOverview,
+  type OverviewResponse,
+  type StatsProviderCode,
+  type StatsResult,
+  type StatsSeries,
+} from '@/api/stats';
+import { usePermission } from '@/hooks/usePermission';
+
+export const DASHBOARD_PROVIDERS: StatsProviderCode[] = [
+  'member-distribution',
+  'interview-data',
+  'meeting-attendance',
+  'task-progress',
+  'internship-duration',
+];
+
+export function findSeries(result: StatsResult | undefined, name: string): StatsSeries | undefined {
+  return result?.series.find((s) => s.name === name);
+}
+
+export function seriesToXY(series: StatsSeries | undefined): { categories: string[]; values: number[] } {
+  if (!series || !series.data.length) {
+    return { categories: [], values: [] };
+  }
+  const categories = series.x_axis?.length ? series.x_axis : series.data.map((d) => d.label);
+  return { categories, values: series.data.map((d) => d.value) };
+}
+
+export function seriesToPie(series: StatsSeries | undefined): { name: string; value: number }[] {
+  if (!series) return [];
+  return series.data.map((d) => ({ name: d.label, value: d.value }));
+}
+
+export interface DashboardStatsState {
+  overview: OverviewResponse | null;
+  charts: Partial<Record<StatsProviderCode, StatsResult>>;
+  errors: Partial<Record<StatsProviderCode, string>>;
+  loading: boolean;
+  updatedAt: Date | null;
+  canReadCharts: boolean;
+  reload: () => Promise<void>;
+}
+
+export function useDashboardStats(refreshMs?: number): DashboardStatsState {
+  const canReadCharts = usePermission('stats:read');
+  const [overview, setOverview] = useState<OverviewResponse | null>(null);
+  const [charts, setCharts] = useState<Partial<Record<StatsProviderCode, StatsResult>>>({});
+  const [errors, setErrors] = useState<Partial<Record<StatsProviderCode, string>>>({});
+  const [loading, setLoading] = useState(true);
+  const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      setOverview(await getStatsOverview());
+    } catch {
+      setOverview(null);
+    }
+    if (!canReadCharts) {
+      setCharts({});
+      setErrors({});
+      setUpdatedAt(new Date());
+      setLoading(false);
+      return;
+    }
+    const next: Partial<Record<StatsProviderCode, StatsResult>> = {};
+    const errs: Partial<Record<StatsProviderCode, string>> = {};
+    await Promise.all(DASHBOARD_PROVIDERS.map(async (code) => {
+      try {
+        next[code] = await getStats(code);
+      } catch (e) {
+        errs[code] = e instanceof Error ? e.message : '加载失败';
+      }
+    }));
+    setCharts(next);
+    setErrors(errs);
+    setUpdatedAt(new Date());
+    setLoading(false);
+  }, [canReadCharts]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  useEffect(() => {
+    if (!refreshMs || refreshMs <= 0) return undefined;
+    const id = window.setInterval(() => {
+      void reload();
+    }, refreshMs);
+    return () => window.clearInterval(id);
+  }, [reload, refreshMs]);
+
+  return { overview, charts, errors, loading, updatedAt, canReadCharts, reload };
+}

--- a/frontend/src/pages/dashboard/useDashboardStats.ts
+++ b/frontend/src/pages/dashboard/useDashboardStats.ts
@@ -68,13 +68,13 @@ export function useDashboardStats(refreshMs?: number): DashboardStatsState {
     }
     const next: Partial<Record<StatsProviderCode, StatsResult>> = {};
     const errs: Partial<Record<StatsProviderCode, string>> = {};
-    await Promise.all(DASHBOARD_PROVIDERS.map(async (code) => {
+    for (const code of DASHBOARD_PROVIDERS) {
       try {
         next[code] = await getStats(code);
       } catch (e) {
         errs[code] = e instanceof Error ? e.message : '加载失败';
       }
-    }));
+    }
     setCharts(next);
     setErrors(errs);
     setUpdatedAt(new Date());

--- a/frontend/src/pages/dashboard/useDashboardStats.ts
+++ b/frontend/src/pages/dashboard/useDashboardStats.ts
@@ -7,6 +7,7 @@ import {
   type StatsResult,
   type StatsSeries,
 } from '@/api/stats';
+import { isCanceledError } from '@/api/error';
 import { usePermission } from '@/hooks/usePermission';
 
 export const DASHBOARD_PROVIDERS: StatsProviderCode[] = [
@@ -44,10 +45,6 @@ export interface DashboardStatsState {
   reload: () => Promise<void>;
 }
 
-function isAbortError(e: unknown): boolean {
-  return typeof e === 'object' && e !== null && 'code' in e && (e as { code?: string }).code === 'ERR_CANCELED';
-}
-
 export function useDashboardStats(refreshMs?: number): DashboardStatsState {
   const canReadCharts = usePermission('stats:read');
   const [overview, setOverview] = useState<OverviewResponse | null>(null);
@@ -65,7 +62,7 @@ export function useDashboardStats(refreshMs?: number): DashboardStatsState {
       const ov = await getStatsOverview(signal);
       setOverview(ov);
     } catch (e) {
-      if (isAbortError(e)) return;
+      if (isCanceledError(e)) return;
       if (!loaded.current) {
         setOverview(null);
       }
@@ -83,7 +80,7 @@ export function useDashboardStats(refreshMs?: number): DashboardStatsState {
       try {
         next[code] = await getStats(code, undefined, signal);
       } catch (e) {
-        if (isAbortError(e)) return;
+        if (isCanceledError(e)) return;
         errs[code] = e instanceof Error ? e.message : '加载失败';
       }
     }

--- a/frontend/src/pages/dashboard/useDashboardStats.ts
+++ b/frontend/src/pages/dashboard/useDashboardStats.ts
@@ -44,6 +44,10 @@ export interface DashboardStatsState {
   reload: () => Promise<void>;
 }
 
+function isAbortError(e: unknown): boolean {
+  return typeof e === 'object' && e !== null && 'code' in e && (e as { code?: string }).code === 'ERR_CANCELED';
+}
+
 export function useDashboardStats(refreshMs?: number): DashboardStatsState {
   const canReadCharts = usePermission('stats:read');
   const [overview, setOverview] = useState<OverviewResponse | null>(null);
@@ -52,11 +56,12 @@ export function useDashboardStats(refreshMs?: number): DashboardStatsState {
   const [loading, setLoading] = useState(true);
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
 
-  const reload = useCallback(async () => {
+  const reload = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     try {
-      setOverview(await getStatsOverview());
-    } catch {
+      setOverview(await getStatsOverview(signal));
+    } catch (e) {
+      if (isAbortError(e)) return;
       setOverview(null);
     }
     if (!canReadCharts) {
@@ -69,9 +74,11 @@ export function useDashboardStats(refreshMs?: number): DashboardStatsState {
     const next: Partial<Record<StatsProviderCode, StatsResult>> = {};
     const errs: Partial<Record<StatsProviderCode, string>> = {};
     for (const code of DASHBOARD_PROVIDERS) {
+      if (signal?.aborted) return;
       try {
-        next[code] = await getStats(code);
+        next[code] = await getStats(code, undefined, signal);
       } catch (e) {
+        if (isAbortError(e)) return;
         errs[code] = e instanceof Error ? e.message : '加载失败';
       }
     }
@@ -82,7 +89,9 @@ export function useDashboardStats(refreshMs?: number): DashboardStatsState {
   }, [canReadCharts]);
 
   useEffect(() => {
-    void reload();
+    const ac = new AbortController();
+    void reload(ac.signal);
+    return () => ac.abort();
   }, [reload]);
 
   useEffect(() => {

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -12,6 +12,7 @@ import PermissionRoute from '@/router/guards/PermissionRoute';
 // 页面组件
 const Login = lazy(() => import('@/pages/login/Login'));
 const Dashboard = lazy(() => import('@/pages/dashboard/Dashboard'));
+const BigScreenPage = lazy(() => import('@/pages/dashboard/bigscreen/BigScreenPage'));
 const UserList = lazy(() => import('@/pages/user/UserList'));
 const NotificationList = lazy(() => import('@/pages/notification/NotificationList'));
 const TemplateList = lazy(() => import('@/pages/notification/TemplateList'));
@@ -96,6 +97,15 @@ const routes: AppRouteObject[] = [
     path: '/login',
     element: lazyWrap(Login),
     meta: { title: '登录', public: true, hidden: true },
+  },
+  {
+    path: '/dashboard/bigscreen',
+    element: (
+      <AuthRoute>
+        {lazyGuarded(BigScreenPage, 'stats:read')}
+      </AuthRoute>
+    ),
+    meta: { title: '数据大屏', hidden: true, permission: 'stats:read' },
   },
   {
     path: '/',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

实现 Issue #26：前端工作台与数据大屏接入 #11 统计 API，**不新建第二套统计接口**。

- 工作台 `/dashboard`：KPI 来自 `GET /stats/overview`，会员饼图 / 面试柱图 / 会议折线 / 任务进度 / 实习排行来自 5 个 provider
- 数据大屏 `/dashboard/bigscreen`：独立全屏页，每 5 分钟自动刷新，支持按钮与 F11 全屏；返回工作台会退出全屏
- 封装可复用 `Chart` / `PieChart` / `BarChart` / `LineChart`（自动 resize、跟随 light/dark 主题）
- 无 `stats:read` 时仍展示概览数字，图表与任务完成率提示权限
- 图表请求串行；刷新失败保留上次成功数据；时钟不触发图表重绘
- 卸载/切页取消请求时，axios 拦截器不再把 `ERR_CANCELED` 当成网络失败弹 toast

## 关联 Issue

Closes #26

## 测试方式

1. 以具备 `stats:read` 的账号登录（如 admin/admin123）
2. 打开工作台，确认 KPI 与 5 组图表为接口数据而非 mock
3. 点击「数据大屏」，确认全屏布局与刷新时间；点「返回工作台」应退出浏览器全屏
4. 图表加载过程中离开工作台，不应弹出「网络连接失败」
5. 将窗口缩到约 1280 宽，确认图表换列

## 截图 / GIF

| 页面/功能 | 截图 |
|----------|------|
| 工作台 | [工作台](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdashboard-workbench.webp) |
| 数据大屏 | [数据大屏](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdashboard-bigscreen.webp) |

[dashboard-and-bigscreen.mp4](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard-and-bigscreen.mp4)
[dashboard-cancel-no-toast.mp4](https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard-cancel-no-toast.mp4)

## 注意事项

- 复用 #11 `/api/v1/stats/overview` 与 `/stats/{provider}`
- 未引入 React Query / SWR，沿用现有 axios + 本地 state
- Bugbot 问题在本分支修复，**不要合入 Autofix 旁路**（`cursor/dashboard-display-problems-8648`、`cursor/canceled-requests-error-toasts-f933`）

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测
- [ ] 已添加/更新必要的文档
- [x] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

