### PR TITLE
chore(env): add Cloud Agent dev environment + fix workflow AutoMigrate boot failure

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "StarByte",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "backend",
+      "command": "cd backend && APP_ENV=dev go run ./cmd/server"
+    },
+    {
+      "name": "frontend",
+      "command": "cd frontend && npm run dev"
+    }
+  ],
+  "ports": [8080, 5173, 9001]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Idempotent repository bootstrap for the StarByte Cloud Agent environment.
+# Installs system services (PostgreSQL 16, Redis, MinIO) and CLI tooling
+# (golang-migrate, mc), then fetches backend/frontend dependencies and warms
+# the Go build cache. Runtime services are started in start.sh, not here.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATE_VERSION="v4.17.1"
+
+echo "[install] Installing system packages (PostgreSQL 16, Redis, tooling)..."
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -qq
+sudo apt-get install -y -qq \
+  postgresql postgresql-contrib \
+  redis-server \
+  ca-certificates wget curl
+
+echo "[install] Installing golang-migrate..."
+if ! command -v migrate >/dev/null 2>&1; then
+  wget -q "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate.linux-amd64.tar.gz" -O /tmp/migrate.tar.gz
+  tar -xzf /tmp/migrate.tar.gz -C /tmp migrate
+  sudo mv /tmp/migrate /usr/local/bin/migrate
+  sudo chmod +x /usr/local/bin/migrate
+fi
+
+echo "[install] Installing MinIO server + client..."
+if ! command -v minio >/dev/null 2>&1; then
+  wget -q "https://dl.min.io/server/minio/release/linux-amd64/minio" -O /tmp/minio
+  sudo mv /tmp/minio /usr/local/bin/minio
+  sudo chmod +x /usr/local/bin/minio
+fi
+if ! command -v mc >/dev/null 2>&1; then
+  wget -q "https://dl.min.io/client/mc/release/linux-amd64/mc" -O /tmp/mc
+  sudo mv /tmp/mc /usr/local/bin/mc
+  sudo chmod +x /usr/local/bin/mc
+fi
+
+echo "[install] Downloading Go module dependencies..."
+cd "$REPO_ROOT/backend"
+go mod download
+# Warm the build cache so the first backend boot is fast.
+go build -o /tmp/starbyte-server ./cmd/server
+
+echo "[install] Installing frontend dependencies..."
+cd "$REPO_ROOT/frontend"
+npm ci
+
+echo "[install] Done."

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Per-boot runtime initialization for the StarByte Cloud Agent environment.
+# Brings up PostgreSQL, Redis and MinIO, provisions the dev database/role,
+# applies migrations and seeds idempotent test data. Safe to run repeatedly.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DB_USER="starbyte"
+DB_PASSWORD="starbyte"
+DB_NAME="starbyte_dev"
+DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@localhost:5432/${DB_NAME}?sslmode=disable"
+
+echo "[start] Starting PostgreSQL..."
+sudo pg_ctlcluster 16 main start 2>/dev/null || true
+for _ in $(seq 1 30); do
+  if pg_isready -h localhost -p 5432 >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+echo "[start] Ensuring database role and dev database exist..."
+sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASSWORD}' CREATEDB;"
+sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1 \
+  || sudo -u postgres createdb -O "${DB_USER}" "${DB_NAME}"
+
+echo "[start] Starting Redis..."
+redis-cli ping >/dev/null 2>&1 || sudo redis-server --daemonize yes --appendonly yes
+
+echo "[start] Starting MinIO..."
+if ! curl -sf http://localhost:9000/minio/health/live >/dev/null 2>&1; then
+  mkdir -p /tmp/minio-data
+  MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
+    nohup minio server /tmp/minio-data --address ":9000" --console-address ":9001" \
+    > /tmp/minio.log 2>&1 &
+fi
+for _ in $(seq 1 30); do
+  if curl -sf http://localhost:9000/minio/health/live >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+mc alias set local http://localhost:9000 minioadmin minioadmin >/dev/null 2>&1 || true
+mc mb --ignore-existing local/starbyte >/dev/null 2>&1 || true
+
+echo "[start] Applying database migrations..."
+migrate -path "$REPO_ROOT/backend/migrations" -database "$DATABASE_URL" up
+
+echo "[start] Seeding idempotent test data..."
+cd "$REPO_ROOT/backend"
+APP_ENV=dev DB_NAME="${DB_NAME}" go run ./scripts
+
+echo "[start] Infrastructure ready (PostgreSQL, Redis, MinIO)."

