### PR TITLE
fix(workflow): AutoMigrate 不再因 uniqueIndex 导致启动失败

### DIFF
--- a/backend/internal/workflow/model/workflow.go
+++ b/backend/internal/workflow/model/workflow.go
@@ -10,9 +10,14 @@ import (
 // It supports multi-version management via FlowDefinitionVersion.
 //
 // Status values: 0=draft, 1=published, 2=disabled.
+//
+// Key uses gorm "unique" (not uniqueIndex) so AutoMigrate matches the UNIQUE
+// constraint created by 000002_workflow_engine. uniqueIndex would DROP
+// CONSTRAINT "uni_flow_definitions_key", which does not exist (Postgres names
+// it flow_definitions_key_key), and the server would exit on startup.
 type FlowDefinition struct {
 	ID          uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
-	Key         string     `gorm:"type:varchar(100);uniqueIndex;not null" json:"key"`
+	Key         string     `gorm:"type:varchar(100);unique;not null" json:"key"`
 	Name        string     `gorm:"type:varchar(200);not null" json:"name"`
 	Description string     `gorm:"type:text" json:"description"`
 	Category    string     `gorm:"type:varchar(50);default:custom" json:"category"`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

只修后端启动：`FlowDefinition.Key` 的 GORM 标签从 `uniqueIndex` 改为 `unique`，与 `000002_workflow_engine` 里 `key VARCHAR(100) NOT NULL UNIQUE` 对齐。

`cmd/server` 启动时仍会调用 `workflow.AutoMigrate`。`uniqueIndex` 会让 GORM 执行 `DROP CONSTRAINT "uni_flow_definitions_key"`，而 Postgres 实际约束名是 `flow_definitions_key_key`，约束不存在，进程直接退出。

本 PR **不包含** #142 里的 `.cursor/environment.json`、`.cursor/install.sh`、`.cursor/start.sh`，也不 squash 合入 #142。

## 关联 Issue

Relates #142（只抽取启动修复；不关闭 #142，因其还含 Cloud Agent 环境脚本）

## 测试方式

1. `cd backend && go test ./internal/workflow/...`
2. 在已跑过 `000002` 迁移的 Postgres 上启动 `cmd/server`，确认 `workflow.AutoMigrate` 不再因 drop 错名约束失败

## 注意事项

- 不影响其他模块的 `uniqueIndex`，也不改 `idx_def_ver_unique` / `idx_var_unique` 这类已命名复合唯一索引
- 无前端变更

## 检查清单

- [x] 代码遵循项目开发规范
- [x] 已进行自测
- [ ] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d57a26c-6f0a-4764-9392-ca935bef2c5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

