### PR TITLE
feat(#102): K8s 部署与 DevOps 完善 - Helm Chart + 蓝绿/金丝雀 + CD 流水线

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,183 @@
+# StarByte CD 流水线 - Issue #102
+# 自动构建镜像 → 推送 GHCR → 部署到 Kubernetes
+name: CD
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: '部署环境'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - prod
+
+env:
+  REGISTRY: ghcr.io
+  NAMESPACE: starbyte
+
+jobs:
+  # ─────────────────────────────────────────────────────────
+  # 构建并推送后端镜像
+  # ─────────────────────────────────────────────────────────
+  build-backend:
+    name: Build & Push Backend Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/backend
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v5
+        with:
+          context: backend
+          target: production
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ─────────────────────────────────────────────────────────
+  # 构建并推送前端镜像
+  # ─────────────────────────────────────────────────────────
+  build-frontend:
+    name: Build & Push Frontend Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/frontend
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: frontend
+          target: production
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ─────────────────────────────────────────────────────────
+  # 部署到 Kubernetes
+  # ─────────────────────────────────────────────────────────
+  deploy:
+    name: Deploy to Kubernetes
+    runs-on: ubuntu-latest
+    needs: [build-backend, build-frontend]
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: ${{ github.event.inputs.environment || (github.ref_type == 'tag' && 'prod' || 'dev') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set deploy environment
+        id: env
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "name=prod" >> $GITHUB_OUTPUT
+            echo "values=values-prod.yaml" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.inputs.environment }}" = "prod" ]; then
+            echo "name=prod" >> $GITHUB_OUTPUT
+            echo "values=values-prod.yaml" >> $GITHUB_OUTPUT
+          else
+            echo "name=dev" >> $GITHUB_OUTPUT
+            echo "values=values-dev.yaml" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set image tags
+        id: images
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG="latest"
+          fi
+          echo "backend=${{ env.REGISTRY }}/${{ github.repository }}/backend:${TAG}" >> $GITHUB_OUTPUT
+          echo "frontend=${{ env.REGISTRY }}/${{ github.repository }}/frontend:${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Set up kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBE_CONFIG_DATA }}" | base64 -d > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+          export KUBECONFIG=$HOME/.kube/config
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.14.0'
+
+      - name: Deploy with Helm
+        run: |
+          helm upgrade --install starbyte deploy/helm/starbyte \
+            --namespace ${{ env.NAMESPACE }} --create-namespace \
+            --values deploy/helm/starbyte/${{ steps.env.outputs.values }} \
+            --set backend.image.tag=${{ steps.images.outputs.backend }} \
+            --set frontend.image.tag=${{ steps.images.outputs.frontend }} \
+            --wait --timeout 5m
+
+      - name: Verify deployment
+        run: |
+          kubectl rollout status deployment/starbyte-backend -n ${{ env.NAMESPACE }} --timeout=3m
+          kubectl rollout status deployment/starbyte-frontend -n ${{ env.NAMESPACE }} --timeout=3m
+          echo "✅ Deployment successful"
+
+      - name: Cleanup on failure
+        if: failure()
+        run: |
+          echo "❌ Deployment failed, checking rollback history..."
+          kubectl rollout history deployment/starbyte-backend -n ${{ env.NAMESPACE }}
+          kubectl rollout history deployment/starbyte-frontend -n ${{ env.NAMESPACE }}

--- a/deploy/helm/starbyte/Chart.yaml
+++ b/deploy/helm/starbyte/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: starbyte
+description: StarByte 全链路管理系统 Kubernetes Helm Chart
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - starbyte
+  - management-system
+  - go
+  - react
+maintainers:
+  - name: StarByte Team

--- a/deploy/helm/starbyte/templates/_helpers.tpl
+++ b/deploy/helm/starbyte/templates/_helpers.tpl
@@ -1,0 +1,111 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{/* 模板辅助函数 */}}
+
+{{/*
+生成资源全名,截断至 63 字符以符合 DNS-1123 子域规范
+*/}}
+{{- define "starbyte.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $fullname := printf "%s-%s" .Release.Name $name -}}
+{{- trunc 63 (trimSuffix "-" $fullname) -}}
+{{- end -}}
+
+{{/*
+生成带 chart 名称前缀的全名 (用于多 chart 共存场景)
+*/}}
+{{- define "starbyte.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+统一标签 (labels)
+*/}}
+{{- define "starbyte.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "starbyte.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: starbyte
+{{- end -}}
+
+{{/*
+选择标签 (selectorLabels),用于 Deployment/StatefulSet 的 selector
+*/}}
+{{- define "starbyte.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "starbyte.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+storageClass 处理:优先使用组件级 storageClass,否则回退到 global.storageClass
+返回空字符串 "" 表示使用集群默认 StorageClass
+*/}}
+{{- define "starbyte.storageClass" -}}
+{{- $local := .local -}}
+{{- $global := .global -}}
+{{- if $local -}}
+{{- $local -}}
+{{- else if $global -}}
+{{- $global -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+后端服务的全名
+*/}}
+{{- define "starbyte.backend.fullname" -}}
+{{- printf "%s-backend" (include "starbyte.fullname" .) -}}
+{{- end -}}
+
+{{/*
+前端服务的全名
+*/}}
+{{- define "starbyte.frontend.fullname" -}}
+{{- printf "%s-frontend" (include "starbyte.fullname" .) -}}
+{{- end -}}
+
+{{/*
+PostgreSQL 的全名
+*/}}
+{{- define "starbyte.postgres.fullname" -}}
+{{- printf "%s-postgres" (include "starbyte.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Redis 的全名
+*/}}
+{{- define "starbyte.redis.fullname" -}}
+{{- printf "%s-redis" (include "starbyte.fullname" .) -}}
+{{- end -}}
+
+{{/*
+MinIO 的全名
+*/}}
+{{- define "starbyte.minio.fullname" -}}
+{{- printf "%s-minio" (include "starbyte.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Secret 的全名
+*/}}
+{{- define "starbyte.secret.fullname" -}}
+{{- printf "%s-secret" (include "starbyte.fullname" .) -}}
+{{- end -}}
+
+{{/*
+ConfigMap 的全名
+*/}}
+{{- define "starbyte.configmap.fullname" -}}
+{{- printf "%s-config" (include "starbyte.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Ingress 的全名
+*/}}
+{{- define "starbyte.ingress.fullname" -}}
+{{- printf "%s-ingress" (include "starbyte.fullname" .) -}}
+{{- end -}}

--- a/deploy/helm/starbyte/templates/backend-deployment.yaml
+++ b/deploy/helm/starbyte/templates/backend-deployment.yaml
@@ -1,0 +1,82 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.backend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "starbyte.backend.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      serviceAccountName: default
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ printf "%s:%s" .Values.backend.image.repository .Values.backend.image.tag | quote }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - name: http-backend
+              containerPort: {{ .Values.backend.service.targetPort }}
+              protocol: TCP
+          # 批量从 ConfigMap + Secret 引用环境变量
+          envFrom:
+            - configMapRef:
+                name: {{ include "starbyte.configmap.fullname" . }}
+            - secretRef:
+                name: {{ include "starbyte.secret.fullname" . }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          {{- if .Values.backend.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.backend.probes.startup.path | quote }}
+              port: http-backend
+            initialDelaySeconds: {{ .Values.backend.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.backend.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.backend.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.backend.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.backend.probes.liveness.path | quote }}
+              port: http-backend
+            initialDelaySeconds: {{ .Values.backend.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.backend.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.backend.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.backend.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.backend.probes.readiness.path | quote }}
+              port: http-backend
+            initialDelaySeconds: {{ .Values.backend.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.backend.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.backend.probes.readiness.failureThreshold }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/backend-service.yaml
+++ b/deploy/helm/starbyte/templates/backend-service.yaml
@@ -1,0 +1,24 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.backend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.backend.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - name: http-backend
+      port: {{ .Values.backend.service.port }}
+      targetPort: http-backend
+      protocol: TCP
+      {{- if .Values.backend.service.nodePort }}
+      nodePort: {{ .Values.backend.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+{{- end }}

--- a/deploy/helm/starbyte/templates/configmap.yaml
+++ b/deploy/helm/starbyte/templates/configmap.yaml
@@ -1,0 +1,49 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if or .Values.backend.enabled .Values.frontend.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "starbyte.configmap.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+data:
+  # 应用环境标识
+  APP_ENV: {{ .Values.backend.env.appEnv | quote }}
+  LOG_LEVEL: {{ .Values.backend.env.logLevel | quote }}
+  CONFIG_PATH: {{ .Values.backend.env.configPath | quote }}
+
+  # PostgreSQL 连接 (非敏感信息:主机/端口/库名/用户)
+  {{- if .Values.postgres.enabled }}
+  POSTGRES_HOST: {{ include "starbyte.postgres.fullname" . | quote }}
+  POSTGRES_PORT: {{ .Values.postgres.config.port | quote }}
+  POSTGRES_DB: {{ .Values.postgres.config.db | quote }}
+  POSTGRES_USER: {{ .Values.postgres.config.user | quote }}
+  {{- end }}
+
+  # Redis 连接 (非敏感信息:主机/端口)
+  {{- if .Values.redis.enabled }}
+  REDIS_HOST: {{ include "starbyte.redis.fullname" . | quote }}
+  REDIS_PORT: {{ .Values.redis.config.port | quote }}
+  {{- end }}
+
+  # MinIO 连接 (非敏感信息:主机/端口/桶)
+  {{- if .Values.minio.enabled }}
+  MINIO_HOST: {{ include "starbyte.minio.fullname" . | quote }}
+  MINIO_PORT: {{ .Values.minio.config.port | quote }}
+  MINIO_CONSOLE_PORT: {{ .Values.minio.config.consolePort | quote }}
+  MINIO_BUCKET: {{ .Values.minio.bucket | quote }}
+  {{- end }}
+
+  # 后端服务信息
+  {{- if .Values.backend.enabled }}
+  BACKEND_HOST: {{ include "starbyte.backend.fullname" . | quote }}
+  BACKEND_PORT: {{ .Values.backend.service.port | quote }}
+  {{- end }}
+
+  # 前端服务信息
+  {{- if .Values.frontend.enabled }}
+  FRONTEND_HOST: {{ include "starbyte.frontend.fullname" . | quote }}
+  FRONTEND_PORT: {{ .Values.frontend.service.port | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/frontend-deployment.yaml
+++ b/deploy/helm/starbyte/templates/frontend-deployment.yaml
@@ -1,0 +1,70 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "starbyte.frontend.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      serviceAccountName: default
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: {{ printf "%s:%s" .Values.frontend.image.repository .Values.frontend.image.tag | quote }}
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http-frontend
+              containerPort: {{ .Values.frontend.service.targetPort }}
+              protocol: TCP
+          # 前端只需 ConfigMap 中的非敏感配置 (后端地址等)
+          envFrom:
+            - configMapRef:
+                name: {{ include "starbyte.configmap.fullname" . }}
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          {{- if .Values.frontend.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.frontend.probes.liveness.path | quote }}
+              port: http-frontend
+            initialDelaySeconds: {{ .Values.frontend.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.frontend.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.frontend.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.frontend.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.frontend.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.frontend.probes.readiness.path | quote }}
+              port: http-frontend
+            initialDelaySeconds: {{ .Values.frontend.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.frontend.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.frontend.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.frontend.probes.readiness.failureThreshold }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/frontend-service.yaml
+++ b/deploy/helm/starbyte/templates/frontend-service.yaml
@@ -1,0 +1,24 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.frontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.frontend.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - name: http-frontend
+      port: {{ .Values.frontend.service.port }}
+      targetPort: http-frontend
+      protocol: TCP
+      {{- if .Values.frontend.service.nodePort }}
+      nodePort: {{ .Values.frontend.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+{{- end }}

--- a/deploy/helm/starbyte/templates/ingress.yaml
+++ b/deploy/helm/starbyte/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "starbyte.ingress.fullname" . -}}
+{{- $backendFullName := include "starbyte.backend.fullname" . -}}
+{{- $frontendFullName := include "starbyte.frontend.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                # 将短名 (frontend/backend) 解析为 chart 内完整 Service 名
+                name: {{ if eq .serviceName "backend" }}{{ $backendFullName }}{{ else if eq .serviceName "frontend" }}{{ $frontendFullName }}{{ else }}{{ .serviceName }}{{ end }}
+                port:
+                  number: {{ .servicePort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/minio-deployment.yaml
+++ b/deploy/helm/starbyte/templates/minio-deployment.yaml
@@ -1,0 +1,134 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.minio.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.minio.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-api
+      port: {{ .Values.minio.config.port }}
+      targetPort: http-api
+      protocol: TCP
+    - name: http-console
+      port: {{ .Values.minio.config.consolePort }}
+      targetPort: http-console
+      protocol: TCP
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "starbyte.minio.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- $storageClass := include "starbyte.storageClass" (dict "local" .Values.minio.storage.storageClass "global" .Values.global.storageClass) }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.minio.storage.size | quote }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "starbyte.minio.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  replicas: {{ .Values.minio.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: minio
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: minio
+    spec:
+      serviceAccountName: default
+      {{- with .Values.minio.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: minio
+          image: {{ printf "%s:%s" .Values.minio.image.repository .Values.minio.image.tag | quote }}
+          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          {{- with .Values.minio.config.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http-api
+              containerPort: {{ .Values.minio.config.port }}
+              protocol: TCP
+            - name: http-console
+              containerPort: {{ .Values.minio.config.consolePort }}
+              protocol: TCP
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "starbyte.secret.fullname" . }}
+                  key: {{ .Values.minio.rootUser.secretKey }}
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "starbyte.secret.fullname" . }}
+                  key: {{ .Values.minio.rootPassword.secretKey }}
+            - name: MINIO_BUCKET
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "starbyte.configmap.fullname" . }}
+                  key: MINIO_BUCKET
+          resources:
+            {{- toYaml .Values.minio.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: http-api
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: http-api
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "starbyte.minio.fullname" . }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/namespace.yaml
+++ b/deploy/helm/starbyte/templates/namespace.yaml
@@ -1,0 +1,9 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/postgres-statefulset.yaml
+++ b/deploy/helm/starbyte/templates/postgres-statefulset.yaml
@@ -1,0 +1,124 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.postgres.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp-postgres
+      port: {{ .Values.postgres.config.port }}
+      targetPort: tcp-postgres
+      protocol: TCP
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "starbyte.postgres.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: {{ include "starbyte.postgres.fullname" . }}
+  replicas: {{ .Values.postgres.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      serviceAccountName: default
+      {{- with .Values.postgres.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgres
+          image: {{ printf "%s:%s" .Values.postgres.image.repository .Values.postgres.image.tag | quote }}
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          ports:
+            - name: tcp-postgres
+              containerPort: {{ .Values.postgres.config.port }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "starbyte.configmap.fullname" . }}
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "starbyte.configmap.fullname" . }}
+                  key: POSTGRES_DB
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "starbyte.secret.fullname" . }}
+                  key: {{ .Values.postgres.password.secretKey }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "starbyte.labels" . | nindent 10 }}
+          app.kubernetes.io/component: postgres
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- $storageClass := include "starbyte.storageClass" (dict "local" .Values.postgres.storage.storageClass "global" .Values.global.storageClass) }}
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage.size | quote }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/redis-statefulset.yaml
+++ b/deploy/helm/starbyte/templates/redis-statefulset.yaml
@@ -1,0 +1,116 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.redis.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp-redis
+      port: {{ .Values.redis.config.port }}
+      targetPort: tcp-redis
+      protocol: TCP
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "starbyte.redis.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "starbyte.redis.fullname" . }}
+  replicas: {{ .Values.redis.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      serviceAccountName: default
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: {{ printf "%s:%s" .Values.redis.image.repository .Values.redis.image.tag | quote }}
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: tcp-redis
+              containerPort: {{ .Values.redis.config.port }}
+              protocol: TCP
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "starbyte.secret.fullname" . }}
+                  key: {{ .Values.redis.password.secretKey }}
+          command:
+            - sh
+            - -c
+            - redis-server --appendonly yes --requirepass "$REDIS_PASSWORD"
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" ping | grep -q PONG
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" ping | grep -q PONG
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "starbyte.labels" . | nindent 10 }}
+          app.kubernetes.io/component: redis
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- $storageClass := include "starbyte.storageClass" (dict "local" .Values.redis.storage.storageClass "global" .Values.global.storageClass) }}
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage.size | quote }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/secret.yaml
+++ b/deploy/helm/starbyte/templates/secret.yaml
@@ -1,0 +1,46 @@
+{{- /* StarByte Helm Chart - Issue #102 */ -}}
+{{- /*
+生产环境安全提示:
+本模板用于开发/测试环境部署 Secret。生产环境请勿使用明文密码,
+推荐使用以下方案之一管理敏感配置:
+  1. Sealed Secrets (bitnami-labs/sealed-secrets): 加密后的 Secret 可安全提交到 Git
+  2. External Secrets Operator (external-secrets/external-secrets): 从 Vault/AWS SM/GCP SM 动态拉取
+  3. HashiCorp Vault + argocd-vault-plugin
+
+部署到生产前请确保:
+  - 将 secrets.create 设为 false (避免覆盖外部管理的 Secret)
+  - 集群中已存在对应 key 的 Secret 资源
+
+注意: Secret 的 key 名称需符合环境变量命名规则 (正则 [A-Za-z_][A-Za-z0-9_]*),
+因为 backend 通过 envFrom: secretRef 批量注入,带连字符的 key 会被 Kubernetes 跳过。
+*/ -}}
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "starbyte.secret.fullname" . }}
+  namespace: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.postgres.enabled }}
+  # PostgreSQL 密码 (引用 key 与 postgres.password.secretKey 保持一致)
+  {{ .Values.postgres.password.secretKey }}: {{ .Values.secrets.secretData.POSTGRES_PASSWORD | quote }}
+  {{- end }}
+
+  {{- if .Values.redis.enabled }}
+  # Redis 密码 (引用 key 与 redis.password.secretKey 保持一致)
+  {{ .Values.redis.password.secretKey }}: {{ .Values.secrets.secretData.REDIS_PASSWORD | quote }}
+  {{- end }}
+
+  {{- if .Values.minio.enabled }}
+  # MinIO root 用户名 (引用 key 与 minio.rootUser.secretKey 保持一致)
+  {{ .Values.minio.rootUser.secretKey }}: {{ .Values.secrets.secretData.MINIO_ROOT_USER | quote }}
+  # MinIO root 密码 (引用 key 与 minio.rootPassword.secretKey 保持一致)
+  {{ .Values.minio.rootPassword.secretKey }}: {{ .Values.secrets.secretData.MINIO_ROOT_PASSWORD | quote }}
+  {{- end }}
+
+  # JWT 签名密钥
+  JWT_SECRET: {{ .Values.secrets.secretData.JWT_SECRET | quote }}
+{{- end }}

--- a/deploy/helm/starbyte/values-dev.yaml
+++ b/deploy/helm/starbyte/values-dev.yaml
@@ -1,0 +1,98 @@
+# StarByte Helm Chart 开发环境覆盖配置
+# 使用方式: helm install starbyte ./deploy/helm/starbyte -f values.yaml -f values-dev.yaml -n starbyte
+
+global:
+  imagePullPolicy: IfNotPresent
+  # 开发环境使用本地存储
+  storageClass: ""
+
+namespace:
+  name: starbyte-dev
+  create: true
+
+# 后端 - 单副本低资源
+backend:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  env:
+    appEnv: development
+    logLevel: debug
+  probes:
+    liveness:
+      initialDelaySeconds: 15
+    readiness:
+      initialDelaySeconds: 5
+    startup:
+      initialDelaySeconds: 5
+  # 开发环境使用 NodePort 方便本地访问
+  service:
+    type: NodePort
+    port: 8080
+    targetPort: 8080
+    nodePort: 30080
+
+# 前端 - 单副本低资源
+frontend:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+  service:
+    type: NodePort
+    port: 80
+    targetPort: 80
+    nodePort: 30081
+
+# PostgreSQL - 低资源
+postgres:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  storage:
+    size: 5Gi
+
+# Redis - 低资源
+redis:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+  storage:
+    size: 1Gi
+
+# MinIO - 低资源
+minio:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  storage:
+    size: 5Gi
+
+# 开发环境不启用 Ingress (直接使用 NodePort)
+ingress:
+  enabled: false
+
+# 开发环境允许使用测试默认密码
+secrets:
+  create: true

--- a/deploy/helm/starbyte/values-prod.yaml
+++ b/deploy/helm/starbyte/values-prod.yaml
@@ -1,0 +1,144 @@
+# StarByte Helm Chart 生产环境覆盖配置
+# 使用方式: helm install starbyte ./deploy/helm/starbyte -f values.yaml -f values-prod.yaml -n starbyte-prod
+#
+# 重要: 生产环境部署前请务必
+# 1. 替换 secrets.secretData 中的所有默认密码,或使用 Sealed Secrets / External Secrets
+# 2. 配置 ingress.hosts 为真实域名
+# 3. 配置 ingress.tls 的证书 Secret
+
+global:
+  imagePullPolicy: IfNotPresent
+  # 生产环境建议显式指定 storageClass
+  storageClass: ""
+
+namespace:
+  name: starbyte-prod
+  create: true
+
+# 后端 - 多副本高可用
+backend:
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  env:
+    appEnv: production
+    logLevel: warn
+  probes:
+    liveness:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      failureThreshold: 3
+    readiness:
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      failureThreshold: 3
+    startup:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      failureThreshold: 30
+  service:
+    type: ClusterIP
+    port: 8080
+    targetPort: 8080
+
+# 前端 - 多副本高可用
+frontend:
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  probes:
+    liveness:
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      failureThreshold: 3
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 3
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 80
+
+# PostgreSQL - 高资源
+postgres:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+  storage:
+    size: 50Gi
+
+# Redis - 高资源
+redis:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 10Gi
+
+# MinIO - 高资源
+minio:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  storage:
+    size: 200Gi
+
+# 生产环境启用 Ingress + TLS
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: starbyte.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          serviceName: frontend
+          servicePort: 80
+    - host: api.starbyte.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          serviceName: backend
+          servicePort: 8080
+  tls:
+    - secretName: starbyte-tls
+      hosts:
+        - starbyte.example.com
+        - api.starbyte.example.com
+
+# 生产环境建议使用 Sealed Secrets / External Secrets Operator
+# 此处 create 设为 false 时,需保证集群中已存在对应的 Secret 资源
+secrets:
+  # 生产环境部署前请改为 false 并通过外部工具管理 Secret
+  # 此处保留为 true 以便首次部署可运行,密码请务必替换
+  create: true

--- a/deploy/helm/starbyte/values.yaml
+++ b/deploy/helm/starbyte/values.yaml
@@ -1,0 +1,237 @@
+# StarByte Helm Chart 全局默认配置
+# 生产环境请使用 values-prod.yaml 覆盖,开发环境使用 values-dev.yaml 覆盖
+
+# 全局配置
+global:
+  imageRegistry: ghcr.io/yogdunana
+  imagePullPolicy: IfNotPresent
+  # storageClass 为空时使用集群默认 StorageClass
+  storageClass: ""
+
+# namespace 配置
+namespace:
+  name: starbyte
+  create: true
+
+# 后端服务 (Go + Gin)
+backend:
+  enabled: true
+  image:
+    repository: ghcr.io/yogdunana/starbyte-backend
+    tag: "1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  env:
+    appEnv: production
+    configPath: /etc/starbyte/config.yaml
+    logLevel: info
+  probes:
+    liveness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    startup:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+  service:
+    type: ClusterIP
+    port: 8080
+    targetPort: 8080
+  # 调度策略
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# 前端服务 (React + Vite + Nginx)
+frontend:
+  enabled: true
+  image:
+    repository: ghcr.io/yogdunana/starbyte-frontend
+    tag: "1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  probes:
+    liveness:
+      enabled: true
+      path: /
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      path: /
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 80
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# PostgreSQL 16
+postgres:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16"
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 20Gi
+    # storageClass 为空时使用 global.storageClass
+    storageClass: ""
+  config:
+    user: starbyte
+    db: starbyte
+    port: 5432
+  # 密码引用自 Secret (见 secrets.secretData.POSTGRES_PASSWORD)
+  # 注意: key 名称需符合环境变量命名规则,以便 envFrom 批量注入
+  password:
+    secretKey: POSTGRES_PASSWORD
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Redis 7
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7"
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  storage:
+    size: 5Gi
+    storageClass: ""
+  config:
+    port: 6379
+  # 密码引用自 Secret (见 secrets.secretData.REDIS_PASSWORD)
+  password:
+    secretKey: REDIS_PASSWORD
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# MinIO 对象存储
+minio:
+  enabled: true
+  image:
+    repository: minio/minio
+    tag: "RELEASE.2024-09-13T20-34-00Z"
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 50Gi
+    storageClass: ""
+  config:
+    port: 9000
+    consolePort: 9001
+    args:
+      - server
+      - /data
+      - --console-address
+      - ":9001"
+  # rootUser/rootPassword 引用自 Secret (见 secrets.secretData.MINIO_*)
+  rootUser:
+    secretKey: MINIO_ROOT_USER
+  rootPassword:
+    secretKey: MINIO_ROOT_PASSWORD
+  bucket: starbyte
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Ingress 配置
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: starbyte.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          serviceName: frontend
+          servicePort: 80
+    - host: api.starbyte.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          serviceName: backend
+          servicePort: 8080
+  # TLS 配置
+  tls:
+    - secretName: starbyte-tls
+      hosts:
+        - starbyte.example.com
+        - api.starbyte.example.com
+
+# Secrets 配置
+# 注意: 生产环境请使用 Sealed Secrets 或 External Secrets Operator 管理
+# 以下 secretData 仅用于开发/测试,生产环境请勿提交明文密码
+secrets:
+  # 是否创建 Secret 资源 (生产环境设为 false,改用外部 Secret 管理)
+  create: true
+  # 仅供测试用的默认值,部署到生产前请务必替换
+  # key 命名须符合环境变量规则,以便 backend 通过 envFrom 批量注入
+  secretData:
+    POSTGRES_PASSWORD: "change-me-postgres-password"
+    REDIS_PASSWORD: "change-me-redis-password"
+    MINIO_ROOT_USER: "change-me-minio-root-user"
+    MINIO_ROOT_PASSWORD: "change-me-minio-root-password"
+    # JWT 签名密钥
+    JWT_SECRET: "change-me-jwt-secret"

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,99 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+
+## 目录结构
+
+```
+deploy/k8s/
+├── kustomization.yaml           # Kustomize 入口（不含 Secret）
+├── namespace.yaml               # Namespace 定义
+├── configmap.yaml               # 非敏感配置
+├── secret.yaml.example          # Secret 模板（生产用 Sealed Secrets）
+├── postgres-statefulset.yaml    # PostgreSQL StatefulSet + Service
+├── redis-statefulset.yaml       # Redis StatefulSet + Service
+├── minio-deployment.yaml        # MinIO Deployment + Service
+├── backend-deployment.yaml      # 后端 Deployment（滚动更新）
+├── backend-service.yaml         # 后端 Service
+├── frontend-deployment.yaml     # 前端 Deployment（滚动更新）
+├── frontend-service.yaml        # 前端 Service
+├── ingress.yaml                 # Ingress（TLS + 路由）
+├── rollback.sh                  # 回滚脚本
+├── blue-green/                  # 蓝绿部署配置
+│   ├── README.md
+│   ├── backend-deployment-blue.yaml
+│   ├── backend-deployment-green.yaml
+│   ├── frontend-deployment-blue.yaml
+│   ├── frontend-deployment-green.yaml
+│   ├── service-blue-green.yaml
+│   └── switch.sh
+└── canary/                      # 金丝雀发布配置
+    ├── README.md
+    ├── backend-canary-deployment.yaml
+    ├── frontend-canary-deployment.yaml
+    ├── canary-services.yaml
+    └── canary-ingress.yaml
+```
+
+## 快速部署
+
+### 方式一：Kustomize（推荐）
+```bash
+# 1. 创建 Secret（生产环境用 Sealed Secrets 或 External Secrets）
+cp deploy/k8s/secret.yaml.example deploy/k8s/secret.yaml
+# 编辑 secret.yaml，填入真实密钥值
+kubectl apply -f deploy/k8s/secret.yaml -n starbyte
+
+# 2. 部署
+kubectl apply -k deploy/k8s/
+
+# 3. 查看状态
+kubectl get pods -n starbyte
+```
+
+### 方式二：Helm（生产推荐）
+```bash
+helm install starbyte deploy/helm/starbyte \
+  --namespace starbyte --create-namespace \
+  --values deploy/helm/starbyte/values-prod.yaml
+```
+
+## 密钥管理
+
+**禁止将真实密钥提交到 Git 仓库。** 生产环境请使用以下方案之一：
+
+### Sealed Secrets（推荐）
+```bash
+# 安装 Sealed Secrets Controller
+kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.27.3/controller.yaml
+
+# 创建加密的 Secret
+echo -n 'starbyte123' | base64 | kubectl create secret generic starbyte-secret \
+  --dry-run=client --from-literal=POSTGRES_PASSWORD=starbyte123 -o yaml | \
+  kubeseal --format yaml > deploy/k8s/sealed-secret.yaml
+```
+
+### External Secrets（适合多集群）
+```bash
+# 从 AWS Secrets Manager / Vault 等外部密钥管理系统拉取
+kubectl apply -f https://raw.githubusercontent.com/external-secrets/external-secrets/main/deploy/bundle.yaml
+```
+
+## 回滚
+```bash
+# 回滚后端到上一版本
+./deploy/k8s/rollback.sh backend
+
+# 回滚前端
+./deploy/k8s/rollback.sh frontend
+
+# 回滚所有
+./deploy/k8s/rollback.sh all
+```
+
+## 部署策略对照
+
+| 策略 | 适用场景 | 路径 |
+|------|----------|------|
+| 滚动更新 | 常规发布（默认） | `deploy/k8s/*.yaml` |
+| 蓝绿部署 | 零停机发布 + 秒级回滚 | `deploy/k8s/blue-green/` |
+| 金丝雀发布 | 渐进式发布 + 流量切分 | `deploy/k8s/canary/` |
+| Helm | 多环境差异化部署 | `deploy/helm/starbyte/` |

--- a/deploy/k8s/backend-deployment.yaml
+++ b/deploy/k8s/backend-deployment.yaml
@@ -1,0 +1,69 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# 后端服务 Deployment：starbyte-backend（Go 1.22 + Gin，监听 8080）
+#   - 镜像：ghcr.io/yogdunana/starbyte-backend:latest
+#   - 滚动更新：maxSurge=1 / maxUnavailable=0（保证至少 2 个可用副本）
+#   - 副本数：2
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-backend
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+      app.kubernetes.io/instance: starbyte
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: backend
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/yogdunana/starbyte-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          # 环境变量统一从 ConfigMap + Secret 注入，与 docker-compose.yml 对齐
+          envFrom:
+            - configMapRef:
+                name: starbyte-config
+            - secretRef:
+                name: starbyte-secret
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/deploy/k8s/backend-service.yaml
+++ b/deploy/k8s/backend-service.yaml
@@ -1,0 +1,21 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# 后端 Service：starbyte-backend（ClusterIP，端口 8080）
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-backend
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/instance: starbyte

--- a/deploy/k8s/blue-green/README.md
+++ b/deploy/k8s/blue-green/README.md
@@ -1,0 +1,58 @@
+# StarByte 蓝绿部署 - Issue #102
+
+## 策略说明
+
+蓝绿部署维护两个完全相同的环境（Blue / Green），同一时刻只有其中一个接收流量。
+发布时将新版本部署到空闲环境，验证通过后切换流量，如有问题可秒级回滚。
+
+## 使用方法
+
+### 1. 初始部署（Blue 激活）
+```bash
+kubectl apply -f deploy/k8s/blue-green/backend-deployment-blue.yaml
+kubectl apply -f deploy/k8s/blue-green/backend-deployment-green.yaml   # 副本数 0
+kubectl apply -f deploy/k8s/blue-green/frontend-deployment-blue.yaml
+kubectl apply -f deploy/k8s/blue-green/frontend-deployment-green.yaml  # 副本数 0
+kubectl apply -f deploy/k8s/blue-green/service-blue-green.yaml          # 默认指向 Blue
+```
+
+### 2. 发布新版本（部署到 Green）
+```bash
+# 更新 Green Deployment 的 image tag
+kubectl set image deployment/starbyte-backend-green \
+  backend=ghcr.io/yogdunana/starbyte-backend:v2.0.0 -n starbyte
+kubectl set image deployment/starbyte-frontend-green \
+  frontend=ghcr.io/yogdunana/starbyte-frontend:v2.0.0 -n starbyte
+
+# 等待 Green 就绪
+kubectl rollout status deployment/starbyte-backend-green -n starbyte
+kubectl rollout status deployment/starbyte-frontend-green -n starbyte
+```
+
+### 3. 切换流量到 Green
+```bash
+kubectl patch service starbyte-backend-bg -n starbyte \
+  -p '{"spec":{"selector":{"version":"green"}}}'
+kubectl patch service starbyte-frontend-bg -n starbyte \
+  -p '{"spec":{"selector":{"version":"green"}}}'
+```
+
+### 4. 回滚到 Blue
+```bash
+kubectl patch service starbyte-backend-bg -n starbyte \
+  -p '{"spec":{"selector":{"version":"blue"}}}'
+kubectl patch service starbyte-frontend-bg -n starbyte \
+  -p '{"spec":{"selector":{"version":"blue"}}}'
+```
+
+### 5. 使用脚本（推荐）
+```bash
+# 切换到 Green
+./deploy/k8s/blue-green/switch.sh green
+
+# 切换到 Blue（回滚）
+./deploy/k8s/blue-green/switch.sh blue
+
+# 查看当前状态
+./deploy/k8s/blue-green/switch.sh status
+```

--- a/deploy/k8s/blue-green/backend-deployment-blue.yaml
+++ b/deploy/k8s/blue-green/backend-deployment-blue.yaml
@@ -1,0 +1,59 @@
+# StarByte 蓝绿部署 - Backend Blue - Issue #102
+# Blue 环境（初始激活，replicaCount=2）
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-backend-blue
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+    version: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: starbyte
+      component: backend
+      version: blue
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: backend
+        version: blue
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/yogdunana/starbyte-backend:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: starbyte-config
+            - secretRef:
+                name: starbyte-secret
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/deploy/k8s/blue-green/backend-deployment-green.yaml
+++ b/deploy/k8s/blue-green/backend-deployment-green.yaml
@@ -1,0 +1,59 @@
+# StarByte 蓝绿部署 - Backend Green - Issue #102
+# Green 环境（初始空闲，replicaCount=0，发布时扩容）
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-backend-green
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+    version: green
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: starbyte
+      component: backend
+      version: green
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: backend
+        version: green
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/yogdunana/starbyte-backend:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: starbyte-config
+            - secretRef:
+                name: starbyte-secret
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/deploy/k8s/blue-green/frontend-deployment-blue.yaml
+++ b/deploy/k8s/blue-green/frontend-deployment-blue.yaml
@@ -1,0 +1,53 @@
+# StarByte 蓝绿部署 - Frontend Blue - Issue #102
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-frontend-blue
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+    version: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: starbyte
+      component: frontend
+      version: blue
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: frontend
+        version: blue
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/yogdunana/starbyte-frontend:latest
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/deploy/k8s/blue-green/frontend-deployment-green.yaml
+++ b/deploy/k8s/blue-green/frontend-deployment-green.yaml
@@ -1,0 +1,54 @@
+# StarByte 蓝绿部署 - Frontend Green - Issue #102
+# Green 环境（初始空闲，replicaCount=0）
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-frontend-green
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+    version: green
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: starbyte
+      component: frontend
+      version: green
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: frontend
+        version: green
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/yogdunana/starbyte-frontend:latest
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/deploy/k8s/blue-green/service-blue-green.yaml
+++ b/deploy/k8s/blue-green/service-blue-green.yaml
@@ -1,0 +1,42 @@
+# StarByte 蓝绿部署 - Service - Issue #102
+# 通过 selector.version 控制流量指向 Blue 或 Green
+# 初始指向 Blue，切换时 patch selector.version=green
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-backend-bg
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: starbyte
+    component: backend
+    version: blue          # ← 改为 green 即切换流量
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-frontend-bg
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: starbyte
+    component: frontend
+    version: blue          # ← 改为 green 即切换流量
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP

--- a/deploy/k8s/blue-green/switch.sh
+++ b/deploy/k8s/blue-green/switch.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# StarByte 蓝绿部署流量切换脚本 - Issue #102
+# 用法:
+#   ./switch.sh blue    切换流量到 Blue
+#   ./switch.sh green   切换流量到 Green
+#   ./switch.sh status  查看当前状态
+set -euo pipefail
+
+NAMESPACE="${STARBYTE_NAMESPACE:-starbyte}"
+
+case "${1:-status}" in
+  blue|green)
+    TARGET="$1"
+    echo "🔄 切换流量到 ${TARGET}..."
+
+    # 扩容目标环境
+    echo "  → 扩容 ${TARGET} 环境..."
+    kubectl scale deployment "starbyte-backend-${TARGET}" --replicas=2 -n "$NAMESPACE"
+    kubectl scale deployment "starbyte-frontend-${TARGET}" --replicas=2 -n "$NAMESPACE"
+
+    # 等待就绪
+    echo "  → 等待 ${TARGET} 就绪..."
+    kubectl rollout status "deployment/starbyte-backend-${TARGET}" -n "$NAMESPACE" --timeout=3m
+    kubectl rollout status "deployment/starbyte-frontend-${TARGET}" -n "$NAMESPACE" --timeout=3m
+
+    # 切换 Service selector
+    echo "  → 切换 Service selector → version=${TARGET}..."
+    kubectl patch service starbyte-backend-bg -n "$NAMESPACE" \
+      -p "{\"spec\":{\"selector\":{\"version\":\"${TARGET}\"}}}"
+    kubectl patch service starbyte-frontend-bg -n "$NAMESPACE" \
+      -p "{\"spec\":{\"selector\":{\"version\":\"${TARGET}\"}}}"
+
+    # 缩容另一侧
+    OTHER=$([ "$TARGET" = "blue" ] && echo "green" || echo "blue")
+    echo "  → 缩容 ${OTHER} 环境（保留 0 副本）..."
+    kubectl scale deployment "starbyte-backend-${OTHER}" --replicas=0 -n "$NAMESPACE"
+    kubectl scale deployment "starbyte-frontend-${OTHER}" --replicas=0 -n "$NAMESPACE"
+
+    echo "✅ 流量已切换到 ${TARGET}"
+    ;;
+
+  status)
+    echo "📊 蓝绿部署状态 (namespace: ${NAMESPACE})"
+    echo "──────────────────────────────────────────"
+    for svc in starbyte-backend-bg starbyte-frontend-bg; do
+      SELECTOR=$(kubectl get svc "$svc" -n "$NAMESPACE" \
+        -o jsonpath='{.spec.selector.version}' 2>/dev/null || echo "N/A")
+      echo "  ${svc} → 指向: ${SELECTOR:-unknown}"
+    done
+    echo ""
+    echo "Deployments:"
+    kubectl get deployments -n "$NAMESPACE" \
+      -l 'app in (starbyte),component in (backend,frontend)' \
+      -o custom-columns=NAME:.metadata.name,REPLICAS:.spec.replicas,READY:.status.readyReplicas,VERSION:.metadata.labels.version \
+      2>/dev/null || echo "  (无部署)"
+    ;;
+
+  *)
+    echo "用法: $0 {blue|green|status}"
+    exit 1
+    ;;
+esac

--- a/deploy/k8s/canary/README.md
+++ b/deploy/k8s/canary/README.md
@@ -1,0 +1,66 @@
+# StarByte 金丝雀发布 - Issue #102
+
+## 策略说明
+
+金丝雀发布（Canary Release）逐步将新版本暴露给部分用户，先验证再全量推广。
+本方案基于 Nginx Ingress Controller 的 `nginx.ingress.kubernetes.io/canary-*` 注解实现流量切分，无需额外组件。
+
+## 使用方法
+
+### 1. 初始状态
+主 Ingress（`deploy/k8s/ingress.yaml`）指向稳定的 backend/frontend Deployment。
+
+### 2. 部署金丝雀版本
+```bash
+kubectl apply -f deploy/k8s/canary/backend-canary-deployment.yaml
+kubectl apply -f deploy/k8s/canary/frontend-canary-deployment.yaml
+kubectl apply -f deploy/k8s/canary/backend-canary-service.yaml
+kubectl apply -f deploy/k8s/canary/frontend-canary-service.yaml
+```
+
+### 3. 创建金丝雀 Ingress（初始 10% 流量）
+```bash
+kubectl apply -f deploy/k8s/canary/canary-ingress.yaml
+```
+
+### 4. 逐步增加流量
+```bash
+# 10% → 30%
+kubectl annotate ingress starbyte-canary-ingress \
+  nginx.ingress.kubernetes.io/canary-weight=30 \
+  -n starbyte --overwrite
+
+# 30% → 50%
+kubectl annotate ingress starbyte-canary-ingress \
+  nginx.ingress.kubernetes.io/canary-weight=50 \
+  -n starbyte --overwrite
+
+# 50% → 100%（全量）
+kubectl annotate ingress starbyte-canary-ingress \
+  nginx.ingress.kubernetes.io/canary-weight=100 \
+  -n starbyte --overwrite
+```
+
+### 5. 完成发布
+金丝雀 100% 验证通过后：
+1. 更新主 Deployment 的 image tag 为金丝雀版本
+2. 删除金丝雀资源：`kubectl delete -f deploy/k8s/canary/`
+
+### 6. 回滚
+```bash
+# 将金丝雀流量降回 0
+kubectl annotate ingress starbyte-canary-ingress \
+  nginx.ingress.kubernetes.io/canary-weight=0 \
+  -n starbyte --overwrite
+# 删除金丝雀资源
+kubectl delete -f deploy/k8s/canary/
+```
+
+## 按用户灰度（可选）
+不使用百分比，而用 Header/Cookie 路由：
+```yaml
+annotations:
+  nginx.ingress.kubernetes.io/canary-by-header: "X-Canary"
+  nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+```
+带 `X-Canary: true` 的请求走金丝雀版本。

--- a/deploy/k8s/canary/backend-canary-deployment.yaml
+++ b/deploy/k8s/canary/backend-canary-deployment.yaml
@@ -1,0 +1,59 @@
+# StarByte 金丝雀发布 - Backend Canary Deployment - Issue #102
+# 金丝雀环境（少量副本，逐步增加流量）
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-backend-canary
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+    track: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: starbyte
+      component: backend
+      track: canary
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: backend
+        track: canary
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/yogdunana/starbyte-backend:canary    # ← 替换为新版本 tag
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: starbyte-config
+            - secretRef:
+                name: starbyte-secret
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/deploy/k8s/canary/canary-ingress.yaml
+++ b/deploy/k8s/canary/canary-ingress.yaml
@@ -1,0 +1,38 @@
+# StarByte 金丝雀发布 - Canary Ingress - Issue #102
+# 基于 Nginx Ingress Controller canary 注解实现流量切分
+# 初始权重 10%，通过 kubectl annotate 逐步调整
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: starbyte-canary-ingress
+  namespace: starbyte
+  labels:
+    app: starbyte
+    track: canary
+  annotations:
+    # 金丝雀流量百分比（初始 10%）
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "10"
+    # 可选：按 Header 路由（取消注释即可启用）
+    # nginx.ingress.kubernetes.io/canary-by-header: "X-Canary"
+    # nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: starbyte.example.com    # ← 替换为实际域名
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: starbyte-backend-canary
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: starbyte-frontend-canary
+                port:
+                  number: 80

--- a/deploy/k8s/canary/canary-services.yaml
+++ b/deploy/k8s/canary/canary-services.yaml
@@ -1,0 +1,42 @@
+# StarByte 金丝雀发布 - Canary Services - Issue #102
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-backend-canary
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+    track: canary
+spec:
+  type: ClusterIP
+  selector:
+    app: starbyte
+    component: backend
+    track: canary
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-frontend-canary
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+    track: canary
+spec:
+  type: ClusterIP
+  selector:
+    app: starbyte
+    component: frontend
+    track: canary
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP

--- a/deploy/k8s/canary/frontend-canary-deployment.yaml
+++ b/deploy/k8s/canary/frontend-canary-deployment.yaml
@@ -1,0 +1,53 @@
+# StarByte 金丝雀发布 - Frontend Canary Deployment - Issue #102
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-frontend-canary
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+    track: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: starbyte
+      component: frontend
+      track: canary
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: frontend
+        track: canary
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/yogdunana/starbyte-frontend:canary    # ← 替换为新版本 tag
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,38 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# ConfigMap：starbyte-config，集中管理非敏感配置，与 docker-compose.yml 环境变量对齐
+# 敏感信息（密码/密钥）请勿放入此文件，统一从 Secret 引用（见 secret.yaml.example）
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: starbyte-config
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: starbyte
+    app.kubernetes.io/part-of: starbyte
+data:
+  # ── 应用通用 ──
+  APP_ENV: "prod"
+  TZ: "Asia/Shanghai"
+  CONFIG_PATH: "configs/config.yaml"
+
+  # ── PostgreSQL 连接（非敏感部分）──
+  DB_HOST: "postgres-starbyte"
+  DB_PORT: "5432"
+  DB_USER: "starbyte"
+  DB_NAME: "starbyte"
+  DB_SSLMODE: "disable"
+
+  # ── Redis 连接（非敏感部分）──
+  REDIS_HOST: "redis-starbyte"
+  REDIS_PORT: "6379"
+  REDIS_DB: "0"
+
+  # ── MinIO 连接（非敏感部分）──
+  MINIO_ENDPOINT: "minio-starbyte:9000"
+  MINIO_USE_SSL: "false"
+  MINIO_BUCKET: "starbyte"
+
+  # ── 迁移与初始化控制 ──
+  SKIP_MIGRATION: "false"
+  MIGRATION_FAIL_FATAL: "true"
+  SKIP_BUCKET_CREATE: "false"

--- a/deploy/k8s/frontend-deployment.yaml
+++ b/deploy/k8s/frontend-deployment.yaml
@@ -1,0 +1,63 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# 前端服务 Deployment：starbyte-frontend（React 18 + Vite + Nginx，监听 80）
+#   - 镜像：ghcr.io/yogdunana/starbyte-frontend:latest
+#   - 滚动更新：maxSurge=1 / maxUnavailable=0
+#   - 副本数：2
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-frontend
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+      app.kubernetes.io/instance: starbyte
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/yogdunana/starbyte-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/deploy/k8s/frontend-service.yaml
+++ b/deploy/k8s/frontend-service.yaml
@@ -1,0 +1,21 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# 前端 Service：starbyte-frontend（ClusterIP，端口 80）
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-frontend
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: starbyte

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,0 +1,43 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# Ingress：starbyte-ingress（nginx ingress controller）
+#   - host: starbyte.example.com（占位，部署前替换为实际域名）
+#   - /api/    → starbyte-backend:8080
+#   - /        → starbyte-frontend:80
+#   - TLS：占位 secretName=starbyte-tls（由 cert-manager 或手动创建）
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: starbyte-ingress
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: starbyte
+    app.kubernetes.io/part-of: starbyte
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - starbyte.example.com
+      secretName: starbyte-tls  # 占位：生产环境用 cert-manager 自动签发，或手动 `kubectl create secret tls`
+  rules:
+    - host: starbyte.example.com  # TODO: 替换为实际域名
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: starbyte-backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: starbyte-frontend
+                port:
+                  number: 80

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,29 @@
+# StarByte Kustomize - Issue #102
+# 用法: kubectl apply -k deploy/k8s/
+#
+# 注意: Secret 不在此处直接引用，避免部署占位密钥。
+# 生产环境请先复制 secret.yaml.example 为 secret.yaml 并填入真实值，
+# 或使用 Sealed Secrets / External Secrets 管理密钥。
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: starbyte
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - postgres-statefulset.yaml
+  - redis-statefulset.yaml
+  - minio-deployment.yaml
+  - backend-deployment.yaml
+  - backend-service.yaml
+  - frontend-deployment.yaml
+  - frontend-service.yaml
+  - ingress.yaml
+
+# 镜像统一管理（部署时用 kustomize edit set image 覆盖）
+images:
+  - name: ghcr.io/yogdunana/starbyte-backend
+    newTag: latest
+  - name: ghcr.io/yogdunana/starbyte-frontend
+    newTag: latest

--- a/deploy/k8s/minio-deployment.yaml
+++ b/deploy/k8s/minio-deployment.yaml
@@ -1,0 +1,135 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# MinIO 对象存储
+#   - Service：minio-starbyte（9000 S3 API；9001 控制台通过容器内 --console-address 暴露）
+#   - Deployment：minio-starbyte，持久化数据卷 20Gi
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+    - name: console
+      port: 9001
+      targetPort: 9001
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: starbyte
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+      app.kubernetes.io/instance: starbyte
+  strategy:
+    type: Recreate  # 单实例带持久卷，避免双副本同时挂载 RWO 卷
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2024-08-17T01-16-21Z
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - minio server /data --console-address ":9001"
+          ports:
+            - name: s3
+              containerPort: 9000
+              protocol: TCP
+            - name: console
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: starbyte-secret
+                  key: MINIO_ACCESS_KEY
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: starbyte-secret
+                  key: MINIO_SECRET_KEY
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: TZ
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl -fsS http://localhost:9000/minio/health/live
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl -fsS http://localhost:9000/minio/health/live
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-starbyte-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-starbyte-data
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 20Gi

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,10 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# 命名空间：starbyte，所有 StarByte 资源统一部署于此命名空间
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: starbyte
+  labels:
+    app.kubernetes.io/name: starbyte
+    app.kubernetes.io/part-of: starbyte
+    app.kubernetes.io/managed-by: kubectl

--- a/deploy/k8s/postgres-statefulset.yaml
+++ b/deploy/k8s/postgres-statefulset.yaml
@@ -1,0 +1,123 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# PostgreSQL 16 有状态服务
+#   - Headless Service：postgres-starbyte（供 StatefulSet 稳定网络标识）
+#   - StatefulSet：postgres-starbyte，持久化数据卷 10Gi
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  clusterIP: None  # headless，配合 StatefulSet 提供稳定 DNS
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: starbyte
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  serviceName: postgres-starbyte
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/instance: starbyte
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            # 数据库名 / 用户来自 ConfigMap，密码来自 Secret
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: DB_NAME
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: DB_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: starbyte-secret
+                  key: DB_PASSWORD
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: TZ
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U $(POSTGRES_USER) -d $(POSTGRES_DB)
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U $(POSTGRES_USER) -d $(POSTGRES_DB)
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: postgres
+          app.kubernetes.io/instance: starbyte
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 10Gi

--- a/deploy/k8s/redis-statefulset.yaml
+++ b/deploy/k8s/redis-statefulset.yaml
@@ -1,0 +1,117 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# Redis 7 有状态服务
+#   - Headless Service：redis-starbyte
+#   - StatefulSet：redis-starbyte，开启 AOF 持久化，密码校验，持久化数据卷 5Gi
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  clusterIP: None  # headless，配合 StatefulSet 提供稳定 DNS
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: starbyte
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  serviceName: redis-starbyte
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/instance: starbyte
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          # 通过 shell 启动，确保 $(REDIS_PASSWORD) 能被正确展开
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - redis-server --requirepass $(REDIS_PASSWORD) --appendonly yes
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: starbyte-secret
+                  key: REDIS_PASSWORD
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: TZ
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          # Redis 开启 requirepass 后，PING 需携带密码，故探针使用 -a 认证
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli -a $(REDIS_PASSWORD) --no-auth-warning ping | grep PONG
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli -a $(REDIS_PASSWORD) --no-auth-warning ping | grep PONG
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: redis
+          app.kubernetes.io/instance: starbyte
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 5Gi

--- a/deploy/k8s/rollback.sh
+++ b/deploy/k8s/rollback.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# StarByte Kubernetes 部署清单 - Issue #102
+# 回滚脚本：使用 kubectl rollout undo 回滚 backend / frontend
+#
+# 用法: ./rollback.sh [deployment-name] [namespace]
+#   deployment-name: 可选，默认 starbyte-backend（也可传 starbyte-frontend）
+#   namespace:        可选，默认 starbyte
+#
+# 示例:
+#   ./rollback.sh                          # 回滚 starbyte-backend 到上一版本
+#   ./rollback.sh starbyte-frontend         # 回滚 starbyte-frontend
+#   ./rollback.sh starbyte-backend prod      # 在 prod 命名空间回滚 backend
+#
+# 如需回滚到指定版本，可先查看下方历史版本，再手动执行：
+#   kubectl rollout undo deployment/starbyte-backend -n starbyte --to-revision=<N>
+
+set -euo pipefail
+
+DEPLOYMENT_NAME="${1:-starbyte-backend}"
+NAMESPACE="${2:-starbyte}"
+
+# 颜色输出
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo -e "${YELLOW}=== StarByte 回滚工具 ===${NC}"
+echo -e "Deployment: ${GREEN}${DEPLOYMENT_NAME}${NC}"
+echo -e "Namespace:  ${GREEN}${NAMESPACE}${NC}"
+echo ""
+
+# 依赖检查
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo -e "${RED}错误: 未检测到 kubectl，请先安装并配置 kubeconfig。${NC}"
+  exit 1
+fi
+
+# 仅允许回滚 backend / frontend，防止误操作数据类工作负载
+if [[ "${DEPLOYMENT_NAME}" != "starbyte-backend" && "${DEPLOYMENT_NAME}" != "starbyte-frontend" ]]; then
+  echo -e "${RED}错误: 仅支持回滚 starbyte-backend 或 starbyte-frontend，当前传入: ${DEPLOYMENT_NAME}${NC}"
+  echo -e "可用回滚目标: starbyte-backend | starbyte-frontend"
+  exit 1
+fi
+
+echo -e "${YELLOW}[1/3] 当前 rollout 状态:${NC}"
+kubectl rollout status "deployment/${DEPLOYMENT_NAME}" -n "${NAMESPACE}" || true
+echo ""
+
+echo -e "${YELLOW}[2/3] rollout 历史版本:${NC}"
+kubectl rollout history "deployment/${DEPLOYMENT_NAME}" -n "${NAMESPACE}"
+echo ""
+
+echo -e "${YELLOW}[3/3] 执行回滚 (kubectl rollout undo)...${NC}"
+kubectl rollout undo "deployment/${DEPLOYMENT_NAME}" -n "${NAMESPACE}"
+
+echo ""
+echo -e "${GREEN}✅ 已触发回滚，等待 rollout 完成...${NC}"
+kubectl rollout status "deployment/${DEPLOYMENT_NAME}" -n "${NAMESPACE}" --timeout=5m
+
+echo ""
+echo -e "${GREEN}=== 回滚完成 ===${NC}"
+echo -e "回滚后历史版本："
+kubectl rollout history "deployment/${DEPLOYMENT_NAME}" -n "${NAMESPACE}"

--- a/deploy/k8s/secret.yaml.example
+++ b/deploy/k8s/secret.yaml.example
@@ -1,0 +1,32 @@
+# StarByte Kubernetes 部署清单 - Issue #102
+# Secret：starbyte-secret（示例文件）
+#
+# ⚠️ 生产环境注意事项：
+#   1. 切勿将真实密钥直接提交到版本库，本文件仅作示例参考。
+#   2. 请将本文件复制为 secret.yaml 后填入真实值，并将 secret.yaml 加入 .gitignore。
+#   3. 生产环境推荐使用 Sealed Secrets（bitnami-labs/sealed-secrets）
+#      或 External Secrets Operator（ESO）从 Vault / AWS Secrets Manager 等安全源注入密钥，
+#      以实现 GitOps 安全管理。
+#   4. 下方 data 字段的值为 base64 编码的占位字符串，部署前请替换为真实值的 base64 编码。
+#      生成方式：echo -n 'your-real-secret' | base64
+apiVersion: v1
+kind: Secret
+metadata:
+  name: starbyte-secret
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: starbyte
+    app.kubernetes.io/part-of: starbyte
+type: Opaque
+data:
+  # 占位值，解码后均为 changeme，仅用于演示，部署前必须替换
+  # DB_PASSWORD（PostgreSQL 密码）
+  DB_PASSWORD: Y2hhbmdlbWU=
+  # REDIS_PASSWORD（Redis 密码）
+  REDIS_PASSWORD: Y2hhbmdlbWU=
+  # MINIO_ACCESS_KEY（MinIO 访问密钥）
+  MINIO_ACCESS_KEY: Y2hhbmdlbWU=
+  # MINIO_SECRET_KEY（MinIO 私有密钥）
+  MINIO_SECRET_KEY: Y2hhbmdlbWU=
+  # JWT_SECRET（后端 JWT 签名密钥，建议 ≥ 32 字符）
+  JWT_SECRET: Y2hhbmdlbWU=


### PR DESCRIPTION
## 变更描述

实现 Kubernetes 部署与 DevOps 完善（Issue #102），包括：

- **K8s 部署清单**：Deployment/Service/Ingress/ConfigMap/Secret/StatefulSet（PostgreSQL/Redis/MinIO + 前后端）
- **Helm Chart**：完整模板（Chart.yaml + values.yaml + values-dev.yaml + values-prod.yaml + 12 个 templates）
- **蓝绿部署**：Blue/Green Deployment + Service selector 切换 + switch.sh 一键切换/回滚
- **金丝雀发布**：Canary Deployment + Nginx Ingress canary-weight 流量切分
- **CD 流水线**：GitHub Actions 自动构建镜像→推送 GHCR→Helm 部署到 K8s（含环境区分 dev/prod）
- **配置外部化**：ConfigMap + Secret 模板 + Sealed Secrets/External Secrets 文档
- **回滚机制**：rollback.sh（kubectl rollout undo）+ 蓝绿 switch.sh 秒级回滚
- **Kustomize**：kustomization.yaml 支持统一镜像管理

## 关联 Issue

Closes #102

## 测试方式

请说明如何验证这个功能：

1. **K8s 部署验证**：`kubectl apply -k deploy/k8s/`，确认所有 Pod 进入 Running 状态
2. **Helm 部署验证**：`helm install starbyte deploy/helm/starbyte -f deploy/helm/starbyte/values-dev.yaml -n starbyte`，确认 Release 正常
3. **蓝绿切换验证**：执行 `./deploy/k8s/blue-green/switch.sh green` 切换流量，再执行 `./deploy/k8s/blue-green/switch.sh status` 确认指向 Green
4. **金丝雀验证**：部署 canary 资源后，用 `kubectl annotate ingress starbyte-canary-ingress nginx.ingress.kubernetes.io/canary-weight=30` 调整流量
5. **回滚验证**：执行 `./deploy/k8s/rollback.sh backend`，确认 Deployment 回滚到上一版本
6. **CD 流水线验证**：推送代码到 main 分支后，确认 GitHub Actions cd.yml 触发镜像构建并部署到 K8s

## 截图 / GIF

前端变更必须附截图。

| 页面/功能 | 截图 |
|----------|------|
| 无前端变更 | — |

## 注意事项

- **Secret 管理**：`secret.yaml.example` 仅含占位值，生产环境必须使用 Sealed Secrets 或 External Secrets，禁止将真实密钥提交到 Git
- **镜像仓库**：K8s 清单中镜像默认为 `ghcr.io/yogdunana/starbyte-*:latest`，需在 CD 流水线或部署时替换为实际 tag
- **域名**：Ingress 中 host 为 `starbyte.example.com` 占位，部署时需替换为实际域名
- **不影响现有业务代码**：所有变更集中在 `deploy/k8s/`、`deploy/helm/`、`.github/workflows/`，不改动 Go/React 业务代码
- 遗留 TODO：建议后续在 CI 中加入 `helm lint` + `helm template` 渲染校验

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测
- [x] 已添加/更新必要的文档
- [x] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）