--- a/backend/internal/workflow/model/workflow.go
+++ b/backend/internal/workflow/model/workflow.go
@@ -12,7 +12,7 @@ import (
 // Status values: 0=draft, 1=published, 2=disabled.
 type FlowDefinition struct {
 	ID          uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
-	Key         string     `gorm:"type:varchar(100);uniqueIndex;not null" json:"key"`
+	Key         string     `gorm:"type:varchar(100);unique;not null" json:"key"`
 	Name        string     `gorm:"type:varchar(200);not null" json:"name"`
 	Description string     `gorm:"type:text" json:"description"`
 	Category    string     `gorm:"type:varchar(50);default:custom" json:"category"`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述 / Summary

为本仓库配置了可复现的 Cloud Agent 开发环境，并修复了一个导致后端无法启动的 `AutoMigrate` 缺陷。现在后端（Go/Gin）、前端（React/Vite）以及 PostgreSQL 16、Redis、MinIO 基础设施可以完整跑起来。

## 改动内容 / Changes

### 1. 修复后端启动失败 (`backend/internal/workflow/model/workflow.go`)
迁移脚本 `000002` 将 `flow_definitions.key` 建为 `UNIQUE` 约束（`flow_definitions_key_key`），但 GORM 模型将该字段标注为 `uniqueIndex`，使得 `field.Unique=false`。启动时 `workflow.AutoMigrate` 发现数据库列是唯一的而模型不是，于是尝试 `DROP CONSTRAINT "uni_flow_definitions_key"`（一个并不存在的名字），导致致命错误、进程退出：

```
auto migrate workflow tables failed: ERROR: constraint "uni_flow_definitions_key" of relation "flow_definitions" does not exist (SQLSTATE 42704)
```

将标签由 `uniqueIndex` 改为 `unique`，与迁移创建的约束一致，`AutoMigrate` 对该列变为无操作，后端得以正常启动。

### 2. 新增 Cloud Agent 开发环境配置 (`.cursor/`)
- `.cursor/environment.json` — 使用默认镜像（已自带 Go 1.22 + Node 22），定义 `install`/`start` 与 `backend`、`frontend` 两个终端，暴露端口 `8080`、`5173`、`9001`。
- `.cursor/install.sh` — 幂等安装 PostgreSQL 16、Redis、MinIO（server + `mc`）、`golang-migrate`，下载 Go 依赖并预热构建缓存，执行 `npm ci`。
- `.cursor/start.sh` — 每次启动时拉起 PostgreSQL/Redis/MinIO，创建 `starbyte` 角色与 `starbyte_dev` 库，执行迁移与幂等种子数据。

> 说明：本环境无 Docker，故未使用 `deploy/docker-compose.dev.yml`，改为原生安装等价的服务。运行后端时应使用基座配置 `configs/config.yaml` 并配合 `APP_ENV=dev` 加载 `config.dev.yaml` 覆盖（脚本已如此处理）。

## 验证 / Verification
- `/health` → `ok`，`/health/ready` → `database/redis/minio` 全部 `ok`，状态 `ready`。
- `POST /api/v1/auth/login`（`admin/admin123`）返回 JWT 与用户档案。
- 前端 `http://localhost:5173` 可访问，`/api` 代理到后端登录成功。
- `start.sh` 二次运行验证幂等（迁移 `no change`、种子 `seed completed`）。

默认账号：`admin/admin123`（社长 + 超管）、`test/test123`（会员）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00414466-b4b6-4317-8294-45756e62c553?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00414466-b4b6-4317-8294-45756e62c553&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

