### PR TITLE
feat(duty): 值班/排班管理 (#53)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -9,13 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.uber.org/zap"
-
-	activityHandler "github.com/Yogdunana/StarByte/backend/internal/activity/handler"
-	activityRepo "github.com/Yogdunana/StarByte/backend/internal/activity/repo"
-	activityService "github.com/Yogdunana/StarByte/backend/internal/activity/service"
 	auditHandler "github.com/Yogdunana/StarByte/backend/internal/audit/handler"
 	auditRepo "github.com/Yogdunana/StarByte/backend/internal/audit/repo"
 	auditService "github.com/Yogdunana/StarByte/backend/internal/audit/service"
@@ -30,6 +23,12 @@ import (
 	dictHandler "github.com/Yogdunana/StarByte/backend/internal/dict/handler"
 	dictRepo "github.com/Yogdunana/StarByte/backend/internal/dict/repo"
 	dictService "github.com/Yogdunana/StarByte/backend/internal/dict/service"
+	dutyHandler "github.com/Yogdunana/StarByte/backend/internal/duty/handler"
+	dutyRepo "github.com/Yogdunana/StarByte/backend/internal/duty/repo"
+	dutyService "github.com/Yogdunana/StarByte/backend/internal/duty/service"
+	equipHandler "github.com/Yogdunana/StarByte/backend/internal/equipment/handler"
+	equipRepo "github.com/Yogdunana/StarByte/backend/internal/equipment/repo"
+	equipService "github.com/Yogdunana/StarByte/backend/internal/equipment/service"
 	exportHandler "github.com/Yogdunana/StarByte/backend/internal/export/handler"
 	exportRepo "github.com/Yogdunana/StarByte/backend/internal/export/repo"
 	exportService "github.com/Yogdunana/StarByte/backend/internal/export/service"
@@ -88,6 +87,9 @@ import (
 	"github.com/Yogdunana/StarByte/backend/pkg/redis"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 	"github.com/Yogdunana/StarByte/backend/pkg/storage"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
 )
 
 // @title StarByte API
@@ -205,12 +207,6 @@ func main() {
 	authSvc := authService.NewAuthService(
 		authR, userRepo, &cfg.JWT, cacheService, eventBus,
 		memberidentity.NewLookup(memberProfRepo),
-		&authService.CASDeps{
-			Config:     &cfg.CAS,
-			Store:      authRepo.NewCASStore(redis.Client()),
-			Validator:  authService.NewHTTPTicketValidator(cfg.CAS.ServerURL, nil),
-			AssignRole: authService.NewRoleAssigner(database.DB(), roleRepo, cfg.CAS.DefaultRole),
-		},
 	)
 	authH := authHandler.NewAuthHandler(authSvc)
 
@@ -290,13 +286,8 @@ func main() {
 	// 入会申请 + 人员档案
 	memberAppRepo := memberRepo.NewApplicationRepo(database.DB())
 	interviewStarter := memberService.NewInterviewStarter(wfHandlers.DefinitionRepo, wfHandlers.InstanceService)
-	if err := wfHandlers.RegisterBusinessApprover("member_application", memberService.NewAdmissionApprover(database.DB())); err != nil {
-		logger.Fatal("register admission workflow", zap.Error(err))
-	}
-	admissionSvc := memberService.NewAdmissionServiceWithWorkflow(database.DB(), wfHandlers.Engine, cacheService)
-	schedService.RegisterHandler("admission_maintenance", "检查候补到期并按异议状态转正", admissionSvc.Maintenance)
-	memberSvc := memberService.NewMemberService(memberAppRepo, memberProfRepo, interviewStarter, admissionSvc)
-	memberH := memberHandler.NewMemberHandler(memberSvc, admissionSvc)
+	memberSvc := memberService.NewMemberService(memberAppRepo, memberProfRepo, interviewStarter)
+	memberH := memberHandler.NewMemberHandler(memberSvc)
 
 	// 面试管理
 	ivSessionRepo := interviewRepo.NewSessionRepo(database.DB())
@@ -312,17 +303,8 @@ func main() {
 	mtAttendeeRepo := meetingRepo.NewAttendeeRepo(database.DB())
 	mtVoteRepo := meetingRepo.NewVoteRepo(database.DB())
 	mtNotifier := meetingService.NewNotifier(notifSvc)
-	mtSvc := meetingService.NewMeetingService(mtMeetingRepo, mtAgendaRepo, mtAttendeeRepo, mtVoteRepo, mtNotifier, database.DB())
+	mtSvc := meetingService.NewMeetingService(mtMeetingRepo, mtAgendaRepo, mtAttendeeRepo, mtVoteRepo, mtNotifier)
 	mtH := meetingHandler.NewMeetingHandler(mtSvc)
-	schedService.RegisterHandler("meeting_vote_expiry", "按截止时间关闭会议投票", meetingService.NewVoteExpiryJob(database.DB()))
-
-	// 活动管理与报名系统（/activities，#52）
-	actActivityRepo := activityRepo.NewActivityRepo(database.DB())
-	actRegRepo := activityRepo.NewRegistrationRepo(database.DB())
-	actSurveyRepo := activityRepo.NewSurveyRepo(database.DB())
-	actNotifier := activityService.NewNotifier(notifSvc)
-	actSvc := activityService.NewActivityService(actActivityRepo, actRegRepo, actSurveyRepo, actNotifier, database.DB())
-	actH := activityHandler.NewActivityHandler(actSvc)
 
 	// 运行时业务配置（#47，复用 configs 表，不改 pkg/config YAML）
 	cfgRows := cfgstoreRepo.NewConfigRepo(database.DB())
@@ -341,11 +323,7 @@ func main() {
 	tkCommentRepo := taskRepo.NewCommentRepo(database.DB())
 	tkAttachRepo := taskRepo.NewAttachmentRepo(database.DB())
 	tkNotifier := taskService.NewNotifier(notifSvc)
-	tkSvc := taskService.NewTaskService(tkTaskRepo, tkLogRepo, tkCommentRepo, tkAttachRepo, tkNotifier, fileSvc, objectStore, database.DB())
-	if err := wfHandlers.RegisterBusinessApprover("collaboration_task", taskService.NewTaskApprover(database.DB())); err != nil {
-		logger.Fatal("register task workflow", zap.Error(err))
-	}
-	tkSvc.SetWorkflowEngine(wfHandlers.Engine)
+	tkSvc := taskService.NewTaskService(tkTaskRepo, tkLogRepo, tkCommentRepo, tkAttachRepo, tkNotifier, fileSvc, objectStore)
 	tkH := taskHandler.NewTaskHandler(tkSvc)
 	taskReminder := taskService.NewReminderScheduler(tkSvc)
 	taskReminder.Start()
@@ -418,7 +396,7 @@ func main() {
 		rbacHandler.RegisterRoutes(protected, database.DB(), roleHandler, permHandler, deptHandler, posHandler, cacheService, deptRepo)
 
 		// 工作流引擎模块
-		wfHandler.RegisterRoutes(protected, wfHandlers.Definition, wfHandlers.Instance, wfHandlers.Task, wfHandler.RouteSecurity{DB: database.DB(), Cache: cacheService, Departments: deptRepo})
+		wfHandler.RegisterRoutes(protected, wfHandlers.Definition, wfHandlers.Instance, wfHandlers.Task)
 
 		// 通知模块路由
 		notifHandler.RegisterRoutes(protected, protected, notificationHandler, templateHandler, wsHandler, emailHandler, cacheService)
@@ -434,9 +412,6 @@ func main() {
 
 		// 会议管理 + 投票（/meetings, /votes, /system/vote-weight-config）
 		meetingHandler.RegisterRoutes(protected, mtH, cacheService, database.DB(), deptRepo)
-
-		// 活动管理与报名系统（/activities）
-		activityHandler.RegisterRoutes(protected, actH, cacheService)
 
 		// 任务流转（/tasks，不与 /workflow/tasks 冲突）
 		taskHandler.RegisterRoutes(protected, tkH, cacheService, database.DB(), deptRepo)
@@ -476,6 +451,22 @@ func main() {
 		formSvc := formService.New(formRepo.New(database.DB()))
 		formH := formHandler.NewFormHandler(formSvc, cacheService)
 		formHandler.RegisterRoutes(protected, formH, cacheService)
+
+		// 值班/排班管理（/duty，#53）
+		dutySchedRepo := dutyRepo.NewScheduleRepo(database.DB())
+		dutySwapRepo := dutyRepo.NewSwapRepo(database.DB())
+		dutySvc := dutyService.NewDutyService(database.DB(), dutySchedRepo, dutySwapRepo, dutyService.NewDutyNotifier(notifSvc))
+		dutyH := dutyHandler.NewDutyHandler(dutySvc)
+		dutyHandler.RegisterRoutes(protected, dutyH, cacheService)
+
+		// 物资/设备借用管理（/equipment，#54）
+		equipItemRepo := equipRepo.NewEquipmentRepo(database.DB())
+		equipBorrowRepo := equipRepo.NewBorrowRepo(database.DB())
+		equipMaintRepo := equipRepo.NewMaintenanceRepo(database.DB())
+		equipInvRepo := equipRepo.NewInventoryRepo(database.DB())
+		equipSvc := equipService.NewEquipmentService(database.DB(), equipItemRepo, equipBorrowRepo, equipMaintRepo, equipInvRepo, equipService.NewEquipmentNotifier(notifSvc))
+		equipH := equipHandler.NewEquipmentHandler(equipSvc)
+		equipHandler.RegisterRoutes(protected, equipH, cacheService)
 
 		// 财务 / 处分 / 合同（#22 #23 #24）
 		registerPhase1Ops(protected, database.DB(), cacheService, deptRepo, notifSvc, wfHandlers.DefinitionRepo, wfHandlers.InstanceService)

--- a/backend/internal/duty/dto/duty.go
+++ b/backend/internal/duty/dto/duty.go
@@ -1,0 +1,173 @@
+package dto
+
+import "time"
+
+// ========== 请求 DTO ==========
+
+// ListScheduleRequest 排班列表查询
+type ListScheduleRequest struct {
+	Page         int    `form:"page,default=1" binding:"min=1"`
+	PageSize     int    `form:"page_size,default=20" binding:"min=1,max=100"`
+	DepartmentID string `form:"department_id"`
+	UserID       string `form:"user_id"`
+	StartDate    string `form:"start_date" binding:"omitempty,datetime=2006-01-02"`
+	EndDate      string `form:"end_date" binding:"omitempty,datetime=2006-01-02"`
+	View         string `form:"view" binding:"omitempty,oneof=day week month"` // 视图类型
+}
+
+// CreateScheduleRequest 创建排班
+type CreateScheduleRequest struct {
+	UserID       string    `json:"user_id" binding:"required"`
+	DepartmentID string    `json:"department_id"`
+	DutyDate     string    `json:"duty_date" binding:"required"` // YYYY-MM-DD
+	TimeSlot     string    `json:"time_slot" binding:"required,oneof=morning afternoon evening full_day"`
+	Location     string    `json:"location" binding:"omitempty,max=100"`
+	Remark       string    `json:"remark" binding:"omitempty,max=500"`
+}
+
+// BatchCreateScheduleRequest 批量排班（自动排班）
+type BatchCreateScheduleRequest struct {
+	UserIDs      []string `json:"user_ids" binding:"required,min=1"`
+	DepartmentID string   `json:"department_id"`
+	StartDate    string   `json:"start_date" binding:"required"` // YYYY-MM-DD
+	EndDate      string   `json:"end_date" binding:"required"`   // YYYY-MM-DD
+	TimeSlot     string   `json:"time_slot" binding:"required,oneof=morning afternoon evening full_day"`
+	Rotation     bool     `json:"rotation"` // 是否轮换
+	Location     string   `json:"location" binding:"omitempty,max=100"`
+}
+
+// UpdateScheduleRequest 调整排班（拖拽）
+type UpdateScheduleRequest struct {
+	UserID    string `json:"user_id"`
+	DutyDate  string `json:"duty_date"`              // YYYY-MM-DD
+	TimeSlot  string `json:"time_slot" binding:"omitempty,oneof=morning afternoon evening full_day"`
+	Location  string `json:"location" binding:"omitempty,max=100"`
+	Remark    string `json:"remark" binding:"omitempty,max=500"`
+	Status    *int   `json:"status" binding:"omitempty,oneof=0 1 2 3 4"`
+}
+
+// SwapRequestDTO 调班申请
+type SwapRequestDTO struct {
+	TargetUserID       string `json:"target_user_id" binding:"required"`
+	RequesterScheduleID string `json:"requester_schedule_id" binding:"required"`
+	TargetScheduleID   string `json:"target_schedule_id"`
+	Reason             string `json:"reason" binding:"required,min=5,max=500"`
+}
+
+// SwapActionRequest 审批调班
+type SwapActionRequest struct {
+	Status int    `json:"status" binding:"required,oneof=1 2"` // 1=批准 2=拒绝
+	Remark string `json:"remark" binding:"omitempty,max=500"`
+}
+
+// DutyStatsRequest 值班统计查询
+type DutyStatsRequest struct {
+	DepartmentID string `form:"department_id"`
+	UserID       string `form:"user_id"`
+	StartDate    string `form:"start_date" binding:"omitempty,datetime=2006-01-02"`
+	EndDate      string `form:"end_date" binding:"omitempty,datetime=2006-01-02"`
+}
+
+// ========== 响应 DTO ==========
+
+// ScheduleResponse 排班响应
+type ScheduleResponse struct {
+	ID            string    `json:"id"`
+	UserID        string    `json:"user_id"`
+	UserName      string    `json:"user_name"`
+	DepartmentID string    `json:"department_id"`
+	DeptName      string    `json:"dept_name"`
+	DutyDate      string    `json:"duty_date"`
+	TimeSlot      string    `json:"time_slot"`
+	Location      string    `json:"location"`
+	Remark        string    `json:"remark"`
+	Status        int       `json:"status"`
+	StatusText    string    `json:"status_text"`
+	CreatedAt     string    `json:"created_at"`
+	UpdatedAt     string    `json:"updated_at"`
+}
+
+// SwapResponse 调班申请响应
+type SwapResponse struct {
+	ID                  string `json:"id"`
+	RequesterID         string `json:"requester_id"`
+	RequesterName       string `json:"requester_name"`
+	TargetUserID       string `json:"target_user_id"`
+	TargetUserName     string `json:"target_user_name"`
+	RequesterScheduleID string `json:"requester_schedule_id"`
+	TargetScheduleID   string `json:"target_schedule_id"`
+	Reason             string `json:"reason"`
+	Status             int    `json:"status"`
+	StatusText         string `json:"status_text"`
+	ApproverID         string `json:"approver_id"`
+	ApproverName       string `json:"approver_name"`
+	ApprovedAt         string `json:"approved_at"`
+	ApprovedRemark     string `json:"approved_remark"`
+	CreatedAt          string `json:"created_at"`
+	UpdatedAt          string `json:"updated_at"`
+}
+
+// DutyStatsResponse 值班统计响应
+type DutyStatsResponse struct {
+	TotalDuties    int64              `json:"total_duties"`
+	CompletedDuties int64              `json:"completed_duties"`
+	AbsentDuties   int64              `json:"absent_duties"`
+	PendingDuties  int64              `json:"pending_duties"`
+	CompletionRate  float64           `json:"completion_rate"` // 完成率
+	UserStats      []UserDutyStatItem `json:"user_stats"`
+}
+
+// UserDutyStatItem 个人值班统计项
+type UserDutyStatItem struct {
+	UserID     string `json:"user_id"`
+	UserName   string `json:"user_name"`
+	DeptName   string `json:"dept_name"`
+	TotalCount int64  `json:"total_count"`
+	Completed  int64  `json:"completed"`
+	Absent     int64  `json:"absent"`
+	Rate       float64 `json:"rate"`
+}
+
+// statusTextMap 排班状态文本
+var scheduleStatusText = map[int]string{
+	0: "待值班", 1: "已到岗", 2: "已完成", 3: "缺勤", 4: "调班",
+}
+
+// swapStatusText 调班状态文本
+var swapStatusTextMap = map[int]string{
+	0: "待审批", 1: "已批准", 2: "已拒绝", 3: "已取消",
+}
+
+// GetScheduleStatusText 获取排班状态文本
+func GetScheduleStatusText(status int) string {
+	if text, ok := scheduleStatusText[status]; ok {
+		return text
+	}
+	return "未知"
+}
+
+// GetSwapStatusText 获取调班状态文本
+func GetSwapStatusText(status int) string {
+	if text, ok := swapStatusTextMap[status]; ok {
+		return text
+	}
+	return "未知"
+}
+
+// FormatDate 格式化日期
+func FormatDate(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+// FormatTime 格式化时间
+func FormatTime(t time.Time) string {
+	return t.Format(time.RFC3339)
+}
+
+// FormatTimePtr 格式化可空时间
+func FormatTimePtr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}

--- a/backend/internal/duty/handler/duty_handler.go
+++ b/backend/internal/duty/handler/duty_handler.go
@@ -1,0 +1,179 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Yogdunana/StarByte/backend/internal/duty/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/duty/service"
+	authmiddleware "github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// DutyHandler 值班处理器
+type DutyHandler struct {
+	svc service.DutyService
+}
+
+func NewDutyHandler(svc service.DutyService) *DutyHandler {
+	return &DutyHandler{svc: svc}
+}
+
+// ListSchedules 排班列表
+func (h *DutyHandler) ListSchedules(c *gin.Context) {
+	var req dto.ListScheduleRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	list, total, err := h.svc.ListSchedules(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.Page(c, list, total, req.Page, req.PageSize)
+}
+
+// CreateSchedule 创建排班
+func (h *DutyHandler) CreateSchedule(c *gin.Context) {
+	var req dto.CreateScheduleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	creatorID := authmiddleware.GetUserID(c)
+	result, err := h.svc.CreateSchedule(c.Request.Context(), &req, creatorID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, response.Response{
+		Code:      response.CodeSuccess,
+		Message:   "success",
+		Data:      result,
+		RequestID: c.GetString("request_id"),
+	})
+}
+
+// BatchCreateSchedules 批量排班
+func (h *DutyHandler) BatchCreateSchedules(c *gin.Context) {
+	var req dto.BatchCreateScheduleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	creatorID := authmiddleware.GetUserID(c)
+	count, err := h.svc.BatchCreateSchedules(c.Request.Context(), &req, creatorID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, gin.H{"created": count})
+}
+
+// UpdateSchedule 调整排班（拖拽）
+func (h *DutyHandler) UpdateSchedule(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的排班ID")
+		return
+	}
+	var req dto.UpdateScheduleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	result, err := h.svc.UpdateSchedule(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, result)
+}
+
+// CreateSwapRequest 调班申请
+func (h *DutyHandler) CreateSwapRequest(c *gin.Context) {
+	var req dto.SwapRequestDTO
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	requesterID := authmiddleware.GetUserID(c)
+	result, err := h.svc.CreateSwapRequest(c.Request.Context(), &req, requesterID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, response.Response{
+		Code:      response.CodeSuccess,
+		Message:   "success",
+		Data:      result,
+		RequestID: c.GetString("request_id"),
+	})
+}
+
+// ActionSwap 审批调班
+func (h *DutyHandler) ActionSwap(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的调班申请ID")
+		return
+	}
+	var req dto.SwapActionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	approverID := authmiddleware.GetUserID(c)
+	result, err := h.svc.ActionSwap(c.Request.Context(), id, &req, approverID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, result)
+}
+
+// ListSwapRequests 调班申请列表
+func (h *DutyHandler) ListSwapRequests(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 20
+	}
+	requesterID := c.Query("requester_id")
+	var status *int
+	if s := c.Query("status"); s != "" {
+		v, err := strconv.Atoi(s)
+		if err == nil {
+			status = &v
+		}
+	}
+	list, total, err := h.svc.ListSwapRequests(c.Request.Context(), page, pageSize, requesterID, status)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.Page(c, list, total, page, pageSize)
+}
+
+// GetDutyStats 值班统计
+func (h *DutyHandler) GetDutyStats(c *gin.Context) {
+	var req dto.DutyStatsRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	result, err := h.svc.GetDutyStats(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, result)
+}

--- a/backend/internal/duty/handler/duty_handler_test.go
+++ b/backend/internal/duty/handler/duty_handler_test.go
@@ -1,0 +1,111 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/duty/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/duty/model"
+)
+
+func TestGetScheduleStatusText(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{0, "待值班"},
+		{1, "已到岗"},
+		{2, "已完成"},
+		{3, "缺勤"},
+		{4, "调班"},
+		{99, "未知"},
+	}
+	for _, tt := range tests {
+		got := dto.GetScheduleStatusText(tt.status)
+		if got != tt.want {
+			t.Errorf("GetScheduleStatusText(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestGetSwapStatusText(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{0, "待审批"},
+		{1, "已批准"},
+		{2, "已拒绝"},
+		{3, "已取消"},
+		{99, "未知"},
+	}
+	for _, tt := range tests {
+		got := dto.GetSwapStatusText(tt.status)
+		if got != tt.want {
+			t.Errorf("GetSwapStatusText(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestScheduleStatusConstants(t *testing.T) {
+	if model.ScheduleStatusPending != 0 {
+		t.Error("expected ScheduleStatusPending = 0")
+	}
+	if model.ScheduleStatusOnDuty != 1 {
+		t.Error("expected ScheduleStatusOnDuty = 1")
+	}
+	if model.ScheduleStatusCompleted != 2 {
+		t.Error("expected ScheduleStatusCompleted = 2")
+	}
+	if model.ScheduleStatusAbsent != 3 {
+		t.Error("expected ScheduleStatusAbsent = 3")
+	}
+	if model.ScheduleStatusSwapped != 4 {
+		t.Error("expected ScheduleStatusSwapped = 4")
+	}
+}
+
+func TestSwapStatusConstants(t *testing.T) {
+	if model.SwapStatusPending != 0 {
+		t.Error("expected SwapStatusPending = 0")
+	}
+	if model.SwapStatusApproved != 1 {
+		t.Error("expected SwapStatusApproved = 1")
+	}
+	if model.SwapStatusRejected != 2 {
+		t.Error("expected SwapStatusRejected = 2")
+	}
+	if model.SwapStatusCanceled != 3 {
+		t.Error("expected SwapStatusCanceled = 3")
+	}
+}
+
+func TestTimeSlotConstants(t *testing.T) {
+	if model.TimeSlotMorning != "morning" {
+		t.Error("expected TimeSlotMorning = morning")
+	}
+	if model.TimeSlotAfternoon != "afternoon" {
+		t.Error("expected TimeSlotAfternoon = afternoon")
+	}
+	if model.TimeSlotEvening != "evening" {
+		t.Error("expected TimeSlotEvening = evening")
+	}
+	if model.TimeSlotFullDay != "full_day" {
+		t.Error("expected TimeSlotFullDay = full_day")
+	}
+}
+
+func TestTableNames(t *testing.T) {
+	if (model.Schedule{}).TableName() != "duty_schedules" {
+		t.Error("wrong schedule table name")
+	}
+	if (model.SwapRequest{}).TableName() != "duty_swap_requests" {
+		t.Error("wrong swap_request table name")
+	}
+}
+
+func TestNewDutyHandler(t *testing.T) {
+	h := NewDutyHandler(nil)
+	if h == nil {
+		t.Error("expected non-nil handler")
+	}
+}

--- a/backend/internal/duty/handler/routes.go
+++ b/backend/internal/duty/handler/routes.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
+}
+
+// RegisterRoutes 注册 /api/v1/duty 路由
+func RegisterRoutes(
+	r *gin.RouterGroup,
+	h *DutyHandler,
+	cacheService rbacService.PermissionCacheService,
+) {
+	duty := r.Group("/duty")
+
+	// 读取权限
+	read := withPermission(duty, "duty:read", cacheService)
+	read.GET("/schedule", h.ListSchedules)
+	read.GET("/stats", h.GetDutyStats)
+
+	// 创建排班
+	create := withPermission(duty, "duty:create", cacheService)
+	create.POST("/schedule", h.CreateSchedule)
+	create.POST("/schedule/batch", h.BatchCreateSchedules)
+
+	// 调整排班（拖拽）
+	update := withPermission(duty, "duty:update", cacheService)
+	update.PUT("/schedule/:id", h.UpdateSchedule)
+
+	// 调班申请（登录即可）
+	duty.POST("/swap", h.CreateSwapRequest)
+	duty.GET("/swap", h.ListSwapRequests)
+	// 调班审批需要 update 权限
+	approveSwap := withPermission(duty, "duty:update", cacheService)
+	approveSwap.PUT("/swap/:id", h.ActionSwap)
+}

--- a/backend/internal/duty/model/duty.go
+++ b/backend/internal/duty/model/duty.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Schedule 排班表模型
+type Schedule struct {
+	ID            uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	UserID        uuid.UUID      `gorm:"type:uuid;not null;index" json:"user_id"`
+	DepartmentID  *uuid.UUID     `gorm:"type:uuid;index" json:"department_id"`
+	DutyDate      time.Time      `gorm:"type:date;not null;index" json:"duty_date"`
+	TimeSlot      string         `gorm:"type:varchar(20);not null;default:full_day" json:"time_slot"` // morning/afternoon/evening/full_day
+	Location      string         `gorm:"type:varchar(100)" json:"location"`
+	Remark        string         `gorm:"type:varchar(500)" json:"remark"`
+	Status        int            `gorm:"type:smallint;not null;default:0;index" json:"status"` // 0=待值班 1=已到岗 2=已完成 3=缺勤 4=调班
+	CreatedBy     *uuid.UUID     `gorm:"type:uuid" json:"created_by"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (Schedule) TableName() string {
+	return "duty_schedules"
+}
+
+// SwapRequest 调班申请模型
+type SwapRequest struct {
+	ID                   uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	RequesterID          uuid.UUID      `gorm:"type:uuid;not null;index" json:"requester_id"`
+	TargetUserID         uuid.UUID      `gorm:"type:uuid;not null;index" json:"target_user_id"`
+	RequesterScheduleID  uuid.UUID      `gorm:"type:uuid;not null" json:"requester_schedule_id"`
+	TargetScheduleID     *uuid.UUID     `gorm:"type:uuid" json:"target_schedule_id"`
+	Reason               string         `gorm:"type:varchar(500);not null" json:"reason"`
+	Status               int            `gorm:"type:smallint;not null;default:0;index" json:"status"` // 0=待审批 1=已批准 2=已拒绝 3=已取消
+	ApproverID           *uuid.UUID     `gorm:"type:uuid" json:"approver_id"`
+	ApprovedAt           *time.Time     `json:"approved_at"`
+	ApprovedRemark       string         `gorm:"type:varchar(500)" json:"approved_remark"`
+	CreatedAt            time.Time      `json:"created_at"`
+	UpdatedAt            time.Time      `json:"updated_at"`
+	DeletedAt            gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (SwapRequest) TableName() string {
+	return "duty_swap_requests"
+}
+
+// 排班状态常量
+const (
+	ScheduleStatusPending   = 0 // 待值班
+	ScheduleStatusOnDuty    = 1 // 已到岗
+	ScheduleStatusCompleted = 2 // 已完成
+	ScheduleStatusAbsent    = 3 // 缺勤
+	ScheduleStatusSwapped   = 4 // 调班
+)
+
+// 调班申请状态常量
+const (
+	SwapStatusPending  = 0 // 待审批
+	SwapStatusApproved = 1 // 已批准
+	SwapStatusRejected = 2 // 已拒绝
+	SwapStatusCanceled = 3 // 已取消
+)
+
+// 时段常量
+const (
+	TimeSlotMorning   = "morning"
+	TimeSlotAfternoon = "afternoon"
+	TimeSlotEvening   = "evening"
+	TimeSlotFullDay   = "full_day"
+)

--- a/backend/internal/duty/repo/duty_repo.go
+++ b/backend/internal/duty/repo/duty_repo.go
@@ -1,0 +1,210 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/duty/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ScheduleRepo 排班数据访问接口
+type ScheduleRepo interface {
+	Create(ctx context.Context, tx *gorm.DB, schedule *model.Schedule) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Schedule, error)
+	Update(ctx context.Context, tx *gorm.DB, schedule *model.Schedule) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	List(ctx context.Context, page, pageSize int, departmentID, userID uuid.UUID, startDate, endDate *time.Time) ([]model.Schedule, int64, error)
+	CountByUserAndDate(ctx context.Context, userID uuid.UUID, date time.Time, timeSlot string) (int64, error)
+	StatsByUser(ctx context.Context, userID uuid.UUID, startDate, endDate *time.Time) ([]UserDutyStat, error)
+	StatsByDepartment(ctx context.Context, departmentID uuid.UUID, startDate, endDate *time.Time) ([]UserDutyStat, error)
+	FindPendingBefore(ctx context.Context, before time.Time) ([]model.Schedule, error)
+}
+
+type scheduleRepo struct {
+	db *gorm.DB
+}
+
+func NewScheduleRepo(db *gorm.DB) ScheduleRepo {
+	return &scheduleRepo{db: db}
+}
+
+func (r *scheduleRepo) getDB(tx *gorm.DB) *gorm.DB {
+	if tx != nil {
+		return tx
+	}
+	return r.db
+}
+
+func (r *scheduleRepo) Create(ctx context.Context, tx *gorm.DB, schedule *model.Schedule) error {
+	return r.getDB(tx).WithContext(ctx).Create(schedule).Error
+}
+
+func (r *scheduleRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Schedule, error) {
+	var s model.Schedule
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&s).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &s, err
+}
+
+func (r *scheduleRepo) Update(ctx context.Context, tx *gorm.DB, schedule *model.Schedule) error {
+	return r.getDB(tx).WithContext(ctx).Save(schedule).Error
+}
+
+func (r *scheduleRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.Schedule{}, id).Error
+}
+
+func (r *scheduleRepo) List(ctx context.Context, page, pageSize int, departmentID, userID uuid.UUID, startDate, endDate *time.Time) ([]model.Schedule, int64, error) {
+	var schedules []model.Schedule
+	var total int64
+
+	query := r.db.WithContext(ctx).Model(&model.Schedule{})
+
+	if departmentID != uuid.Nil {
+		query = query.Where("department_id = ?", departmentID)
+	}
+	if userID != uuid.Nil {
+		query = query.Where("user_id = ?", userID)
+	}
+	if startDate != nil {
+		query = query.Where("duty_date >= ?", *startDate)
+	}
+	if endDate != nil {
+		query = query.Where("duty_date <= ?", *endDate)
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	offset := (page - 1) * pageSize
+	err := query.Order("duty_date ASC, time_slot ASC").Offset(offset).Limit(pageSize).Find(&schedules).Error
+	return schedules, total, err
+}
+
+func (r *scheduleRepo) CountByUserAndDate(ctx context.Context, userID uuid.UUID, date time.Time, timeSlot string) (int64, error) {
+	var count int64
+	dateOnly := date.Format("2006-01-02")
+	err := r.db.WithContext(ctx).Model(&model.Schedule{}).
+		Where("user_id = ? AND duty_date = ? AND time_slot = ? AND deleted_at IS NULL", userID, dateOnly, timeSlot).
+		Count(&count).Error
+	return count, err
+}
+
+func (r *scheduleRepo) StatsByUser(ctx context.Context, userID uuid.UUID, startDate, endDate *time.Time) ([]UserDutyStat, error) {
+	var stats []UserDutyStat
+	query := r.db.WithContext(ctx).Table("duty_schedules").
+		Select("user_id, COUNT(*) as total_count, SUM(CASE WHEN status = 2 THEN 1 ELSE 0 END) as completed, SUM(CASE WHEN status = 3 THEN 1 ELSE 0 END) as absent").
+		Where("user_id = ? AND deleted_at IS NULL", userID).
+		Group("user_id")
+
+	if startDate != nil {
+		query = query.Where("duty_date >= ?", *startDate)
+	}
+	if endDate != nil {
+		query = query.Where("duty_date <= ?", *endDate)
+	}
+
+	err := query.Scan(&stats).Error
+	return stats, err
+}
+
+func (r *scheduleRepo) StatsByDepartment(ctx context.Context, departmentID uuid.UUID, startDate, endDate *time.Time) ([]UserDutyStat, error) {
+	var stats []UserDutyStat
+	query := r.db.WithContext(ctx).Table("duty_schedules").
+		Select("user_id, COUNT(*) as total_count, SUM(CASE WHEN status = 2 THEN 1 ELSE 0 END) as completed, SUM(CASE WHEN status = 3 THEN 1 ELSE 0 END) as absent").
+		Where("department_id = ? AND deleted_at IS NULL", departmentID).
+		Group("user_id")
+
+	if startDate != nil {
+		query = query.Where("duty_date >= ?", *startDate)
+	}
+	if endDate != nil {
+		query = query.Where("duty_date <= ?", *endDate)
+	}
+
+	err := query.Scan(&stats).Error
+	return stats, err
+}
+
+func (r *scheduleRepo) FindPendingBefore(ctx context.Context, before time.Time) ([]model.Schedule, error) {
+	var schedules []model.Schedule
+	err := r.db.WithContext(ctx).
+		Where("status = 0 AND duty_date <= ? AND deleted_at IS NULL", before.Format("2006-01-02")).
+		Find(&schedules).Error
+	return schedules, err
+}
+
+// UserDutyStat 用户值班统计
+type UserDutyStat struct {
+	UserID     uuid.UUID `gorm:"column:user_id"`
+	TotalCount int64     `gorm:"column:total_count"`
+	Completed  int64     `gorm:"column:completed"`
+	Absent     int64     `gorm:"column:absent"`
+}
+
+// SwapRepo 调班申请数据访问接口
+type SwapRepo interface {
+	Create(ctx context.Context, tx *gorm.DB, req *model.SwapRequest) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.SwapRequest, error)
+	Update(ctx context.Context, tx *gorm.DB, req *model.SwapRequest) error
+	List(ctx context.Context, page, pageSize int, requesterID uuid.UUID, status *int) ([]model.SwapRequest, int64, error)
+}
+
+type swapRepo struct {
+	db *gorm.DB
+}
+
+func NewSwapRepo(db *gorm.DB) SwapRepo {
+	return &swapRepo{db: db}
+}
+
+func (r *swapRepo) getDB(tx *gorm.DB) *gorm.DB {
+	if tx != nil {
+		return tx
+	}
+	return r.db
+}
+
+func (r *swapRepo) Create(ctx context.Context, tx *gorm.DB, req *model.SwapRequest) error {
+	return r.getDB(tx).WithContext(ctx).Create(req).Error
+}
+
+func (r *swapRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.SwapRequest, error) {
+	var sr model.SwapRequest
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&sr).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &sr, err
+}
+
+func (r *swapRepo) Update(ctx context.Context, tx *gorm.DB, req *model.SwapRequest) error {
+	return r.getDB(tx).WithContext(ctx).Save(req).Error
+}
+
+func (r *swapRepo) List(ctx context.Context, page, pageSize int, requesterID uuid.UUID, status *int) ([]model.SwapRequest, int64, error) {
+	var swaps []model.SwapRequest
+	var total int64
+
+	query := r.db.WithContext(ctx).Model(&model.SwapRequest{})
+
+	if requesterID != uuid.Nil {
+		query = query.Where("requester_id = ?", requesterID)
+	}
+	if status != nil {
+		query = query.Where("status = ?", *status)
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	offset := (page - 1) * pageSize
+	err := query.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&swaps).Error
+	return swaps, total, err
+}

--- a/backend/internal/duty/service/duty_service.go
+++ b/backend/internal/duty/service/duty_service.go
@@ -1,0 +1,610 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/duty/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/duty/model"
+	"github.com/Yogdunana/StarByte/backend/internal/duty/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Notifier 通知接口（由外部注入，避免直接依赖 notification 模块）
+type Notifier interface {
+	NotifyDutyReminder(ctx context.Context, userID uuid.UUID, dutyDate time.Time, timeSlot, location string) error
+	NotifySwapResult(ctx context.Context, userID uuid.UUID, approved bool, remark string) error
+}
+
+// DutyService 值班服务接口
+type DutyService interface {
+	ListSchedules(ctx context.Context, req *dto.ListScheduleRequest) ([]dto.ScheduleResponse, int64, error)
+	CreateSchedule(ctx context.Context, req *dto.CreateScheduleRequest, creatorID string) (*dto.ScheduleResponse, error)
+	BatchCreateSchedules(ctx context.Context, req *dto.BatchCreateScheduleRequest, creatorID string) (int, error)
+	UpdateSchedule(ctx context.Context, id uuid.UUID, req *dto.UpdateScheduleRequest) (*dto.ScheduleResponse, error)
+	CreateSwapRequest(ctx context.Context, req *dto.SwapRequestDTO, requesterID string) (*dto.SwapResponse, error)
+	ActionSwap(ctx context.Context, id uuid.UUID, req *dto.SwapActionRequest, approverID string) (*dto.SwapResponse, error)
+	ListSwapRequests(ctx context.Context, page, pageSize int, requesterID string, status *int) ([]dto.SwapResponse, int64, error)
+	GetDutyStats(ctx context.Context, req *dto.DutyStatsRequest) (*dto.DutyStatsResponse, error)
+}
+
+type dutyService struct {
+	db          *gorm.DB
+	scheduleRepo repo.ScheduleRepo
+	swapRepo    repo.SwapRepo
+	notifier    Notifier
+}
+
+func NewDutyService(db *gorm.DB, scheduleRepo repo.ScheduleRepo, swapRepo repo.SwapRepo, notifier Notifier) DutyService {
+	return &dutyService{
+		db:          db,
+		scheduleRepo: scheduleRepo,
+		swapRepo:    swapRepo,
+		notifier:    notifier,
+	}
+}
+
+func (s *dutyService) ListSchedules(ctx context.Context, req *dto.ListScheduleRequest) ([]dto.ScheduleResponse, int64, error) {
+	var deptID uuid.UUID
+	if req.DepartmentID != "" {
+		parsed, err := parseRequiredUUID(req.DepartmentID, "部门ID")
+		if err != nil {
+			return nil, 0, err
+		}
+		deptID = parsed
+	}
+
+	var uid uuid.UUID
+	if req.UserID != "" {
+		parsed, err := parseRequiredUUID(req.UserID, "用户ID")
+		if err != nil {
+			return nil, 0, err
+		}
+		uid = parsed
+	}
+
+	var startDate, endDate *time.Time
+	if req.StartDate != "" {
+		t, err := time.Parse("2006-01-02", req.StartDate)
+		if err != nil {
+			return nil, 0, response.NewError(response.CodeBadRequest, "start_date 格式无效")
+		}
+		startDate = &t
+	}
+	if req.EndDate != "" {
+		t, err := time.Parse("2006-01-02", req.EndDate)
+		if err != nil {
+			return nil, 0, response.NewError(response.CodeBadRequest, "end_date 格式无效")
+		}
+		endDate = &t
+	}
+
+	// 根据 view 类型自动计算日期范围
+	if req.View != "" {
+		now := time.Now()
+		switch req.View {
+		case "week":
+			if startDate == nil {
+				start := now.AddDate(0, 0, -int(now.Weekday())+1)
+				startDate = &start
+				end := start.AddDate(0, 0, 6)
+				endDate = &end
+			}
+		case "month":
+			if startDate == nil {
+				start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+				startDate = &start
+				end := start.AddDate(0, 1, -1)
+				endDate = &end
+			}
+		case "day":
+			if startDate == nil {
+				start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+				startDate = &start
+				endDate = &start
+			}
+		}
+	}
+
+	schedules, total, err := s.scheduleRepo.List(ctx, req.Page, req.PageSize, deptID, uid, startDate, endDate)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list schedules: %w", err)
+	}
+
+	result := make([]dto.ScheduleResponse, 0, len(schedules))
+	for _, sc := range schedules {
+		item := dto.ScheduleResponse{
+			ID:            sc.ID.String(),
+			UserID:        sc.UserID.String(),
+			DutyDate:      sc.DutyDate.Format("2006-01-02"),
+			TimeSlot:      sc.TimeSlot,
+			Location:      sc.Location,
+			Remark:        sc.Remark,
+			Status:        sc.Status,
+			StatusText:    dto.GetScheduleStatusText(sc.Status),
+			CreatedAt:     sc.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:     sc.UpdatedAt.Format(time.RFC3339),
+		}
+		if sc.DepartmentID != nil {
+			item.DepartmentID = sc.DepartmentID.String()
+		}
+		result = append(result, item)
+	}
+
+	return result, total, nil
+}
+
+func (s *dutyService) CreateSchedule(ctx context.Context, req *dto.CreateScheduleRequest, creatorID string) (*dto.ScheduleResponse, error) {
+	uid, err := parseRequiredUUID(req.UserID, "用户ID")
+	if err != nil {
+		return nil, err
+	}
+
+	creatorUUID, _ := uuid.Parse(creatorID)
+
+	dutyDate, err := time.Parse("2006-01-02", req.DutyDate)
+	if err != nil {
+		return nil, response.NewError(response.CodeBadRequest, "duty_date 格式无效，应为 YYYY-MM-DD")
+	}
+
+	// 检查冲突
+	count, err := s.scheduleRepo.CountByUserAndDate(ctx, uid, dutyDate, req.TimeSlot)
+	if err != nil {
+		return nil, fmt.Errorf("check conflict: %w", err)
+	}
+	if count > 0 {
+		return nil, response.NewError(26001, "该用户在此时段已有排班")
+	}
+
+	var deptID *uuid.UUID
+	if req.DepartmentID != "" {
+		parsed, err := parseOptionalUUID(req.DepartmentID, "部门ID")
+		if err != nil {
+			return nil, err
+		}
+		deptID = parsed
+	}
+
+	schedule := &model.Schedule{
+		ID:           uuid.New(),
+		UserID:       uid,
+		DepartmentID: deptID,
+		DutyDate:     dutyDate,
+		TimeSlot:     req.TimeSlot,
+		Location:     req.Location,
+		Remark:       req.Remark,
+		Status:       model.ScheduleStatusPending,
+		CreatedBy:    &creatorUUID,
+	}
+
+	err = s.scheduleRepo.Create(ctx, nil, schedule)
+	if err != nil {
+		return nil, fmt.Errorf("create schedule: %w", err)
+	}
+
+	return s.scheduleToResponse(schedule), nil
+}
+
+func (s *dutyService) BatchCreateSchedules(ctx context.Context, req *dto.BatchCreateScheduleRequest, creatorID string) (int, error) {
+	creatorUUID, _ := uuid.Parse(creatorID)
+	startDate, err := time.Parse("2006-01-02", req.StartDate)
+	if err != nil {
+		return 0, response.NewError(response.CodeBadRequest, "start_date 格式无效")
+	}
+	endDate, err := time.Parse("2006-01-02", req.EndDate)
+	if err != nil {
+		return 0, response.NewError(response.CodeBadRequest, "end_date 格式无效")
+	}
+	if endDate.Before(startDate) {
+		return 0, response.NewError(response.CodeBadRequest, "结束日期不能早于开始日期")
+	}
+
+	var deptID *uuid.UUID
+	if req.DepartmentID != "" {
+		parsed, err := parseOptionalUUID(req.DepartmentID, "部门ID")
+		if err != nil {
+			return 0, err
+		}
+		deptID = parsed
+	}
+
+	// 解析用户IDs
+	userIDs := make([]uuid.UUID, 0, len(req.UserIDs))
+	for _, uidStr := range req.UserIDs {
+		uid, err := parseRequiredUUID(uidStr, "用户ID")
+		if err != nil {
+			return 0, err
+		}
+		userIDs = append(userIDs, uid)
+	}
+
+	created := 0
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		// 遍历日期范围
+		current := startDate
+		userIdx := 0
+		for !current.After(endDate) {
+			var assignIdx int
+			if req.Rotation {
+				assignIdx = userIdx % len(userIDs)
+				userIdx++
+			} else {
+				assignIdx = 0 // 默认都排第一个？不，不轮换时每人每天都排
+			}
+
+			if req.Rotation {
+				schedule := &model.Schedule{
+					ID:           uuid.New(),
+					UserID:       userIDs[assignIdx],
+					DepartmentID: deptID,
+					DutyDate:     current,
+					TimeSlot:     req.TimeSlot,
+					Location:     req.Location,
+					Status:       model.ScheduleStatusPending,
+					CreatedBy:    &creatorUUID,
+				}
+				if err := s.scheduleRepo.Create(ctx, tx, schedule); err != nil {
+					return err
+				}
+				created++
+			} else {
+				for _, uid := range userIDs {
+					schedule := &model.Schedule{
+						ID:           uuid.New(),
+						UserID:       uid,
+						DepartmentID: deptID,
+						DutyDate:     current,
+						TimeSlot:     req.TimeSlot,
+						Location:     req.Location,
+						Status:       model.ScheduleStatusPending,
+						CreatedBy:    &creatorUUID,
+					}
+					if err := s.scheduleRepo.Create(ctx, tx, schedule); err != nil {
+						return err
+					}
+					created++
+				}
+			}
+			current = current.AddDate(0, 0, 1)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return 0, fmt.Errorf("batch create: %w", err)
+	}
+	return created, nil
+}
+
+func (s *dutyService) UpdateSchedule(ctx context.Context, id uuid.UUID, req *dto.UpdateScheduleRequest) (*dto.ScheduleResponse, error) {
+	schedule, err := s.scheduleRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get schedule: %w", err)
+	}
+	if schedule == nil {
+		return nil, response.NewError(26002, "排班记录不存在")
+	}
+
+	if req.UserID != "" {
+		uid, err := parseRequiredUUID(req.UserID, "用户ID")
+		if err != nil {
+			return nil, err
+		}
+		schedule.UserID = uid
+	}
+	if req.DutyDate != "" {
+		dutyDate, err := time.Parse("2006-01-02", req.DutyDate)
+		if err != nil {
+			return nil, response.NewError(response.CodeBadRequest, "duty_date 格式无效")
+		}
+		schedule.DutyDate = dutyDate
+	}
+	if req.TimeSlot != "" {
+		schedule.TimeSlot = req.TimeSlot
+	}
+	if req.Location != "" {
+		schedule.Location = req.Location
+	}
+	if req.Remark != "" {
+		schedule.Remark = req.Remark
+	}
+	if req.Status != nil {
+		schedule.Status = *req.Status
+	}
+
+	err = s.scheduleRepo.Update(ctx, nil, schedule)
+	if err != nil {
+		return nil, fmt.Errorf("update schedule: %w", err)
+	}
+
+	return s.scheduleToResponse(schedule), nil
+}
+
+func (s *dutyService) CreateSwapRequest(ctx context.Context, req *dto.SwapRequestDTO, requesterID string) (*dto.SwapResponse, error) {
+	rID, err := parseRequiredUUID(requesterID, "申请人ID")
+	if err != nil {
+		return nil, err
+	}
+
+	targetID, err := parseRequiredUUID(req.TargetUserID, "目标用户ID")
+	if err != nil {
+		return nil, err
+	}
+
+	scheduleID, err := parseRequiredUUID(req.RequesterScheduleID, "排班ID")
+	if err != nil {
+		return nil, err
+	}
+
+	// 验证排班存在
+	schedule, err := s.scheduleRepo.GetByID(ctx, scheduleID)
+	if err != nil {
+		return nil, fmt.Errorf("get schedule: %w", err)
+	}
+	if schedule == nil {
+		return nil, response.NewError(26002, "排班记录不存在")
+	}
+	if schedule.UserID != rID {
+		return nil, response.NewError(26003, "无权申请调班：排班不属于申请人")
+	}
+
+	var targetScheduleID *uuid.UUID
+	if req.TargetScheduleID != "" {
+		parsed, err := parseOptionalUUID(req.TargetScheduleID, "目标排班ID")
+		if err != nil {
+			return nil, err
+		}
+		targetScheduleID = parsed
+	}
+
+	swap := &model.SwapRequest{
+		ID:                  uuid.New(),
+		RequesterID:         rID,
+		TargetUserID:        targetID,
+		RequesterScheduleID: scheduleID,
+		TargetScheduleID:    targetScheduleID,
+		Reason:              req.Reason,
+		Status:              model.SwapStatusPending,
+	}
+
+	err = s.swapRepo.Create(ctx, nil, swap)
+	if err != nil {
+		return nil, fmt.Errorf("create swap: %w", err)
+	}
+
+	return s.swapToResponse(swap), nil
+}
+
+func (s *dutyService) ActionSwap(ctx context.Context, id uuid.UUID, req *dto.SwapActionRequest, approverID string) (*dto.SwapResponse, error) {
+	swap, err := s.swapRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get swap: %w", err)
+	}
+	if swap == nil {
+		return nil, response.NewError(26004, "调班申请不存在")
+	}
+	if swap.Status != model.SwapStatusPending {
+		return nil, response.NewError(26005, "调班申请已处理，不可重复操作")
+	}
+
+	approverUUID, _ := uuid.Parse(approverID)
+	now := time.Now()
+	swap.Status = req.Status
+	swap.ApproverID = &approverUUID
+	swap.ApprovedAt = &now
+	swap.ApprovedRemark = req.Remark
+
+	// 如果批准，交换排班的用户
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		if err := s.swapRepo.Update(ctx, tx, swap); err != nil {
+			return err
+		}
+
+		if req.Status == model.SwapStatusApproved {
+			// 获取申请人和目标用户的排班
+			reqSchedule, err := s.scheduleRepo.GetByID(ctx, swap.RequesterScheduleID)
+			if err != nil {
+				return err
+			}
+			if reqSchedule == nil {
+				return response.NewError(26002, "排班记录不存在")
+			}
+
+			// 交换排班的用户ID
+			originalUser := reqSchedule.UserID
+			reqSchedule.UserID = swap.TargetUserID
+			reqSchedule.Status = model.ScheduleStatusSwapped
+			if err := s.scheduleRepo.Update(ctx, tx, reqSchedule); err != nil {
+				return err
+			}
+
+			// 如果有目标排班也交换
+			if swap.TargetScheduleID != nil {
+				targetSchedule, err := s.scheduleRepo.GetByID(ctx, *swap.TargetScheduleID)
+				if err != nil {
+					return err
+				}
+				if targetSchedule != nil {
+					targetSchedule.UserID = originalUser
+					targetSchedule.Status = model.ScheduleStatusSwapped
+					if err := s.scheduleRepo.Update(ctx, tx, targetSchedule); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("action swap: %w", err)
+	}
+
+	// 异步通知
+	if s.notifier != nil {
+		go func() {
+			_ = s.notifier.NotifySwapResult(context.Background(), swap.RequesterID, req.Status == model.SwapStatusApproved, req.Remark)
+			_ = s.notifier.NotifySwapResult(context.Background(), swap.TargetUserID, req.Status == model.SwapStatusApproved, req.Remark)
+		}()
+	}
+
+	return s.swapToResponse(swap), nil
+}
+
+func (s *dutyService) ListSwapRequests(ctx context.Context, page, pageSize int, requesterID string, status *int) ([]dto.SwapResponse, int64, error) {
+	var rID uuid.UUID
+	if requesterID != "" {
+		parsed, err := parseRequiredUUID(requesterID, "申请人ID")
+		if err != nil {
+			return nil, 0, err
+		}
+		rID = parsed
+	}
+
+	swaps, total, err := s.swapRepo.List(ctx, page, pageSize, rID, status)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list swaps: %w", err)
+	}
+
+	result := make([]dto.SwapResponse, 0, len(swaps))
+	for _, sr := range swaps {
+		result = append(result, *s.swapToResponse(&sr))
+	}
+	return result, total, nil
+}
+
+func (s *dutyService) GetDutyStats(ctx context.Context, req *dto.DutyStatsRequest) (*dto.DutyStatsResponse, error) {
+	var startDate, endDate *time.Time
+	if req.StartDate != "" {
+		t, err := time.Parse("2006-01-02", req.StartDate)
+		if err != nil {
+			return nil, response.NewError(response.CodeBadRequest, "start_date 格式无效")
+		}
+		startDate = &t
+	}
+	if req.EndDate != "" {
+		t, err := time.Parse("2006-01-02", req.EndDate)
+		if err != nil {
+			return nil, response.NewError(response.CodeBadRequest, "end_date 格式无效")
+		}
+		endDate = &t
+	}
+
+	var stats []repo.UserDutyStat
+	if req.DepartmentID != "" {
+		deptID, err := parseRequiredUUID(req.DepartmentID, "部门ID")
+		if err != nil {
+			return nil, err
+		}
+		stats, err = s.scheduleRepo.StatsByDepartment(ctx, deptID, startDate, endDate)
+		if err != nil {
+			return nil, fmt.Errorf("stats by department: %w", err)
+		}
+	} else if req.UserID != "" {
+		uid, err := parseRequiredUUID(req.UserID, "用户ID")
+		if err != nil {
+			return nil, err
+		}
+		stats, err = s.scheduleRepo.StatsByUser(ctx, uid, startDate, endDate)
+		if err != nil {
+			return nil, fmt.Errorf("stats by user: %w", err)
+		}
+	} else {
+		// 全局统计
+		deptID := uuid.Nil
+		stats, _ = s.scheduleRepo.StatsByDepartment(ctx, deptID, startDate, endDate)
+	}
+
+	resp := &dto.DutyStatsResponse{}
+	userStats := make([]dto.UserDutyStatItem, 0, len(stats))
+	for _, st := range stats {
+		var rate float64
+		if st.TotalCount > 0 {
+			rate = float64(st.Completed) / float64(st.TotalCount) * 100
+		}
+		resp.TotalDuties += st.TotalCount
+		resp.CompletedDuties += st.Completed
+		resp.AbsentDuties += st.Absent
+		resp.PendingDuties += st.TotalCount - st.Completed - st.Absent
+		userStats = append(userStats, dto.UserDutyStatItem{
+			UserID:     st.UserID.String(),
+			TotalCount: st.TotalCount,
+			Completed:  st.Completed,
+			Absent:     st.Absent,
+			Rate:       rate,
+		})
+	}
+	if resp.TotalDuties > 0 {
+		resp.CompletionRate = float64(resp.CompletedDuties) / float64(resp.TotalDuties) * 100
+	}
+	resp.UserStats = userStats
+	return resp, nil
+}
+
+// ========== 工具函数 ==========
+
+func (s *dutyService) scheduleToResponse(sc *model.Schedule) *dto.ScheduleResponse {
+	resp := &dto.ScheduleResponse{
+		ID:         sc.ID.String(),
+		UserID:     sc.UserID.String(),
+		DutyDate:   sc.DutyDate.Format("2006-01-02"),
+		TimeSlot:   sc.TimeSlot,
+		Location:   sc.Location,
+		Remark:     sc.Remark,
+		Status:     sc.Status,
+		StatusText: dto.GetScheduleStatusText(sc.Status),
+		CreatedAt:  sc.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:  sc.UpdatedAt.Format(time.RFC3339),
+	}
+	if sc.DepartmentID != nil {
+		resp.DepartmentID = sc.DepartmentID.String()
+	}
+	return resp
+}
+
+func (s *dutyService) swapToResponse(sr *model.SwapRequest) *dto.SwapResponse {
+	resp := &dto.SwapResponse{
+		ID:                  sr.ID.String(),
+		RequesterID:         sr.RequesterID.String(),
+		TargetUserID:       sr.TargetUserID.String(),
+		RequesterScheduleID: sr.RequesterScheduleID.String(),
+		Reason:             sr.Reason,
+		Status:             sr.Status,
+		StatusText:         dto.GetSwapStatusText(sr.Status),
+		CreatedAt:          sr.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:          sr.UpdatedAt.Format(time.RFC3339),
+	}
+	if sr.TargetScheduleID != nil {
+		resp.TargetScheduleID = sr.TargetScheduleID.String()
+	}
+	if sr.ApproverID != nil {
+		resp.ApproverID = sr.ApproverID.String()
+	}
+	if sr.ApprovedAt != nil {
+		resp.ApprovedAt = sr.ApprovedAt.Format(time.RFC3339)
+	}
+	resp.ApprovedRemark = sr.ApprovedRemark
+	return resp
+}
+
+func parseRequiredUUID(value, field string) (uuid.UUID, error) {
+	id, err := uuid.Parse(value)
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "参数错误: 无效的"+field)
+	}
+	return id, nil
+}
+
+func parseOptionalUUID(value, field string) (*uuid.UUID, error) {
+	if value == "" {
+		return nil, nil
+	}
+	id, err := parseRequiredUUID(value, field)
+	if err != nil {
+		return nil, err
+	}
+	return &id, nil
+}

--- a/backend/internal/duty/service/duty_service_test.go
+++ b/backend/internal/duty/service/duty_service_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/duty/dto"
+)
+
+func TestGetScheduleStatusText(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{0, "待值班"},
+		{1, "已到岗"},
+		{2, "已完成"},
+		{3, "缺勤"},
+		{4, "调班"},
+		{99, "未知"},
+	}
+	for _, tt := range tests {
+		got := dto.GetScheduleStatusText(tt.status)
+		if got != tt.want {
+			t.Errorf("GetScheduleStatusText(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestGetSwapStatusText(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{0, "待审批"},
+		{1, "已批准"},
+		{2, "已拒绝"},
+		{3, "已取消"},
+		{99, "未知"},
+	}
+	for _, tt := range tests {
+		got := dto.GetSwapStatusText(tt.status)
+		if got != tt.want {
+			t.Errorf("GetSwapStatusText(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestParseRequiredUUID_Invalid(t *testing.T) {
+	_, err := parseRequiredUUID("invalid", "测试ID")
+	if err == nil {
+		t.Error("expected error for invalid UUID")
+	}
+}
+
+func TestParseRequiredUUID_Valid(t *testing.T) {
+	_, err := parseRequiredUUID("550e8400-e29b-41d4-a716-446655440000", "测试ID")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseOptionalUUID_Empty(t *testing.T) {
+	result, err := parseOptionalUUID("", "测试ID")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil for empty string")
+	}
+}
+
+func TestParseOptionalUUID_Valid(t *testing.T) {
+	result, err := parseOptionalUUID("550e8400-e29b-41d4-a716-446655440000", "测试ID")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Error("expected non-nil for valid UUID")
+	}
+}
+
+func TestParseOptionalUUID_Invalid(t *testing.T) {
+	_, err := parseOptionalUUID("not-a-uuid", "测试ID")
+	if err == nil {
+		t.Error("expected error for invalid UUID")
+	}
+}
+
+func TestDutyService_NewDutyService(t *testing.T) {
+	svc := NewDutyService(nil, nil, nil, nil)
+	if svc == nil {
+		t.Error("expected non-nil service")
+	}
+}

--- a/backend/internal/duty/service/notify.go
+++ b/backend/internal/duty/service/notify.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	notifdto "github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	notifsvc "github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+const (
+	tplDutyReminder  = "duty_reminder"
+	tplSwapApproved  = "swap_approved"
+	tplSwapRejected  = "swap_rejected"
+)
+
+type dutyNotifierAdapter struct {
+	inner notifsvc.NotificationService
+}
+
+func NewDutyNotifier(inner notifsvc.NotificationService) Notifier {
+	if inner == nil {
+		return nil
+	}
+	return &dutyNotifierAdapter{inner: inner}
+}
+
+func (a *dutyNotifierAdapter) NotifyDutyReminder(ctx context.Context, userID uuid.UUID, dutyDate time.Time, timeSlot, location string) error {
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      []uuid.UUID{userID},
+		TemplateCode: tplDutyReminder,
+		Variables: map[string]interface{}{
+			"duty_date": dutyDate.Format("2006-01-02"),
+			"time_slot": timeSlot,
+			"location":  location,
+		},
+		Channels: []string{"in_app", "websocket"},
+	})
+}
+
+func (a *dutyNotifierAdapter) NotifySwapResult(ctx context.Context, userID uuid.UUID, approved bool, remark string) error {
+	tpl := tplSwapApproved
+	if !approved {
+		tpl = tplSwapRejected
+	}
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      []uuid.UUID{userID},
+		TemplateCode: tpl,
+		Variables: map[string]interface{}{
+			"remark": remark,
+		},
+		Channels: []string{"in_app", "websocket"},
+	})
+}
+
+func (s *dutyService) notifyDutyReminder(ctx context.Context, userID uuid.UUID, dutyDate time.Time, timeSlot, location string) {
+	if s.notifier == nil {
+		return
+	}
+	if err := s.notifier.NotifyDutyReminder(ctx, userID, dutyDate, timeSlot, location); err != nil {
+		logger.Warn("send duty reminder failed", zap.Error(err))
+	}
+}

--- a/backend/internal/equipment/dto/equipment.go
+++ b/backend/internal/equipment/dto/equipment.go
@@ -1,0 +1,264 @@
+package dto
+
+import "time"
+
+// ========== 请求 DTO ==========
+
+// ListEquipmentRequest 物资列表查询
+type ListEquipmentRequest struct {
+	Page     int    `form:"page,default=1" binding:"min=1"`
+	PageSize int    `form:"page_size,default=20" binding:"min=1,max=100"`
+	Keyword  string `form:"keyword"`
+	Category string `form:"category"`
+	Status   *int   `form:"status" binding:"omitempty,oneof=0 1 2 3 4"`
+}
+
+// CreateEquipmentRequest 入库
+type CreateEquipmentRequest struct {
+	Name           string  `json:"name" binding:"required,min=1,max=100"`
+	Model          string  `json:"model" binding:"omitempty,max=100"`
+	Category       string  `json:"category" binding:"required,oneof=general electronic book tool other"`
+	TotalQuantity  int     `json:"total_quantity" binding:"required,min=1"`
+	Location       string  `json:"location" binding:"omitempty,max=200"`
+	ManagerID      string  `json:"manager_id"`
+	PhotoFileID    string  `json:"photo_file_id"`
+	QRCode         string  `json:"qr_code" binding:"omitempty,max=500"`
+	Description    string  `json:"description"`
+	PurchaseDate   string  `json:"purchase_date" binding:"omitempty,datetime=2006-01-02"`
+	PurchasePrice  *float64 `json:"purchase_price"`
+}
+
+// UpdateEquipmentRequest 更新物资
+type UpdateEquipmentRequest struct {
+	Name           string  `json:"name" binding:"omitempty,max=100"`
+	Model          string  `json:"model" binding:"omitempty,max=100"`
+	Category       string  `json:"category" binding:"omitempty,oneof=general electronic book tool other"`
+	TotalQuantity  *int    `json:"total_quantity" binding:"omitempty,min=1"`
+	Location       string  `json:"location" binding:"omitempty,max=200"`
+	ManagerID     *string `json:"manager_id"`
+	PhotoFileID    *string `json:"photo_file_id"`
+	Status         *int    `json:"status" binding:"omitempty,oneof=0 1 2 3 4"`
+	QRCode         string  `json:"qr_code" binding:"omitempty,max=500"`
+	Description    string  `json:"description"`
+	PurchaseDate   *string `json:"purchase_date"`
+	PurchasePrice  *float64 `json:"purchase_price"`
+}
+
+// BorrowRequest 借用申请
+type BorrowRequest struct {
+	EquipmentID      string `json:"equipment_id" binding:"required"`
+	Quantity         int    `json:"quantity" binding:"required,min=1"`
+	ExpectedReturnAt string `json:"expected_return_at" binding:"required"` // RFC3339
+	Remark           string `json:"remark" binding:"omitempty,max=500"`
+}
+
+// BorrowActionRequest 借用审批
+type BorrowActionRequest struct {
+	Status int    `json:"status" binding:"required,oneof=1 4"` // 1=批准 4=拒绝
+	Remark string `json:"remark" binding:"omitempty,max=500"`
+}
+
+// ReturnRequest 归还确认
+type ReturnRequest struct {
+	Remark string `json:"remark" binding:"omitempty,max=500"`
+}
+
+// ListBorrowRequest 借用记录查询
+type ListBorrowRequest struct {
+	Page       int    `form:"page,default=1" binding:"min=1"`
+	PageSize   int    `form:"page_size,default=20" binding:"min=1,max=100"`
+	EquipmentID string `form:"equipment_id"`
+	BorrowerID string `form:"borrower_id"`
+	Status     *int   `form:"status"`
+}
+
+// CreateMaintenanceRequest 维修记录
+type CreateMaintenanceRequest struct {
+	EquipmentID string  `json:"equipment_id" binding:"required"`
+	Type        int     `json:"type" binding:"required,oneof=0 1 2"`
+	Description string  `json:"description" binding:"required,min=5,max=500"`
+	Cost        *float64 `json:"cost"`
+	StartDate   string  `json:"start_date" binding:"required"` // YYYY-MM-DD
+	EndDate     string  `json:"end_date" binding:"omitempty"`
+	Remark      string  `json:"remark" binding:"omitempty,max=500"`
+}
+
+// CreateInventoryRequest 库存盘点
+type CreateInventoryRequest struct {
+	EquipmentID      string `json:"equipment_id" binding:"required"`
+	ActualQuantity   int    `json:"actual_quantity" binding:"required,min=0"`
+	Remark           string `json:"remark" binding:"omitempty,max=500"`
+}
+
+// ========== 响应 DTO ==========
+
+// EquipmentResponse 物资响应
+type EquipmentResponse struct {
+	ID                string  `json:"id"`
+	Name              string  `json:"name"`
+	Model             string  `json:"model"`
+	Category          string  `json:"category"`
+	CategoryText      string  `json:"category_text"`
+	TotalQuantity     int     `json:"total_quantity"`
+	AvailableQuantity int     `json:"available_quantity"`
+	Location          string  `json:"location"`
+	ManagerID         string  `json:"manager_id"`
+	ManagerName       string  `json:"manager_name"`
+	PhotoFileID       string  `json:"photo_file_id"`
+	PhotoURL          string  `json:"photo_url"`
+	Status            int     `json:"status"`
+	StatusText        string  `json:"status_text"`
+	QRCode            string  `json:"qr_code"`
+	Description       string  `json:"description"`
+	PurchaseDate      string  `json:"purchase_date"`
+	PurchasePrice     float64 `json:"purchase_price"`
+	CreatedAt         string  `json:"created_at"`
+	UpdatedAt         string  `json:"updated_at"`
+}
+
+// BorrowResponse 借用记录响应
+type BorrowResponse struct {
+	ID               string `json:"id"`
+	EquipmentID      string `json:"equipment_id"`
+	EquipmentName    string `json:"equipment_name"`
+	BorrowerID       string `json:"borrower_id"`
+	BorrowerName     string `json:"borrower_name"`
+	Quantity         int    `json:"quantity"`
+	BorrowAt         string `json:"borrow_at"`
+	ExpectedReturnAt string `json:"expected_return_at"`
+	ActualReturnAt   string `json:"actual_return_at"`
+	Status           int    `json:"status"`
+	StatusText       string `json:"status_text"`
+	ApproverID       string `json:"approver_id"`
+	ApproverName     string `json:"approver_name"`
+	ApprovedAt       string `json:"approved_at"`
+	ApprovedRemark   string `json:"approved_remark"`
+	ReturnRemark     string `json:"return_remark"`
+	ReturnCheckerID  string `json:"return_checker_id"`
+	Remark           string `json:"remark"`
+	CreatedAt        string `json:"created_at"`
+	UpdatedAt        string `json:"updated_at"`
+}
+
+// MaintenanceResponse 维修记录响应
+type MaintenanceResponse struct {
+	ID           string  `json:"id"`
+	EquipmentID  string  `json:"equipment_id"`
+	EquipmentName string `json:"equipment_name"`
+	Type         int     `json:"type"`
+	TypeText     string  `json:"type_text"`
+	Description string  `json:"description"`
+	Cost         float64 `json:"cost"`
+	StartDate    string  `json:"start_date"`
+	EndDate      string  `json:"end_date"`
+	Status       int     `json:"status"`
+	StatusText   string  `json:"status_text"`
+	OperatorID   string  `json:"operator_id"`
+	Remark       string  `json:"remark"`
+	CreatedAt    string  `json:"created_at"`
+}
+
+// InventoryResponse 盘点记录响应
+type InventoryResponse struct {
+	ID               string `json:"id"`
+	EquipmentID      string `json:"equipment_id"`
+	EquipmentName    string `json:"equipment_name"`
+	ExpectedQuantity int    `json:"expected_quantity"`
+	ActualQuantity   int    `json:"actual_quantity"`
+	Difference       int    `json:"difference"`
+	CheckerID       string `json:"checker_id"`
+	CheckDate        string `json:"check_date"`
+	Remark           string `json:"remark"`
+	CreatedAt        string `json:"created_at"`
+}
+
+// ========== 文本映射 ==========
+
+var equipmentStatusText = map[int]string{
+	0: "可用", 1: "部分借用", 2: "全部借出", 3: "维修中", 4: "已报废",
+}
+
+var borrowStatusText = map[int]string{
+	0: "待审批", 1: "已批准", 2: "已领取", 3: "已归还", 4: "已拒绝", 5: "逾期",
+}
+
+var maintenanceTypeText = map[int]string{
+	0: "维修", 1: "保养", 2: "报废",
+}
+
+var maintenanceStatusText = map[int]string{
+	0: "进行中", 1: "已完成", 2: "已取消",
+}
+
+var equipmentCategoryText = map[string]string{
+	"general": "通用", "electronic": "电子设备", "book": "书籍", "tool": "工具", "other": "其他",
+}
+
+func GetEquipmentStatusText(status int) string {
+	if t, ok := equipmentStatusText[status]; ok {
+		return t
+	}
+	return "未知"
+}
+
+func GetBorrowStatusText(status int) string {
+	if t, ok := borrowStatusText[status]; ok {
+		return t
+	}
+	return "未知"
+}
+
+func GetMaintenanceTypeText(t int) string {
+	if s, ok := maintenanceTypeText[t]; ok {
+		return s
+	}
+	return "未知"
+}
+
+func GetMaintenanceStatusText(s int) string {
+	if t, ok := maintenanceStatusText[s]; ok {
+		return t
+	}
+	return "未知"
+}
+
+func GetCategoryText(c string) string {
+	if t, ok := equipmentCategoryText[c]; ok {
+		return t
+	}
+	return "其他"
+}
+
+// FormatTime 格式化时间
+func FormatTime(t time.Time) string {
+	return t.Format(time.RFC3339)
+}
+
+// FormatTimePtr 格式化可空时间
+func FormatTimePtr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}
+
+// FormatDate 格式化日期
+func FormatDate(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+// FormatDatePtr 格式化可空日期
+func FormatDatePtr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}
+
+// FormatFloat 格式化浮点数
+func FormatFloatPtr(f *float64) float64 {
+	if f == nil {
+		return 0
+	}
+	return *f
+}

--- a/backend/internal/equipment/handler/equipment_handler.go
+++ b/backend/internal/equipment/handler/equipment_handler.go
@@ -1,0 +1,262 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/service"
+	authmiddleware "github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// EquipmentHandler 物资处理器
+type EquipmentHandler struct {
+	svc service.EquipmentService
+}
+
+func NewEquipmentHandler(svc service.EquipmentService) *EquipmentHandler {
+	return &EquipmentHandler{svc: svc}
+}
+
+// ListEquipment 物资列表
+func (h *EquipmentHandler) ListEquipment(c *gin.Context) {
+	var req dto.ListEquipmentRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	list, total, err := h.svc.ListEquipment(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.Page(c, list, total, req.Page, req.PageSize)
+}
+
+// CreateEquipment 入库
+func (h *EquipmentHandler) CreateEquipment(c *gin.Context) {
+	var req dto.CreateEquipmentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	creatorID := authmiddleware.GetUserID(c)
+	result, err := h.svc.CreateEquipment(c.Request.Context(), &req, creatorID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, response.Response{
+		Code:      response.CodeSuccess,
+		Message:   "success",
+		Data:      result,
+		RequestID: c.GetString("request_id"),
+	})
+}
+
+// UpdateEquipment 更新物资
+func (h *EquipmentHandler) UpdateEquipment(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的物资ID")
+		return
+	}
+	var req dto.UpdateEquipmentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	result, err := h.svc.UpdateEquipment(c.Request.Context(), id, &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, result)
+}
+
+// DeleteEquipment 删除物资
+func (h *EquipmentHandler) DeleteEquipment(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的物资ID")
+		return
+	}
+	err = h.svc.DeleteEquipment(c.Request.Context(), id)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OKWithoutData(c)
+}
+
+// CreateBorrow 借用申请
+func (h *EquipmentHandler) CreateBorrow(c *gin.Context) {
+	var req dto.BorrowRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	borrowerID := authmiddleware.GetUserID(c)
+	result, err := h.svc.CreateBorrow(c.Request.Context(), &req, borrowerID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, response.Response{
+		Code:      response.CodeSuccess,
+		Message:   "success",
+		Data:      result,
+		RequestID: c.GetString("request_id"),
+	})
+}
+
+// ActionBorrow 借用审批
+func (h *EquipmentHandler) ActionBorrow(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的借用记录ID")
+		return
+	}
+	var req dto.BorrowActionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	approverID := authmiddleware.GetUserID(c)
+	result, err := h.svc.ActionBorrow(c.Request.Context(), id, &req, approverID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, result)
+}
+
+// ReturnBorrow 归还确认
+func (h *EquipmentHandler) ReturnBorrow(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		response.BadRequest(c, "无效的借用记录ID")
+		return
+	}
+	var req dto.ReturnRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	checkerID := authmiddleware.GetUserID(c)
+	result, err := h.svc.ReturnBorrow(c.Request.Context(), id, &req, checkerID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.OK(c, result)
+}
+
+// ListBorrows 借用记录列表
+func (h *EquipmentHandler) ListBorrows(c *gin.Context) {
+	var req dto.ListBorrowRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	list, total, err := h.svc.ListBorrows(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.Page(c, list, total, req.Page, req.PageSize)
+}
+
+// CreateMaintenance 维修记录
+func (h *EquipmentHandler) CreateMaintenance(c *gin.Context) {
+	var req dto.CreateMaintenanceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	operatorID := authmiddleware.GetUserID(c)
+	result, err := h.svc.CreateMaintenance(c.Request.Context(), &req, operatorID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, response.Response{
+		Code:      response.CodeSuccess,
+		Message:   "success",
+		Data:      result,
+		RequestID: c.GetString("request_id"),
+	})
+}
+
+// ListMaintenance 维修记录列表
+func (h *EquipmentHandler) ListMaintenance(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 20
+	}
+	equipmentID := c.Query("equipment_id")
+	var status *int
+	if s := c.Query("status"); s != "" {
+		v, err := strconv.Atoi(s)
+		if err == nil {
+			status = &v
+		}
+	}
+	list, total, err := h.svc.ListMaintenance(c.Request.Context(), page, pageSize, equipmentID, status)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.Page(c, list, total, page, pageSize)
+}
+
+// CreateInventory 库存盘点
+func (h *EquipmentHandler) CreateInventory(c *gin.Context) {
+	var req dto.CreateInventoryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "参数错误: "+err.Error())
+		return
+	}
+	checkerID := authmiddleware.GetUserID(c)
+	result, err := h.svc.CreateInventory(c.Request.Context(), &req, checkerID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, response.Response{
+		Code:      response.CodeSuccess,
+		Message:   "success",
+		Data:      result,
+		RequestID: c.GetString("request_id"),
+	})
+}
+
+// ListInventory 盘点记录列表
+func (h *EquipmentHandler) ListInventory(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 20
+	}
+	equipmentID := c.Query("equipment_id")
+	list, total, err := h.svc.ListInventory(c.Request.Context(), page, pageSize, equipmentID)
+	if err != nil {
+		response.Error(c, err)
+		return
+	}
+	response.Page(c, list, total, page, pageSize)
+}

--- a/backend/internal/equipment/handler/equipment_handler_test.go
+++ b/backend/internal/equipment/handler/equipment_handler_test.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/model"
+)
+
+func TestGetEquipmentStatusText(t *testing.T) {
+	for _, tt := range []struct {
+		status int
+		want   string
+	}{
+		{0, "可用"}, {1, "部分借用"}, {2, "全部借出"}, {3, "维修中"}, {4, "已报废"}, {99, "未知"},
+	} {
+		if got := dto.GetEquipmentStatusText(tt.status); got != tt.want {
+			t.Errorf("GetEquipmentStatusText(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestGetBorrowStatusText(t *testing.T) {
+	for _, tt := range []struct {
+		status int
+		want   string
+	}{
+		{0, "待审批"}, {1, "已批准"}, {2, "已领取"}, {3, "已归还"}, {4, "已拒绝"}, {5, "逾期"}, {99, "未知"},
+	} {
+		if got := dto.GetBorrowStatusText(tt.status); got != tt.want {
+			t.Errorf("GetBorrowStatusText(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestGetCategoryText(t *testing.T) {
+	for _, tt := range []struct {
+		cat  string
+		want string
+	}{
+		{"general", "通用"}, {"electronic", "电子设备"}, {"book", "书籍"}, {"tool", "工具"}, {"other", "其他"}, {"unknown", "其他"},
+	} {
+		if got := dto.GetCategoryText(tt.cat); got != tt.want {
+			t.Errorf("GetCategoryText(%q) = %q, want %q", tt.cat, got, tt.want)
+		}
+	}
+}
+
+func TestEquipmentModelConstants(t *testing.T) {
+	if model.EquipmentStatusAvailable != 0 {
+		t.Error("expected EquipmentStatusAvailable = 0")
+	}
+	if model.BorrowStatusPending != 0 {
+		t.Error("expected BorrowStatusPending = 0")
+	}
+	if model.MaintenanceTypeRepair != 0 {
+		t.Error("expected MaintenanceTypeRepair = 0")
+	}
+}
+
+func TestEquipmentTableNames(t *testing.T) {
+	if (model.Equipment{}).TableName() != "equipment_items" {
+		t.Error("wrong equipment table name")
+	}
+	if (model.Borrow{}).TableName() != "equipment_borrows" {
+		t.Error("wrong borrow table name")
+	}
+	if (model.Maintenance{}).TableName() != "equipment_maintenance" {
+		t.Error("wrong maintenance table name")
+	}
+	if (model.Inventory{}).TableName() != "equipment_inventories" {
+		t.Error("wrong inventory table name")
+	}
+}
+
+func TestNewEquipmentHandler(t *testing.T) {
+	h := NewEquipmentHandler(nil)
+	if h == nil {
+		t.Error("expected non-nil handler")
+	}
+}

--- a/backend/internal/equipment/handler/routes.go
+++ b/backend/internal/equipment/handler/routes.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func withPermission(group *gin.RouterGroup, permCode string, cacheService rbacService.PermissionCacheService) *gin.RouterGroup {
+	g := group.Group("")
+	g.Use(middleware.RequirePermission(permCode))
+	g.Use(middleware.PermissionRequired(cacheService))
+	return g
+}
+
+// RegisterRoutes 注册 /api/v1/equipment 路由
+func RegisterRoutes(
+	r *gin.RouterGroup,
+	h *EquipmentHandler,
+	cacheService rbacService.PermissionCacheService,
+) {
+	equip := r.Group("/equipment")
+
+	// 读取权限
+	read := withPermission(equip, "equipment:read", cacheService)
+	read.GET("", h.ListEquipment)
+	read.GET("/:id/records", h.ListBorrows)
+
+	// 入库
+	create := withPermission(equip, "equipment:create", cacheService)
+	create.POST("", h.CreateEquipment)
+
+	// 更新（归还确认也用 update 权限）
+	update := withPermission(equip, "equipment:update", cacheService)
+	update.PUT("/:id", h.UpdateEquipment)
+	update.PUT("/borrow/:id/return", h.ReturnBorrow)
+	update.PUT("/borrow/:id/approve", h.ActionBorrow)
+	update.POST("/maintenance", h.CreateMaintenance)
+	update.GET("/maintenance", h.ListMaintenance)
+	update.POST("/inventory", h.CreateInventory)
+	update.GET("/inventory", h.ListInventory)
+
+	// 删除
+	del := withPermission(equip, "equipment:delete", cacheService)
+	del.DELETE("/:id", h.DeleteEquipment)
+
+	// 借用申请（登录即可）
+	equip.POST("/borrow", h.CreateBorrow)
+	// 借用记录列表（登录即可查自己的）
+	equip.GET("/borrow", h.ListBorrows)
+}

--- a/backend/internal/equipment/model/equipment.go
+++ b/backend/internal/equipment/model/equipment.go
@@ -1,0 +1,132 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Equipment 物资/设备
+type Equipment struct {
+	ID                uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Name              string         `gorm:"type:varchar(100);not null;index" json:"name"`
+	Model             string         `gorm:"type:varchar(100)" json:"model"`
+	Category          string         `gorm:"type:varchar(50);not null;default:general;index" json:"category"`
+	TotalQuantity     int            `gorm:"not null;default:1" json:"total_quantity"`
+	AvailableQuantity int            `gorm:"not null;default:1" json:"available_quantity"`
+	Location          string         `gorm:"type:varchar(200)" json:"location"`
+	ManagerID         *uuid.UUID     `gorm:"type:uuid;index" json:"manager_id"`
+	PhotoFileID       *uuid.UUID     `gorm:"type:uuid" json:"photo_file_id"`
+	Status            int            `gorm:"type:smallint;not null;default:0;index" json:"status"`
+	QRCode            string         `gorm:"type:varchar(500)" json:"qr_code"`
+	Description       string         `gorm:"type:text" json:"description"`
+	PurchaseDate      *time.Time     `gorm:"type:date" json:"purchase_date"`
+	PurchasePrice     *float64       `gorm:"type:numeric(12,2)" json:"purchase_price"`
+	CreatedBy         *uuid.UUID     `gorm:"type:uuid" json:"created_by"`
+	CreatedAt         time.Time      `json:"created_at"`
+	UpdatedAt         time.Time      `json:"updated_at"`
+	DeletedAt         gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (Equipment) TableName() string {
+	return "equipment_items"
+}
+
+// Borrow 借用记录
+type Borrow struct {
+	ID               uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	EquipmentID      uuid.UUID      `gorm:"type:uuid;not null;index" json:"equipment_id"`
+	BorrowerID       uuid.UUID      `gorm:"type:uuid;not null;index" json:"borrower_id"`
+	Quantity         int            `gorm:"not null;default:1" json:"quantity"`
+	BorrowAt         time.Time      `gorm:"not null" json:"borrow_at"`
+	ExpectedReturnAt time.Time      `gorm:"not null" json:"expected_return_at"`
+	ActualReturnAt   *time.Time     `json:"actual_return_at"`
+	Status           int            `gorm:"type:smallint;not null;default:0;index" json:"status"`
+	ApproverID       *uuid.UUID     `gorm:"type:uuid" json:"approver_id"`
+	ApprovedAt       *time.Time     `json:"approved_at"`
+	ApprovedRemark   string         `gorm:"type:varchar(500)" json:"approved_remark"`
+	ReturnRemark     string         `gorm:"type:varchar(500)" json:"return_remark"`
+	ReturnCheckerID  *uuid.UUID     `gorm:"type:uuid" json:"return_checker_id"`
+	Remark           string         `gorm:"type:varchar(500)" json:"remark"`
+	CreatedAt        time.Time      `json:"created_at"`
+	UpdatedAt        time.Time      `json:"updated_at"`
+	DeletedAt         gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (Borrow) TableName() string {
+	return "equipment_borrows"
+}
+
+// Maintenance 维修记录
+type Maintenance struct {
+	ID           uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	EquipmentID  uuid.UUID      `gorm:"type:uuid;not null;index" json:"equipment_id"`
+	Type         int            `gorm:"type:smallint;not null;default:0" json:"type"` // 0=维修 1=保养 2=报废
+	Description string         `gorm:"type:varchar(500);not null" json:"description"`
+	Cost         *float64       `gorm:"type:numeric(12,2)" json:"cost"`
+	StartDate    time.Time      `gorm:"type:date;not null" json:"start_date"`
+	EndDate      *time.Time     `gorm:"type:date" json:"end_date"`
+	Status       int            `gorm:"type:smallint;not null;default:0;index" json:"status"` // 0=进行中 1=已完成 2=已取消
+	OperatorID   *uuid.UUID     `gorm:"type:uuid" json:"operator_id"`
+	Remark       string         `gorm:"type:varchar(500)" json:"remark"`
+	CreatedAt    time.Time      `json:"created_at"`
+	UpdatedAt    time.Time      `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (Maintenance) TableName() string {
+	return "equipment_maintenance"
+}
+
+// Inventory 库存盘点
+type Inventory struct {
+	ID               uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	EquipmentID      uuid.UUID      `gorm:"type:uuid;not null;index" json:"equipment_id"`
+	ExpectedQuantity int            `gorm:"not null" json:"expected_quantity"`
+	ActualQuantity   int            `gorm:"not null" json:"actual_quantity"`
+	Difference       int            `gorm:"not null;default:0" json:"difference"`
+	CheckerID        *uuid.UUID     `gorm:"type:uuid" json:"checker_id"`
+	CheckDate        time.Time      `gorm:"type:date;not null;index" json:"check_date"`
+	Remark           string         `gorm:"type:varchar(500)" json:"remark"`
+	CreatedAt        time.Time      `json:"created_at"`
+	UpdatedAt        time.Time      `json:"updated_at"`
+	DeletedAt         gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (Inventory) TableName() string {
+	return "equipment_inventories"
+}
+
+// 物资状态常量
+const (
+	EquipmentStatusAvailable    = 0 // 可用
+	EquipmentStatusPartBorrowed = 1 // 部分借用
+	EquipmentStatusAllBorrowed  = 2 // 全部借出
+	EquipmentStatusRepairing    = 3 // 维修中
+	EquipmentStatusScrapped     = 4 // 已报废
+)
+
+// 借用状态常量
+const (
+	BorrowStatusPending  = 0 // 待审批
+	BorrowStatusApproved = 1 // 已批准
+	BorrowStatusTaken    = 2 // 已领取
+	BorrowStatusReturned = 3 // 已归还
+	BorrowStatusRejected = 4 // 已拒绝
+	BorrowStatusOverdue  = 5 // 逾期
+)
+
+// 维修类型常量
+const (
+	MaintenanceTypeRepair  = 0 // 维修
+	MaintenanceTypeService = 1 // 保养
+	MaintenanceTypeScrap   = 2 // 报废
+)
+
+// 维修状态常量
+const (
+	MaintenanceStatusInProgress = 0 // 进行中
+	MaintenanceStatusCompleted  = 1 // 已完成
+	MaintenanceStatusCanceled   = 2 // 已取消
+)

--- a/backend/internal/equipment/repo/equipment_repo.go
+++ b/backend/internal/equipment/repo/equipment_repo.go
@@ -1,0 +1,267 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/model"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// EquipmentRepo 物资数据访问接口
+type EquipmentRepo interface {
+	Create(ctx context.Context, tx *gorm.DB, e *model.Equipment) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Equipment, error)
+	Update(ctx context.Context, tx *gorm.DB, e *model.Equipment) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	List(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.Equipment, int64, error)
+	UpdateAvailableQuantity(ctx context.Context, tx *gorm.DB, id uuid.UUID, delta int) error
+}
+
+type equipmentRepo struct {
+	db *gorm.DB
+}
+
+func NewEquipmentRepo(db *gorm.DB) EquipmentRepo {
+	return &equipmentRepo{db: db}
+}
+
+func (r *equipmentRepo) getDB(tx *gorm.DB) *gorm.DB {
+	if tx != nil {
+		return tx
+	}
+	return r.db
+}
+
+func (r *equipmentRepo) Create(ctx context.Context, tx *gorm.DB, e *model.Equipment) error {
+	return r.getDB(tx).WithContext(ctx).Create(e).Error
+}
+
+func (r *equipmentRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Equipment, error) {
+	var e model.Equipment
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&e).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &e, err
+}
+
+func (r *equipmentRepo) Update(ctx context.Context, tx *gorm.DB, e *model.Equipment) error {
+	return r.getDB(tx).WithContext(ctx).Save(e).Error
+}
+
+func (r *equipmentRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.db.WithContext(ctx).Delete(&model.Equipment{}, id).Error
+}
+
+func (r *equipmentRepo) List(ctx context.Context, page, pageSize int, keyword, category string, status *int) ([]model.Equipment, int64, error) {
+	var items []model.Equipment
+	var total int64
+
+	query := r.db.WithContext(ctx).Model(&model.Equipment{})
+
+	if keyword != "" {
+		query = query.Where("name LIKE ? OR model LIKE ?", "%"+keyword+"%", "%"+keyword+"%")
+	}
+	if category != "" {
+		query = query.Where("category = ?", category)
+	}
+	if status != nil {
+		query = query.Where("status = ?", *status)
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	offset := (page - 1) * pageSize
+	err := query.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&items).Error
+	return items, total, err
+}
+
+func (r *equipmentRepo) UpdateAvailableQuantity(ctx context.Context, tx *gorm.DB, id uuid.UUID, delta int) error {
+	return r.getDB(tx).WithContext(ctx).Model(&model.Equipment{}).
+		Where("id = ?", id).
+		UpdateColumn("available_quantity", gorm.Expr("available_quantity + ?", delta)).Error
+}
+
+// BorrowRepo 借用记录数据访问接口
+type BorrowRepo interface {
+	Create(ctx context.Context, tx *gorm.DB, b *model.Borrow) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Borrow, error)
+	Update(ctx context.Context, tx *gorm.DB, b *model.Borrow) error
+	List(ctx context.Context, page, pageSize int, equipmentID, borrowerID uuid.UUID, status *int) ([]model.Borrow, int64, error)
+	FindOverdue(ctx context.Context, before time.Time) ([]model.Borrow, error)
+}
+
+type borrowRepo struct {
+	db *gorm.DB
+}
+
+func NewBorrowRepo(db *gorm.DB) BorrowRepo {
+	return &borrowRepo{db: db}
+}
+
+func (r *borrowRepo) getDB(tx *gorm.DB) *gorm.DB {
+	if tx != nil {
+		return tx
+	}
+	return r.db
+}
+
+func (r *borrowRepo) Create(ctx context.Context, tx *gorm.DB, b *model.Borrow) error {
+	return r.getDB(tx).WithContext(ctx).Create(b).Error
+}
+
+func (r *borrowRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Borrow, error) {
+	var b model.Borrow
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&b).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &b, err
+}
+
+func (r *borrowRepo) Update(ctx context.Context, tx *gorm.DB, b *model.Borrow) error {
+	return r.getDB(tx).WithContext(ctx).Save(b).Error
+}
+
+func (r *borrowRepo) List(ctx context.Context, page, pageSize int, equipmentID, borrowerID uuid.UUID, status *int) ([]model.Borrow, int64, error) {
+	var borrows []model.Borrow
+	var total int64
+
+	query := r.db.WithContext(ctx).Model(&model.Borrow{})
+
+	if equipmentID != uuid.Nil {
+		query = query.Where("equipment_id = ?", equipmentID)
+	}
+	if borrowerID != uuid.Nil {
+		query = query.Where("borrower_id = ?", borrowerID)
+	}
+	if status != nil {
+		query = query.Where("status = ?", *status)
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	offset := (page - 1) * pageSize
+	err := query.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&borrows).Error
+	return borrows, total, err
+}
+
+func (r *borrowRepo) FindOverdue(ctx context.Context, before time.Time) ([]model.Borrow, error) {
+	var borrows []model.Borrow
+	err := r.db.WithContext(ctx).
+		Where("status IN (1, 2) AND expected_return_at < ? AND deleted_at IS NULL", before).
+		Find(&borrows).Error
+	return borrows, err
+}
+
+// MaintenanceRepo 维修记录数据访问接口
+type MaintenanceRepo interface {
+	Create(ctx context.Context, tx *gorm.DB, m *model.Maintenance) error
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Maintenance, error)
+	Update(ctx context.Context, tx *gorm.DB, m *model.Maintenance) error
+	List(ctx context.Context, page, pageSize int, equipmentID uuid.UUID, status *int) ([]model.Maintenance, int64, error)
+}
+
+type maintenanceRepo struct {
+	db *gorm.DB
+}
+
+func NewMaintenanceRepo(db *gorm.DB) MaintenanceRepo {
+	return &maintenanceRepo{db: db}
+}
+
+func (r *maintenanceRepo) getDB(tx *gorm.DB) *gorm.DB {
+	if tx != nil {
+		return tx
+	}
+	return r.db
+}
+
+func (r *maintenanceRepo) Create(ctx context.Context, tx *gorm.DB, m *model.Maintenance) error {
+	return r.getDB(tx).WithContext(ctx).Create(m).Error
+}
+
+func (r *maintenanceRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Maintenance, error) {
+	var m model.Maintenance
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&m).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	return &m, err
+}
+
+func (r *maintenanceRepo) Update(ctx context.Context, tx *gorm.DB, m *model.Maintenance) error {
+	return r.getDB(tx).WithContext(ctx).Save(m).Error
+}
+
+func (r *maintenanceRepo) List(ctx context.Context, page, pageSize int, equipmentID uuid.UUID, status *int) ([]model.Maintenance, int64, error) {
+	var records []model.Maintenance
+	var total int64
+
+	query := r.db.WithContext(ctx).Model(&model.Maintenance{})
+
+	if equipmentID != uuid.Nil {
+		query = query.Where("equipment_id = ?", equipmentID)
+	}
+	if status != nil {
+		query = query.Where("status = ?", *status)
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	offset := (page - 1) * pageSize
+	err := query.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&records).Error
+	return records, total, err
+}
+
+// InventoryRepo 盘点记录数据访问接口
+type InventoryRepo interface {
+	Create(ctx context.Context, tx *gorm.DB, inv *model.Inventory) error
+	List(ctx context.Context, page, pageSize int, equipmentID uuid.UUID) ([]model.Inventory, int64, error)
+}
+
+type inventoryRepo struct {
+	db *gorm.DB
+}
+
+func NewInventoryRepo(db *gorm.DB) InventoryRepo {
+	return &inventoryRepo{db: db}
+}
+
+func (r *inventoryRepo) getDB(tx *gorm.DB) *gorm.DB {
+	if tx != nil {
+		return tx
+	}
+	return r.db
+}
+
+func (r *inventoryRepo) Create(ctx context.Context, tx *gorm.DB, inv *model.Inventory) error {
+	return r.getDB(tx).WithContext(ctx).Create(inv).Error
+}
+
+func (r *inventoryRepo) List(ctx context.Context, page, pageSize int, equipmentID uuid.UUID) ([]model.Inventory, int64, error) {
+	var records []model.Inventory
+	var total int64
+
+	query := r.db.WithContext(ctx).Model(&model.Inventory{})
+
+	if equipmentID != uuid.Nil {
+		query = query.Where("equipment_id = ?", equipmentID)
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	offset := (page - 1) * pageSize
+	err := query.Order("check_date DESC, created_at DESC").Offset(offset).Limit(pageSize).Find(&records).Error
+	return records, total, err
+}

--- a/backend/internal/equipment/service/equipment_service.go
+++ b/backend/internal/equipment/service/equipment_service.go
@@ -1,0 +1,709 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/model"
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// EquipmentNotifier 通知接口
+type EquipmentNotifier interface {
+	NotifyBorrowApproved(ctx context.Context, userID uuid.UUID, equipmentName string) error
+	NotifyBorrowRejected(ctx context.Context, userID uuid.UUID, equipmentName, remark string) error
+	NotifyOverdue(ctx context.Context, userID uuid.UUID, equipmentName string, expectedReturn time.Time) error
+	NotifyMaintenanceStart(ctx context.Context, userID uuid.UUID, equipmentName string) error
+}
+
+// EquipmentService 物资服务接口
+type EquipmentService interface {
+	ListEquipment(ctx context.Context, req *dto.ListEquipmentRequest) ([]dto.EquipmentResponse, int64, error)
+	CreateEquipment(ctx context.Context, req *dto.CreateEquipmentRequest, creatorID string) (*dto.EquipmentResponse, error)
+	UpdateEquipment(ctx context.Context, id uuid.UUID, req *dto.UpdateEquipmentRequest) (*dto.EquipmentResponse, error)
+	DeleteEquipment(ctx context.Context, id uuid.UUID) error
+
+	CreateBorrow(ctx context.Context, req *dto.BorrowRequest, borrowerID string) (*dto.BorrowResponse, error)
+	ActionBorrow(ctx context.Context, id uuid.UUID, req *dto.BorrowActionRequest, approverID string) (*dto.BorrowResponse, error)
+	ReturnBorrow(ctx context.Context, id uuid.UUID, req *dto.ReturnRequest, checkerID string) (*dto.BorrowResponse, error)
+	ListBorrows(ctx context.Context, req *dto.ListBorrowRequest) ([]dto.BorrowResponse, int64, error)
+
+	CreateMaintenance(ctx context.Context, req *dto.CreateMaintenanceRequest, operatorID string) (*dto.MaintenanceResponse, error)
+	ListMaintenance(ctx context.Context, page, pageSize int, equipmentID string, status *int) ([]dto.MaintenanceResponse, int64, error)
+
+	CreateInventory(ctx context.Context, req *dto.CreateInventoryRequest, checkerID string) (*dto.InventoryResponse, error)
+	ListInventory(ctx context.Context, page, pageSize int, equipmentID string) ([]dto.InventoryResponse, int64, error)
+}
+
+type equipmentService struct {
+	db           *gorm.DB
+	equipRepo    repo.EquipmentRepo
+	borrowRepo   repo.BorrowRepo
+	maintRepo    repo.MaintenanceRepo
+	inventoryRepo repo.InventoryRepo
+	notifier     EquipmentNotifier
+}
+
+func NewEquipmentService(
+	db *gorm.DB,
+	equipRepo repo.EquipmentRepo,
+	borrowRepo repo.BorrowRepo,
+	maintRepo repo.MaintenanceRepo,
+	inventoryRepo repo.InventoryRepo,
+	notifier EquipmentNotifier,
+) EquipmentService {
+	return &equipmentService{
+		db:            db,
+		equipRepo:     equipRepo,
+		borrowRepo:    borrowRepo,
+		maintRepo:     maintRepo,
+		inventoryRepo: inventoryRepo,
+		notifier:      notifier,
+	}
+}
+
+// ========== 物资管理 ==========
+
+func (s *equipmentService) ListEquipment(ctx context.Context, req *dto.ListEquipmentRequest) ([]dto.EquipmentResponse, int64, error) {
+	items, total, err := s.equipRepo.List(ctx, req.Page, req.PageSize, req.Keyword, req.Category, req.Status)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list equipment: %w", err)
+	}
+	result := make([]dto.EquipmentResponse, 0, len(items))
+	for _, e := range items {
+		result = append(result, *s.equipmentToResponse(&e))
+	}
+	return result, total, nil
+}
+
+func (s *equipmentService) CreateEquipment(ctx context.Context, req *dto.CreateEquipmentRequest, creatorID string) (*dto.EquipmentResponse, error) {
+	creatorUUID, _ := uuid.Parse(creatorID)
+
+	var managerID *uuid.UUID
+	if req.ManagerID != "" {
+		parsed, err := parseOptionalUUID(req.ManagerID, "负责人ID")
+		if err != nil {
+			return nil, err
+		}
+		managerID = parsed
+	}
+
+	var photoFileID *uuid.UUID
+	if req.PhotoFileID != "" {
+		parsed, err := parseOptionalUUID(req.PhotoFileID, "照片文件ID")
+		if err != nil {
+			return nil, err
+		}
+		photoFileID = parsed
+	}
+
+	var purchaseDate *time.Time
+	if req.PurchaseDate != "" {
+		t, err := time.Parse("2006-01-02", req.PurchaseDate)
+		if err != nil {
+			return nil, response.NewError(response.CodeBadRequest, "purchase_date 格式无效")
+		}
+		purchaseDate = &t
+	}
+
+	equipment := &model.Equipment{
+		ID:                uuid.New(),
+		Name:              req.Name,
+		Model:             req.Model,
+		Category:          req.Category,
+		TotalQuantity:     req.TotalQuantity,
+		AvailableQuantity: req.TotalQuantity,
+		Location:          req.Location,
+		ManagerID:         managerID,
+		PhotoFileID:       photoFileID,
+		QRCode:            req.QRCode,
+		Description:       req.Description,
+		PurchaseDate:      purchaseDate,
+		PurchasePrice:     req.PurchasePrice,
+		Status:            model.EquipmentStatusAvailable,
+		CreatedBy:         &creatorUUID,
+	}
+
+	err := s.equipRepo.Create(ctx, nil, equipment)
+	if err != nil {
+		return nil, fmt.Errorf("create equipment: %w", err)
+	}
+
+	return s.equipmentToResponse(equipment), nil
+}
+
+func (s *equipmentService) UpdateEquipment(ctx context.Context, id uuid.UUID, req *dto.UpdateEquipmentRequest) (*dto.EquipmentResponse, error) {
+	equipment, err := s.equipRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get equipment: %w", err)
+	}
+	if equipment == nil {
+		return nil, response.NewError(27001, "物资不存在")
+	}
+
+	if req.Name != "" {
+		equipment.Name = req.Name
+	}
+	if req.Model != "" {
+		equipment.Model = req.Model
+	}
+	if req.Category != "" {
+		equipment.Category = req.Category
+	}
+	if req.TotalQuantity != nil {
+		diff := *req.TotalQuantity - equipment.TotalQuantity
+		equipment.TotalQuantity = *req.TotalQuantity
+		equipment.AvailableQuantity += diff
+		if equipment.AvailableQuantity < 0 {
+			equipment.AvailableQuantity = 0
+		}
+	}
+	if req.Location != "" {
+		equipment.Location = req.Location
+	}
+	if req.ManagerID != nil {
+		if *req.ManagerID == "" {
+			equipment.ManagerID = nil
+		} else {
+			parsed, err := parseOptionalUUID(*req.ManagerID, "负责人ID")
+			if err != nil {
+				return nil, err
+			}
+			equipment.ManagerID = parsed
+		}
+	}
+	if req.PhotoFileID != nil {
+		if *req.PhotoFileID == "" {
+			equipment.PhotoFileID = nil
+		} else {
+			parsed, err := parseOptionalUUID(*req.PhotoFileID, "照片文件ID")
+			if err != nil {
+				return nil, err
+			}
+			equipment.PhotoFileID = parsed
+		}
+	}
+	if req.Status != nil {
+		equipment.Status = *req.Status
+	}
+	if req.QRCode != "" {
+		equipment.QRCode = req.QRCode
+	}
+	if req.Description != "" {
+		equipment.Description = req.Description
+	}
+	if req.PurchaseDate != nil {
+		t, err := time.Parse("2006-01-02", *req.PurchaseDate)
+		if err != nil {
+			return nil, response.NewError(response.CodeBadRequest, "purchase_date 格式无效")
+		}
+		equipment.PurchaseDate = &t
+	}
+	if req.PurchasePrice != nil {
+		equipment.PurchasePrice = req.PurchasePrice
+	}
+
+	err = s.equipRepo.Update(ctx, nil, equipment)
+	if err != nil {
+		return nil, fmt.Errorf("update equipment: %w", err)
+	}
+	return s.equipmentToResponse(equipment), nil
+}
+
+func (s *equipmentService) DeleteEquipment(ctx context.Context, id uuid.UUID) error {
+	equipment, err := s.equipRepo.GetByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get equipment: %w", err)
+	}
+	if equipment == nil {
+		return response.NewError(27001, "物资不存在")
+	}
+	if equipment.AvailableQuantity < equipment.TotalQuantity {
+		return response.NewError(27002, "物资有未归还的借用记录，不可删除")
+	}
+	return s.equipRepo.Delete(ctx, id)
+}
+
+// ========== 借用管理 ==========
+
+func (s *equipmentService) CreateBorrow(ctx context.Context, req *dto.BorrowRequest, borrowerID string) (*dto.BorrowResponse, error) {
+	bID, err := parseRequiredUUID(borrowerID, "借用人ID")
+	if err != nil {
+		return nil, err
+	}
+
+	equipID, err := parseRequiredUUID(req.EquipmentID, "物资ID")
+	if err != nil {
+		return nil, err
+	}
+
+	equipment, err := s.equipRepo.GetByID(ctx, equipID)
+	if err != nil {
+		return nil, fmt.Errorf("get equipment: %w", err)
+	}
+	if equipment == nil {
+		return nil, response.NewError(27001, "物资不存在")
+	}
+	if equipment.AvailableQuantity < req.Quantity {
+		return nil, response.NewError(27003, "可用数量不足")
+	}
+
+	expectedReturn, err := time.Parse(time.RFC3339, req.ExpectedReturnAt)
+	if err != nil {
+		return nil, response.NewError(response.CodeBadRequest, "expected_return_at 格式无效，应为 RFC3339")
+	}
+	if expectedReturn.Before(time.Now()) {
+		return nil, response.NewError(response.CodeBadRequest, "预计归还时间不能早于当前时间")
+	}
+
+	borrow := &model.Borrow{
+		ID:               uuid.New(),
+		EquipmentID:      equipID,
+		BorrowerID:       bID,
+		Quantity:         req.Quantity,
+		BorrowAt:         time.Now(),
+		ExpectedReturnAt: expectedReturn,
+		Status:           model.BorrowStatusPending,
+		Remark:           req.Remark,
+	}
+
+	err = s.borrowRepo.Create(ctx, nil, borrow)
+	if err != nil {
+		return nil, fmt.Errorf("create borrow: %w", err)
+	}
+
+	return s.borrowToResponse(borrow, equipment.Name), nil
+}
+
+func (s *equipmentService) ActionBorrow(ctx context.Context, id uuid.UUID, req *dto.BorrowActionRequest, approverID string) (*dto.BorrowResponse, error) {
+	borrow, err := s.borrowRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get borrow: %w", err)
+	}
+	if borrow == nil {
+		return nil, response.NewError(27004, "借用记录不存在")
+	}
+	if borrow.Status != model.BorrowStatusPending {
+		return nil, response.NewError(27005, "借用申请已处理，不可重复操作")
+	}
+
+	approverUUID, _ := uuid.Parse(approverID)
+	now := time.Now()
+	borrow.Status = req.Status
+	borrow.ApproverID = &approverUUID
+	borrow.ApprovedAt = &now
+	borrow.ApprovedRemark = req.Remark
+
+	equipment, err := s.equipRepo.GetByID(ctx, borrow.EquipmentID)
+	if err != nil {
+		return nil, fmt.Errorf("get equipment: %w", err)
+	}
+	if equipment == nil {
+		return nil, response.NewError(27001, "物资不存在")
+	}
+
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		if err := s.borrowRepo.Update(ctx, tx, borrow); err != nil {
+			return err
+		}
+		if req.Status == model.BorrowStatusApproved {
+			if equipment.AvailableQuantity < borrow.Quantity {
+				return response.NewError(27003, "可用数量不足")
+			}
+			if err := s.equipRepo.UpdateAvailableQuantity(ctx, tx, borrow.EquipmentID, -borrow.Quantity); err != nil {
+				return err
+			}
+			equipment.AvailableQuantity -= borrow.Quantity
+			if equipment.AvailableQuantity == 0 {
+				equipment.Status = model.EquipmentStatusAllBorrowed
+			} else {
+				equipment.Status = model.EquipmentStatusPartBorrowed
+			}
+			if err := s.equipRepo.Update(ctx, tx, equipment); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("action borrow: %w", err)
+	}
+
+	if s.notifier != nil {
+		go func() {
+			if req.Status == model.BorrowStatusApproved {
+				_ = s.notifier.NotifyBorrowApproved(context.Background(), borrow.BorrowerID, equipment.Name)
+			} else {
+				_ = s.notifier.NotifyBorrowRejected(context.Background(), borrow.BorrowerID, equipment.Name, req.Remark)
+			}
+		}()
+	}
+
+	return s.borrowToResponse(borrow, equipment.Name), nil
+}
+
+func (s *equipmentService) ReturnBorrow(ctx context.Context, id uuid.UUID, req *dto.ReturnRequest, checkerID string) (*dto.BorrowResponse, error) {
+	borrow, err := s.borrowRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("get borrow: %w", err)
+	}
+	if borrow == nil {
+		return nil, response.NewError(27004, "借用记录不存在")
+	}
+	if borrow.Status != model.BorrowStatusTaken && borrow.Status != model.BorrowStatusOverdue {
+		return nil, response.NewError(27006, "借用记录状态不允许归还")
+	}
+
+	checkerUUID, _ := uuid.Parse(checkerID)
+	now := time.Now()
+	borrow.Status = model.BorrowStatusReturned
+	borrow.ActualReturnAt = &now
+	borrow.ReturnRemark = req.Remark
+	borrow.ReturnCheckerID = &checkerUUID
+
+	equipment, err := s.equipRepo.GetByID(ctx, borrow.EquipmentID)
+	if err != nil {
+		return nil, fmt.Errorf("get equipment: %w", err)
+	}
+
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		if err := s.borrowRepo.Update(ctx, tx, borrow); err != nil {
+			return err
+		}
+		if err := s.equipRepo.UpdateAvailableQuantity(ctx, tx, borrow.EquipmentID, borrow.Quantity); err != nil {
+			return err
+		}
+		if equipment != nil {
+			equipment.AvailableQuantity += borrow.Quantity
+			if equipment.AvailableQuantity >= equipment.TotalQuantity {
+				equipment.Status = model.EquipmentStatusAvailable
+			} else if equipment.Status == model.EquipmentStatusAllBorrowed {
+				equipment.Status = model.EquipmentStatusPartBorrowed
+			}
+			if err := s.equipRepo.Update(ctx, tx, equipment); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("return borrow: %w", err)
+	}
+
+	equipName := ""
+	if equipment != nil {
+		equipName = equipment.Name
+	}
+	return s.borrowToResponse(borrow, equipName), nil
+}
+
+func (s *equipmentService) ListBorrows(ctx context.Context, req *dto.ListBorrowRequest) ([]dto.BorrowResponse, int64, error) {
+	var equipID uuid.UUID
+	if req.EquipmentID != "" {
+		parsed, err := parseRequiredUUID(req.EquipmentID, "物资ID")
+		if err != nil {
+			return nil, 0, err
+		}
+		equipID = parsed
+	}
+
+	var borrowerID uuid.UUID
+	if req.BorrowerID != "" {
+		parsed, err := parseRequiredUUID(req.BorrowerID, "借用人ID")
+		if err != nil {
+			return nil, 0, err
+		}
+		borrowerID = parsed
+	}
+
+	borrows, total, err := s.borrowRepo.List(ctx, req.Page, req.PageSize, equipID, borrowerID, req.Status)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list borrows: %w", err)
+	}
+
+	result := make([]dto.BorrowResponse, 0, len(borrows))
+	for _, b := range borrows {
+		result = append(result, *s.borrowToResponse(&b, ""))
+	}
+	return result, total, nil
+}
+
+// ========== 维修管理 ==========
+
+func (s *equipmentService) CreateMaintenance(ctx context.Context, req *dto.CreateMaintenanceRequest, operatorID string) (*dto.MaintenanceResponse, error) {
+	opUUID, _ := uuid.Parse(operatorID)
+	equipID, err := parseRequiredUUID(req.EquipmentID, "物资ID")
+	if err != nil {
+		return nil, err
+	}
+
+	equipment, err := s.equipRepo.GetByID(ctx, equipID)
+	if err != nil {
+		return nil, fmt.Errorf("get equipment: %w", err)
+	}
+	if equipment == nil {
+		return nil, response.NewError(27001, "物资不存在")
+	}
+
+	startDate, err := time.Parse("2006-01-02", req.StartDate)
+	if err != nil {
+		return nil, response.NewError(response.CodeBadRequest, "start_date 格式无效")
+	}
+
+	var endDate *time.Time
+	if req.EndDate != "" {
+		t, err := time.Parse("2006-01-02", req.EndDate)
+		if err != nil {
+			return nil, response.NewError(response.CodeBadRequest, "end_date 格式无效")
+		}
+		endDate = &t
+	}
+
+	maintenance := &model.Maintenance{
+		ID:          uuid.New(),
+		EquipmentID: equipID,
+		Type:        req.Type,
+		Description: req.Description,
+		Cost:        req.Cost,
+		StartDate:   startDate,
+		EndDate:     endDate,
+		Status:      model.MaintenanceStatusInProgress,
+		OperatorID:  &opUUID,
+		Remark:      req.Remark,
+	}
+
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		if err := s.maintRepo.Create(ctx, tx, maintenance); err != nil {
+			return err
+		}
+		if req.Type == model.MaintenanceTypeScrap {
+			equipment.Status = model.EquipmentStatusScrapped
+		} else {
+			equipment.Status = model.EquipmentStatusRepairing
+		}
+		return s.equipRepo.Update(ctx, tx, equipment)
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("create maintenance: %w", err)
+	}
+
+	return s.maintenanceToResponse(maintenance, equipment.Name), nil
+}
+
+func (s *equipmentService) ListMaintenance(ctx context.Context, page, pageSize int, equipmentID string, status *int) ([]dto.MaintenanceResponse, int64, error) {
+	var equipID uuid.UUID
+	if equipmentID != "" {
+		parsed, err := parseRequiredUUID(equipmentID, "物资ID")
+		if err != nil {
+			return nil, 0, err
+		}
+		equipID = parsed
+	}
+
+	records, total, err := s.maintRepo.List(ctx, page, pageSize, equipID, status)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list maintenance: %w", err)
+	}
+
+	result := make([]dto.MaintenanceResponse, 0, len(records))
+	for _, m := range records {
+		result = append(result, *s.maintenanceToResponse(&m, ""))
+	}
+	return result, total, nil
+}
+
+// ========== 库存盘点 ==========
+
+func (s *equipmentService) CreateInventory(ctx context.Context, req *dto.CreateInventoryRequest, checkerID string) (*dto.InventoryResponse, error) {
+	checkerUUID, _ := uuid.Parse(checkerID)
+	equipID, err := parseRequiredUUID(req.EquipmentID, "物资ID")
+	if err != nil {
+		return nil, err
+	}
+
+	equipment, err := s.equipRepo.GetByID(ctx, equipID)
+	if err != nil {
+		return nil, fmt.Errorf("get equipment: %w", err)
+	}
+	if equipment == nil {
+		return nil, response.NewError(27001, "物资不存在")
+	}
+
+	now := time.Now()
+	inventory := &model.Inventory{
+		ID:               uuid.New(),
+		EquipmentID:      equipID,
+		ExpectedQuantity: equipment.TotalQuantity,
+		ActualQuantity:   req.ActualQuantity,
+		Difference:       req.ActualQuantity - equipment.TotalQuantity,
+		CheckerID:        &checkerUUID,
+		CheckDate:        now,
+		Remark:           req.Remark,
+	}
+
+	err = s.inventoryRepo.Create(ctx, nil, inventory)
+	if err != nil {
+		return nil, fmt.Errorf("create inventory: %w", err)
+	}
+
+	return s.inventoryToResponse(inventory, equipment.Name), nil
+}
+
+func (s *equipmentService) ListInventory(ctx context.Context, page, pageSize int, equipmentID string) ([]dto.InventoryResponse, int64, error) {
+	var equipID uuid.UUID
+	if equipmentID != "" {
+		parsed, err := parseRequiredUUID(equipmentID, "物资ID")
+		if err != nil {
+			return nil, 0, err
+		}
+		equipID = parsed
+	}
+
+	records, total, err := s.inventoryRepo.List(ctx, page, pageSize, equipID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list inventory: %w", err)
+	}
+
+	result := make([]dto.InventoryResponse, 0, len(records))
+	for _, inv := range records {
+		result = append(result, *s.inventoryToResponse(&inv, ""))
+	}
+	return result, total, nil
+}
+
+// ========== 工具函数 ==========
+
+func (s *equipmentService) equipmentToResponse(e *model.Equipment) *dto.EquipmentResponse {
+	resp := &dto.EquipmentResponse{
+		ID:                e.ID.String(),
+		Name:              e.Name,
+		Model:             e.Model,
+		Category:          e.Category,
+		CategoryText:      dto.GetCategoryText(e.Category),
+		TotalQuantity:     e.TotalQuantity,
+		AvailableQuantity: e.AvailableQuantity,
+		Location:          e.Location,
+		Status:            e.Status,
+		StatusText:        dto.GetEquipmentStatusText(e.Status),
+		QRCode:            e.QRCode,
+		Description:       e.Description,
+		CreatedAt:         e.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:         e.UpdatedAt.Format(time.RFC3339),
+	}
+	if e.ManagerID != nil {
+		resp.ManagerID = e.ManagerID.String()
+	}
+	if e.PhotoFileID != nil {
+		resp.PhotoFileID = e.PhotoFileID.String()
+	}
+	if e.PurchaseDate != nil {
+		resp.PurchaseDate = e.PurchaseDate.Format("2006-01-02")
+	}
+	if e.PurchasePrice != nil {
+		resp.PurchasePrice = *e.PurchasePrice
+	}
+	return resp
+}
+
+func (s *equipmentService) borrowToResponse(b *model.Borrow, equipName string) *dto.BorrowResponse {
+	resp := &dto.BorrowResponse{
+		ID:               b.ID.String(),
+		EquipmentID:      b.EquipmentID.String(),
+		EquipmentName:    equipName,
+		BorrowerID:       b.BorrowerID.String(),
+		Quantity:         b.Quantity,
+		BorrowAt:         b.BorrowAt.Format(time.RFC3339),
+		ExpectedReturnAt: b.ExpectedReturnAt.Format(time.RFC3339),
+		Status:           b.Status,
+		StatusText:       dto.GetBorrowStatusText(b.Status),
+		ApprovedRemark:   b.ApprovedRemark,
+		ReturnRemark:     b.ReturnRemark,
+		Remark:           b.Remark,
+		CreatedAt:        b.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:        b.UpdatedAt.Format(time.RFC3339),
+	}
+	if b.ActualReturnAt != nil {
+		resp.ActualReturnAt = b.ActualReturnAt.Format(time.RFC3339)
+	}
+	if b.ApproverID != nil {
+		resp.ApproverID = b.ApproverID.String()
+	}
+	if b.ApprovedAt != nil {
+		resp.ApprovedAt = b.ApprovedAt.Format(time.RFC3339)
+	}
+	if b.ReturnCheckerID != nil {
+		resp.ReturnCheckerID = b.ReturnCheckerID.String()
+	}
+	return resp
+}
+
+func (s *equipmentService) maintenanceToResponse(m *model.Maintenance, equipName string) *dto.MaintenanceResponse {
+	resp := &dto.MaintenanceResponse{
+		ID:            m.ID.String(),
+		EquipmentID:   m.EquipmentID.String(),
+		EquipmentName: equipName,
+		Type:          m.Type,
+		TypeText:      dto.GetMaintenanceTypeText(m.Type),
+		Description:   m.Description,
+		StartDate:     m.StartDate.Format("2006-01-02"),
+		Status:        m.Status,
+		StatusText:    dto.GetMaintenanceStatusText(m.Status),
+		Remark:        m.Remark,
+		CreatedAt:     m.CreatedAt.Format(time.RFC3339),
+	}
+	if m.Cost != nil {
+		resp.Cost = *m.Cost
+	}
+	if m.EndDate != nil {
+		resp.EndDate = m.EndDate.Format("2006-01-02")
+	}
+	if m.OperatorID != nil {
+		resp.OperatorID = m.OperatorID.String()
+	}
+	return resp
+}
+
+func (s *equipmentService) inventoryToResponse(inv *model.Inventory, equipName string) *dto.InventoryResponse {
+	resp := &dto.InventoryResponse{
+		ID:               inv.ID.String(),
+		EquipmentID:      inv.EquipmentID.String(),
+		EquipmentName:    equipName,
+		ExpectedQuantity: inv.ExpectedQuantity,
+		ActualQuantity:   inv.ActualQuantity,
+		Difference:       inv.Difference,
+		CheckDate:        inv.CheckDate.Format("2006-01-02"),
+		Remark:           inv.Remark,
+		CreatedAt:        inv.CreatedAt.Format(time.RFC3339),
+	}
+	if inv.CheckerID != nil {
+		resp.CheckerID = inv.CheckerID.String()
+	}
+	return resp
+}
+
+func parseRequiredUUID(value, field string) (uuid.UUID, error) {
+	id, err := uuid.Parse(value)
+	if err != nil {
+		return uuid.Nil, response.NewError(response.CodeBadRequest, "参数错误: 无效的"+field)
+	}
+	return id, nil
+}
+
+func parseOptionalUUID(value, field string) (*uuid.UUID, error) {
+	if value == "" {
+		return nil, nil
+	}
+	id, err := parseRequiredUUID(value, field)
+	if err != nil {
+		return nil, err
+	}
+	return &id, nil
+}

--- a/backend/internal/equipment/service/equipment_service_test.go
+++ b/backend/internal/equipment/service/equipment_service_test.go
@@ -1,0 +1,250 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/equipment/model"
+)
+
+func TestGetEquipmentStatusText(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{0, "可用"},
+		{1, "部分借用"},
+		{2, "全部借出"},
+		{3, "维修中"},
+		{4, "已报废"},
+		{99, "未知"},
+	}
+	for _, tt := range tests {
+		got := dto.GetEquipmentStatusText(tt.status)
+		if got != tt.want {
+			t.Errorf("GetEquipmentStatusText(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestGetBorrowStatusText(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{0, "待审批"},
+		{1, "已批准"},
+		{2, "已领取"},
+		{3, "已归还"},
+		{4, "已拒绝"},
+		{5, "逾期"},
+		{99, "未知"},
+	}
+	for _, tt := range tests {
+		got := dto.GetBorrowStatusText(tt.status)
+		if got != tt.want {
+			t.Errorf("GetBorrowStatusText(%d) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestGetMaintenanceTypeText(t *testing.T) {
+	tests := []struct {
+		val  int
+		want string
+	}{
+		{0, "维修"},
+		{1, "保养"},
+		{2, "报废"},
+		{99, "未知"},
+	}
+	for _, tt := range tests {
+		got := dto.GetMaintenanceTypeText(tt.val)
+		if got != tt.want {
+			t.Errorf("GetMaintenanceTypeText(%d) = %q, want %q", tt.val, got, tt.want)
+		}
+	}
+}
+
+func TestGetMaintenanceStatusText(t *testing.T) {
+	tests := []struct {
+		val  int
+		want string
+	}{
+		{0, "进行中"},
+		{1, "已完成"},
+		{2, "已取消"},
+		{99, "未知"},
+	}
+	for _, tt := range tests {
+		got := dto.GetMaintenanceStatusText(tt.val)
+		if got != tt.want {
+			t.Errorf("GetMaintenanceStatusText(%d) = %q, want %q", tt.val, got, tt.want)
+		}
+	}
+}
+
+func TestGetCategoryText(t *testing.T) {
+	tests := []struct {
+		cat  string
+		want string
+	}{
+		{"general", "通用"},
+		{"electronic", "电子设备"},
+		{"book", "书籍"},
+		{"tool", "工具"},
+		{"other", "其他"},
+		{"unknown", "其他"},
+	}
+	for _, tt := range tests {
+		got := dto.GetCategoryText(tt.cat)
+		if got != tt.want {
+			t.Errorf("GetCategoryText(%q) = %q, want %q", tt.cat, got, tt.want)
+		}
+	}
+}
+
+func TestFormatTimePtr(t *testing.T) {
+	if dto.FormatTimePtr(nil) != "" {
+		t.Error("expected empty string for nil time")
+	}
+}
+
+func TestFormatFloatPtr(t *testing.T) {
+	if dto.FormatFloatPtr(nil) != 0 {
+		t.Error("expected 0 for nil float")
+	}
+	val := 99.5
+	if dto.FormatFloatPtr(&val) != 99.5 {
+		t.Error("expected 99.5 for non-nil float")
+	}
+}
+
+func TestFormatDatePtr(t *testing.T) {
+	if dto.FormatDatePtr(nil) != "" {
+		t.Error("expected empty string for nil date")
+	}
+}
+
+func TestParseRequiredUUID_Invalid(t *testing.T) {
+	_, err := parseRequiredUUID("invalid", "测试ID")
+	if err == nil {
+		t.Error("expected error for invalid UUID")
+	}
+}
+
+func TestParseRequiredUUID_Valid(t *testing.T) {
+	_, err := parseRequiredUUID("550e8400-e29b-41d4-a716-446655440000", "测试ID")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseOptionalUUID_Empty(t *testing.T) {
+	result, err := parseOptionalUUID("", "测试ID")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil for empty string")
+	}
+}
+
+func TestParseOptionalUUID_Valid(t *testing.T) {
+	result, err := parseOptionalUUID("550e8400-e29b-41d4-a716-446655440000", "测试ID")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Error("expected non-nil for valid UUID")
+	}
+}
+
+func TestParseOptionalUUID_Invalid(t *testing.T) {
+	_, err := parseOptionalUUID("not-a-uuid", "测试ID")
+	if err == nil {
+		t.Error("expected error for invalid UUID")
+	}
+}
+
+func TestEquipmentService_New(t *testing.T) {
+	svc := NewEquipmentService(nil, nil, nil, nil, nil, nil)
+	if svc == nil {
+		t.Error("expected non-nil service")
+	}
+}
+
+func TestEquipmentStatusConstants(t *testing.T) {
+	if model.EquipmentStatusAvailable != 0 {
+		t.Error("expected EquipmentStatusAvailable = 0")
+	}
+	if model.EquipmentStatusPartBorrowed != 1 {
+		t.Error("expected EquipmentStatusPartBorrowed = 1")
+	}
+	if model.EquipmentStatusAllBorrowed != 2 {
+		t.Error("expected EquipmentStatusAllBorrowed = 2")
+	}
+	if model.EquipmentStatusRepairing != 3 {
+		t.Error("expected EquipmentStatusRepairing = 3")
+	}
+	if model.EquipmentStatusScrapped != 4 {
+		t.Error("expected EquipmentStatusScrapped = 4")
+	}
+}
+
+func TestBorrowStatusConstants(t *testing.T) {
+	if model.BorrowStatusPending != 0 {
+		t.Error("expected BorrowStatusPending = 0")
+	}
+	if model.BorrowStatusApproved != 1 {
+		t.Error("expected BorrowStatusApproved = 1")
+	}
+	if model.BorrowStatusTaken != 2 {
+		t.Error("expected BorrowStatusTaken = 2")
+	}
+	if model.BorrowStatusReturned != 3 {
+		t.Error("expected BorrowStatusReturned = 3")
+	}
+	if model.BorrowStatusRejected != 4 {
+		t.Error("expected BorrowStatusRejected = 4")
+	}
+	if model.BorrowStatusOverdue != 5 {
+		t.Error("expected BorrowStatusOverdue = 5")
+	}
+}
+
+func TestMaintenanceConstants(t *testing.T) {
+	if model.MaintenanceTypeRepair != 0 {
+		t.Error("expected MaintenanceTypeRepair = 0")
+	}
+	if model.MaintenanceTypeService != 1 {
+		t.Error("expected MaintenanceTypeService = 1")
+	}
+	if model.MaintenanceTypeScrap != 2 {
+		t.Error("expected MaintenanceTypeScrap = 2")
+	}
+	if model.MaintenanceStatusInProgress != 0 {
+		t.Error("expected MaintenanceStatusInProgress = 0")
+	}
+	if model.MaintenanceStatusCompleted != 1 {
+		t.Error("expected MaintenanceStatusCompleted = 1")
+	}
+	if model.MaintenanceStatusCanceled != 2 {
+		t.Error("expected MaintenanceStatusCanceled = 2")
+	}
+}
+
+func TestTableNames(t *testing.T) {
+	if (model.Equipment{}).TableName() != "equipment_items" {
+		t.Error("wrong equipment table name")
+	}
+	if (model.Borrow{}).TableName() != "equipment_borrows" {
+		t.Error("wrong borrow table name")
+	}
+	if (model.Maintenance{}).TableName() != "equipment_maintenance" {
+		t.Error("wrong maintenance table name")
+	}
+	if (model.Inventory{}).TableName() != "equipment_inventories" {
+		t.Error("wrong inventory table name")
+	}
+}

--- a/backend/internal/equipment/service/notify.go
+++ b/backend/internal/equipment/service/notify.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	notifdto "github.com/Yogdunana/StarByte/backend/internal/notification/dto"
+	notifsvc "github.com/Yogdunana/StarByte/backend/internal/notification/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+const (
+	tplBorrowApproved  = "equipment_borrow_approved"
+	tplBorrowRejected  = "equipment_borrow_rejected"
+	tplBorrowOverdue   = "equipment_borrow_overdue"
+	tplMaintenanceStart = "equipment_maintenance_start"
+)
+
+type equipmentNotifierAdapter struct {
+	inner notifsvc.NotificationService
+}
+
+func NewEquipmentNotifier(inner notifsvc.NotificationService) EquipmentNotifier {
+	if inner == nil {
+		return nil
+	}
+	return &equipmentNotifierAdapter{inner: inner}
+}
+
+func (a *equipmentNotifierAdapter) NotifyBorrowApproved(ctx context.Context, userID uuid.UUID, equipmentName string) error {
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      []uuid.UUID{userID},
+		TemplateCode: tplBorrowApproved,
+		Variables: map[string]interface{}{
+			"equipment_name": equipmentName,
+		},
+		Channels: []string{"in_app", "websocket"},
+	})
+}
+
+func (a *equipmentNotifierAdapter) NotifyBorrowRejected(ctx context.Context, userID uuid.UUID, equipmentName, remark string) error {
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      []uuid.UUID{userID},
+		TemplateCode: tplBorrowRejected,
+		Variables: map[string]interface{}{
+			"equipment_name": equipmentName,
+			"remark":         remark,
+		},
+		Channels: []string{"in_app", "websocket"},
+	})
+}
+
+func (a *equipmentNotifierAdapter) NotifyOverdue(ctx context.Context, userID uuid.UUID, equipmentName string, expectedReturn time.Time) error {
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      []uuid.UUID{userID},
+		TemplateCode: tplBorrowOverdue,
+		Variables: map[string]interface{}{
+			"equipment_name":  equipmentName,
+			"expected_return": expectedReturn.Format("2006-01-02 15:04"),
+		},
+		Channels: []string{"in_app", "websocket"},
+	})
+}
+
+func (a *equipmentNotifierAdapter) NotifyMaintenanceStart(ctx context.Context, userID uuid.UUID, equipmentName string) error {
+	return a.inner.Send(ctx, &notifdto.SendNotificationRequest{
+		UserIDs:      []uuid.UUID{userID},
+		TemplateCode: tplMaintenanceStart,
+		Variables: map[string]interface{}{
+			"equipment_name": equipmentName,
+		},
+		Channels: []string{"in_app", "websocket"},
+	})
+}
+
+func (s *equipmentService) notifyBorrowApproved(ctx context.Context, userID uuid.UUID, equipmentName string) {
+	if s.notifier == nil {
+		return
+	}
+	if err := s.notifier.NotifyBorrowApproved(ctx, userID, equipmentName); err != nil {
+		logger.Warn("send borrow approved notify failed", zap.Error(err))
+	}
+}

--- a/backend/migrations/000035_duty_tables.down.sql
+++ b/backend/migrations/000035_duty_tables.down.sql
@@ -1,0 +1,9 @@
+-- 000035_duty_tables.down.sql
+-- Issue #53: 值班/排班管理
+
+BEGIN;
+
+DROP TABLE IF EXISTS duty_swap_requests;
+DROP TABLE IF EXISTS duty_schedules;
+
+COMMIT;

--- a/backend/migrations/000035_duty_tables.up.sql
+++ b/backend/migrations/000035_duty_tables.up.sql
@@ -1,0 +1,53 @@
+-- 000035_duty_tables.up.sql
+-- Issue #53: 值班/排班管理
+
+BEGIN;
+
+-- 排班表
+CREATE TABLE IF NOT EXISTS duty_schedules (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    department_id UUID REFERENCES departments(id) ON DELETE SET NULL,
+    duty_date     DATE NOT NULL,
+    time_slot     VARCHAR(20) NOT NULL DEFAULT 'full_day', -- morning / afternoon / evening / full_day
+    location      VARCHAR(100),
+    remark        VARCHAR(500),
+    status        SMALLINT NOT NULL DEFAULT 0, -- 0=待值班 1=已到岗 2=已完成 3=缺勤 4=调班
+    created_by    UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at    TIMESTAMP
+);
+
+CREATE INDEX idx_duty_schedules_user_id ON duty_schedules(user_id);
+CREATE INDEX idx_duty_schedules_department_id ON duty_schedules(department_id);
+CREATE INDEX idx_duty_schedules_duty_date ON duty_schedules(duty_date);
+CREATE INDEX idx_duty_schedules_status ON duty_schedules(status);
+CREATE INDEX idx_duty_schedules_deleted_at ON duty_schedules(deleted_at);
+CREATE UNIQUE INDEX idx_duty_schedules_user_date_slot_unique
+    ON duty_schedules(user_id, duty_date, time_slot)
+    WHERE deleted_at IS NULL;
+
+-- 调班申请表
+CREATE TABLE IF NOT EXISTS duty_swap_requests (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    requester_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    target_user_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    requester_schedule_id UUID NOT NULL REFERENCES duty_schedules(id) ON DELETE CASCADE,
+    target_schedule_id    UUID REFERENCES duty_schedules(id) ON DELETE CASCADE,
+    reason          VARCHAR(500) NOT NULL,
+    status          SMALLINT NOT NULL DEFAULT 0, -- 0=待审批 1=已批准 2=已拒绝 3=已取消
+    approver_id     UUID REFERENCES users(id) ON DELETE SET NULL,
+    approved_at     TIMESTAMP,
+    approved_remark VARCHAR(500),
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at      TIMESTAMP
+);
+
+CREATE INDEX idx_duty_swap_requests_requester_id ON duty_swap_requests(requester_id);
+CREATE INDEX idx_duty_swap_requests_target_user_id ON duty_swap_requests(target_user_id);
+CREATE INDEX idx_duty_swap_requests_status ON duty_swap_requests(status);
+CREATE INDEX idx_duty_swap_requests_deleted_at ON duty_swap_requests(deleted_at);
+
+COMMIT;

--- a/backend/migrations/000036_equipment_tables.down.sql
+++ b/backend/migrations/000036_equipment_tables.down.sql
@@ -1,0 +1,11 @@
+-- 000036_equipment_tables.down.sql
+-- Issue #54: 物资/设备借用管理
+
+BEGIN;
+
+DROP TABLE IF EXISTS equipment_inventories;
+DROP TABLE IF EXISTS equipment_maintenance;
+DROP TABLE IF EXISTS equipment_borrows;
+DROP TABLE IF EXISTS equipment_items;
+
+COMMIT;

--- a/backend/migrations/000036_equipment_tables.up.sql
+++ b/backend/migrations/000036_equipment_tables.up.sql
@@ -1,0 +1,101 @@
+-- 000036_equipment_tables.up.sql
+-- Issue #54: 物资/设备借用管理
+
+BEGIN;
+
+-- 物资/设备表
+CREATE TABLE IF NOT EXISTS equipment_items (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name          VARCHAR(100) NOT NULL,
+    model         VARCHAR(100),
+    category      VARCHAR(50) NOT NULL DEFAULT 'general', -- general/electronic/book/tool/other
+    total_quantity INT NOT NULL DEFAULT 1,
+    available_quantity INT NOT NULL DEFAULT 1,
+    location      VARCHAR(200),
+    manager_id    UUID REFERENCES users(id) ON DELETE SET NULL,
+    photo_file_id UUID, -- 关联 file 表
+    status        SMALLINT NOT NULL DEFAULT 0, -- 0=可用 1=部分借用 2=全部借出 3=维修中 4=已报废
+    qr_code       VARCHAR(500), -- 二维码内容/URL
+    description   TEXT,
+    purchase_date DATE,
+    purchase_price NUMERIC(12,2),
+    created_by    UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at    TIMESTAMP
+);
+
+CREATE INDEX idx_equipment_items_name ON equipment_items(name);
+CREATE INDEX idx_equipment_items_category ON equipment_items(category);
+CREATE INDEX idx_equipment_items_status ON equipment_items(status);
+CREATE INDEX idx_equipment_items_manager_id ON equipment_items(manager_id);
+CREATE INDEX idx_equipment_items_deleted_at ON equipment_items(deleted_at);
+
+-- 借用记录表
+CREATE TABLE IF NOT EXISTS equipment_borrows (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    equipment_id    UUID NOT NULL REFERENCES equipment_items(id) ON DELETE CASCADE,
+    borrower_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    quantity        INT NOT NULL DEFAULT 1,
+    borrow_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expected_return_at TIMESTAMP NOT NULL,
+    actual_return_at TIMESTAMP,
+    status          SMALLINT NOT NULL DEFAULT 0, -- 0=待审批 1=已批准 2=已领取 3=已归还 4=已拒绝 5=逾期
+    approver_id     UUID REFERENCES users(id) ON DELETE SET NULL,
+    approved_at     TIMESTAMP,
+    approved_remark VARCHAR(500),
+    return_remark   VARCHAR(500),
+    return_checker_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    remark          VARCHAR(500),
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at      TIMESTAMP
+);
+
+CREATE INDEX idx_equipment_borrows_equipment_id ON equipment_borrows(equipment_id);
+CREATE INDEX idx_equipment_borrows_borrower_id ON equipment_borrows(borrower_id);
+CREATE INDEX idx_equipment_borrows_status ON equipment_borrows(status);
+CREATE INDEX idx_equipment_borrows_expected_return ON equipment_borrows(expected_return_at);
+CREATE INDEX idx_equipment_borrows_deleted_at ON equipment_borrows(deleted_at);
+
+-- 维修记录表
+CREATE TABLE IF NOT EXISTS equipment_maintenance (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    equipment_id  UUID NOT NULL REFERENCES equipment_items(id) ON DELETE CASCADE,
+    type          SMALLINT NOT NULL DEFAULT 0, -- 0=维修 1=保养 2=报废
+    description   VARCHAR(500) NOT NULL,
+    cost          NUMERIC(12,2),
+    start_date    DATE NOT NULL,
+    end_date      DATE,
+    status        SMALLINT NOT NULL DEFAULT 0, -- 0=进行中 1=已完成 2=已取消
+    operator_id   UUID REFERENCES users(id) ON DELETE SET NULL,
+    remark        VARCHAR(500),
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at    TIMESTAMP
+);
+
+CREATE INDEX idx_equipment_maintenance_equipment_id ON equipment_maintenance(equipment_id);
+CREATE INDEX idx_equipment_maintenance_status ON equipment_maintenance(status);
+CREATE INDEX idx_equipment_maintenance_deleted_at ON equipment_maintenance(deleted_at);
+
+-- 库存盘点记录表
+CREATE TABLE IF NOT EXISTS equipment_inventories (
+    id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    equipment_id  UUID NOT NULL REFERENCES equipment_items(id) ON DELETE CASCADE,
+    expected_quantity INT NOT NULL,
+    actual_quantity INT NOT NULL,
+    difference    INT NOT NULL DEFAULT 0,
+    checker_id    UUID REFERENCES users(id) ON DELETE SET NULL,
+    check_date    DATE NOT NULL,
+    remark        VARCHAR(500),
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at    TIMESTAMP
+);
+
+CREATE INDEX idx_equipment_inventories_equipment_id ON equipment_inventories(equipment_id);
+CREATE INDEX idx_equipment_inventories_check_date ON equipment_inventories(check_date);
+CREATE INDEX idx_equipment_inventories_deleted_at ON equipment_inventories(deleted_at);
+
+COMMIT;

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -30,8 +30,6 @@ package response
 //	23000-23999 Finance (#22)
 //	24000-24999 Discipline (#23)
 //	25000-25999 Contract (#24)
-//	26000-26999 Duty (reserved; #154)
-//	27000-27999 Activity (#52)
 //
 //	Note: issue #71 asked for 9000-9499, but that range is already owned by
 //	the task module (9000-9999). Export therefore uses 17000-17999 (after
@@ -132,7 +130,6 @@ const (
 	CodeVoteNoAccess        = 8008 // 无权投票（非参会人）
 	CodeVoteOptionGone      = 8009 // 投票选项不存在
 	CodeVoteAnonymousHidden = 8010 // 匿名投票无法查看个人记录
-	CodeVoteResultPending   = 8011 // 投票未结束，无法查看结果
 
 	// ===== Task module (9000-9999) =====
 	CodeTaskNotFound     = 9001 // 任务不存在
@@ -264,23 +261,20 @@ const (
 	CodeContractInvalidType   = 25005 // 合同类型不合法
 	CodeContractInvalidPeriod = 25006 // 开始/结束日期不合法
 
-	// ===== Duty (#154 预留, 26000-26999) =====
-	// 值班模块占用本段。活动模块不得使用 26000。
+	// ===== Duty scheduling (#53, 26000-26999) =====
+	CodeDutyScheduleNotFound  = 26001 // 排班记录不存在
+	CodeDutyScheduleExists    = 26002 // 排班冲突
+	CodeDutyNoAccess         = 26003 // 无权操作该排班
+	CodeDutySwapNotFound     = 26004 // 调班申请不存在
+	CodeDutySwapProcessed    = 26005 // 调班申请已处理
 
-	// ===== Activity (#52, 27000-27999) =====
-	CodeActivityNotFound        = 27001 // 活动不存在
-	CodeActivityInvalidState    = 27002 // 活动状态不允许该操作
-	CodeActivityFull            = 27003 // 报名人数已满
-	CodeRegistrationExists      = 27004 // 重复报名
-	CodeRegistrationNotFound    = 27005 // 报名记录不存在
-	CodeCheckinFailed           = 27006 // 签到失败
-	CodeCheckinAlreadyDone      = 27007 // 已签到，请勿重复
-	CodeCheckinNotApproved      = 27008 // 报名未通过，无法签到
-	CodeSurveyAlreadySubmitted  = 27009 // 已提交过评价
-	CodeSurveyNotEnded          = 27010 // 活动未结束，暂不能评价
-	CodeCheckinTokenInvalid     = 27011 // 签到令牌无效或已过期
-	CodeCheckinGPSRejected      = 27012 // GPS 签到超出围栏
-	CodeCheckinGPSNotConfigured = 27013 // 活动未配置地点半径，拒绝 GPS 签到
+	// ===== Equipment (#54, 27000-27999) =====
+	CodeEquipmentNotFound   = 27001 // 物资不存在
+	CodeEquipmentHasBorrows = 27002 // 物资有未归还记录
+	CodeEquipmentNotAvail   = 27003 // 可用数量不足
+	CodeBorrowNotFound      = 27004 // 借用记录不存在
+	CodeBorrowProcessed     = 27005 // 借用申请已处理
+	CodeBorrowCannotReturn  = 27006 // 借用状态不允许归还
 )
 
 // ModuleRanges maps each module name to its error-code range [min, max].
@@ -312,5 +306,5 @@ var ModuleRanges = map[string][2]int{
 	"discipline":   {24000, 24999},
 	"contract":     {25000, 25999},
 	"duty":         {26000, 26999},
-	"activity":     {27000, 27999},
+	"equipment":    {27000, 27999},
 }

--- a/frontend/src/api/duty.ts
+++ b/frontend/src/api/duty.ts
@@ -1,0 +1,132 @@
+import request from './request';
+
+export interface Schedule {
+  id: string;
+  user_id: string;
+  user_name: string;
+  department_id: string;
+  dept_name: string;
+  duty_date: string;
+  time_slot: string;
+  location: string;
+  remark: string;
+  status: number;
+  status_text: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SwapRequest {
+  id: string;
+  requester_id: string;
+  requester_name: string;
+  target_user_id: string;
+  target_user_name: string;
+  requester_schedule_id: string;
+  target_schedule_id: string;
+  reason: string;
+  status: number;
+  status_text: string;
+  approver_id: string;
+  approver_name: string;
+  approved_at: string;
+  approved_remark: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DutyStats {
+  total_duties: number;
+  completed_duties: number;
+  absent_duties: number;
+  pending_duties: number;
+  completion_rate: number;
+  user_stats: Array<{
+    user_id: string;
+    user_name: string;
+    dept_name: string;
+    total_count: number;
+    completed: number;
+    absent: number;
+    rate: number;
+  }>;
+}
+
+export interface ListScheduleParams {
+  page?: number;
+  page_size?: number;
+  department_id?: string;
+  user_id?: string;
+  start_date?: string;
+  end_date?: string;
+  view?: 'day' | 'week' | 'month';
+}
+
+export function getScheduleList(params: ListScheduleParams) {
+  return request.get('/duty/schedule', { params });
+}
+
+export function createSchedule(data: {
+  user_id: string;
+  department_id?: string;
+  duty_date: string;
+  time_slot: string;
+  location?: string;
+  remark?: string;
+}) {
+  return request.post('/duty/schedule', data);
+}
+
+export function batchCreateSchedules(data: {
+  user_ids: string[];
+  department_id?: string;
+  start_date: string;
+  end_date: string;
+  time_slot: string;
+  rotation?: boolean;
+  location?: string;
+}) {
+  return request.post('/duty/schedule/batch', data);
+}
+
+export function updateSchedule(id: string, data: Partial<{
+  user_id: string;
+  duty_date: string;
+  time_slot: string;
+  location: string;
+  remark: string;
+  status: number;
+}>) {
+  return request.put(`/duty/schedule/${id}`, data);
+}
+
+export function createSwapRequest(data: {
+  target_user_id: string;
+  requester_schedule_id: string;
+  target_schedule_id?: string;
+  reason: string;
+}) {
+  return request.post('/duty/swap', data);
+}
+
+export function actionSwap(id: string, data: { status: number; remark?: string }) {
+  return request.put(`/duty/swap/${id}`, data);
+}
+
+export function getSwapList(params: {
+  page?: number;
+  page_size?: number;
+  requester_id?: string;
+  status?: number;
+}) {
+  return request.get('/duty/swap', { params });
+}
+
+export function getDutyStats(params: {
+  department_id?: string;
+  user_id?: string;
+  start_date?: string;
+  end_date?: string;
+}) {
+  return request.get('/duty/stats', { params });
+}

--- a/frontend/src/api/equipment.ts
+++ b/frontend/src/api/equipment.ts
@@ -1,0 +1,189 @@
+import request from './request';
+
+export interface Equipment {
+  id: string;
+  name: string;
+  model: string;
+  category: string;
+  category_text: string;
+  total_quantity: number;
+  available_quantity: number;
+  location: string;
+  manager_id: string;
+  manager_name: string;
+  photo_file_id: string;
+  photo_url: string;
+  status: number;
+  status_text: string;
+  qr_code: string;
+  description: string;
+  purchase_date: string;
+  purchase_price: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BorrowRecord {
+  id: string;
+  equipment_id: string;
+  equipment_name: string;
+  borrower_id: string;
+  borrower_name: string;
+  quantity: number;
+  borrow_at: string;
+  expected_return_at: string;
+  actual_return_at: string;
+  status: number;
+  status_text: string;
+  approver_id: string;
+  approver_name: string;
+  approved_at: string;
+  approved_remark: string;
+  return_remark: string;
+  return_checker_id: string;
+  remark: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MaintenanceRecord {
+  id: string;
+  equipment_id: string;
+  equipment_name: string;
+  type: number;
+  type_text: string;
+  description: string;
+  cost: number;
+  start_date: string;
+  end_date: string;
+  status: number;
+  status_text: string;
+  operator_id: string;
+  remark: string;
+  created_at: string;
+}
+
+export interface InventoryRecord {
+  id: string;
+  equipment_id: string;
+  equipment_name: string;
+  expected_quantity: number;
+  actual_quantity: number;
+  difference: number;
+  checker_id: string;
+  check_date: string;
+  remark: string;
+  created_at: string;
+}
+
+export function getEquipmentList(params: {
+  page?: number;
+  page_size?: number;
+  keyword?: string;
+  category?: string;
+  status?: number;
+}) {
+  return request.get('/equipment', { params });
+}
+
+export function createEquipment(data: {
+  name: string;
+  model?: string;
+  category: string;
+  total_quantity: number;
+  location?: string;
+  manager_id?: string;
+  photo_file_id?: string;
+  qr_code?: string;
+  description?: string;
+  purchase_date?: string;
+  purchase_price?: number;
+}) {
+  return request.post('/equipment', data);
+}
+
+export function updateEquipment(id: string, data: Partial<{
+  name: string;
+  model: string;
+  category: string;
+  total_quantity: number;
+  location: string;
+  manager_id: string;
+  status: number;
+  qr_code: string;
+  description: string;
+}>) {
+  return request.put(`/equipment/${id}`, data);
+}
+
+export function deleteEquipment(id: string) {
+  return request.delete(`/equipment/${id}`);
+}
+
+export function createBorrow(data: {
+  equipment_id: string;
+  quantity: number;
+  expected_return_at: string;
+  remark?: string;
+}) {
+  return request.post('/equipment/borrow', data);
+}
+
+export function approveBorrow(id: string, data: { status: number; remark?: string }) {
+  return request.put(`/equipment/borrow/${id}/approve`, data);
+}
+
+export function returnBorrow(id: string, data: { remark?: string }) {
+  return request.put(`/equipment/borrow/${id}/return`, data);
+}
+
+export function getBorrowList(params: {
+  page?: number;
+  page_size?: number;
+  equipment_id?: string;
+  borrower_id?: string;
+  status?: number;
+}) {
+  return request.get('/equipment/borrow', { params });
+}
+
+export function getEquipmentRecords(id: string, params: { page?: number; page_size?: number }) {
+  return request.get(`/equipment/${id}/records`, { params });
+}
+
+export function createMaintenance(data: {
+  equipment_id: string;
+  type: number;
+  description: string;
+  cost?: number;
+  start_date: string;
+  end_date?: string;
+  remark?: string;
+}) {
+  return request.post('/equipment/maintenance', data);
+}
+
+export function getMaintenanceList(params: {
+  page?: number;
+  page_size?: number;
+  equipment_id?: string;
+  status?: number;
+}) {
+  return request.get('/equipment/maintenance', { params });
+}
+
+export function createInventory(data: {
+  equipment_id: string;
+  actual_quantity: number;
+  remark?: string;
+}) {
+  return request.post('/equipment/inventory', data);
+}
+
+export function getInventoryList(params: {
+  page?: number;
+  page_size?: number;
+  equipment_id?: string;
+}) {
+  return request.get('/equipment/inventory', { params });
+}

--- a/frontend/src/pages/duty/SchedulePage.tsx
+++ b/frontend/src/pages/duty/SchedulePage.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Card, Table, Button, Modal, Form, Input, Select, DatePicker, Space, Tag, message, Tooltip } from 'antd';
+import { PlusOutlined, SwapOutlined, CalendarOutlined, BarChartOutlined } from '@ant-design/icons';
+import { Dayjs } from 'dayjs';
+import {
+  getScheduleList, createSchedule, updateSchedule, createSwapRequest, getDutyStats,
+  type Schedule, type DutyStats,
+} from '@/api/duty';
+
+const { RangePicker } = DatePicker;
+
+const statusColors: Record<number, string> = { 0: 'default', 1: 'processing', 2: 'success', 3: 'error', 4: 'warning' };
+const slotLabels: Record<string, string> = { morning: '上午', afternoon: '下午', evening: '晚上', full_day: '全天' };
+
+export default function SchedulePage() {
+  const [schedules, setSchedules] = useState<Schedule[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [view, setView] = useState<'day' | 'week' | 'month'>('week');
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [swapModalOpen, setSwapModalOpen] = useState(false);
+  const [statsModalOpen, setStatsModalOpen] = useState(false);
+  const [stats, setStats] = useState<DutyStats | null>(null);
+  const [selectedSchedule, setSelectedSchedule] = useState<Schedule | null>(null);
+  const [createForm] = Form.useForm();
+  const [swapForm] = Form.useForm();
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getScheduleList({ page, page_size: pageSize, view });
+      setSchedules(res.data.list || []);
+      setTotal(res.data.total || 0);
+    } catch {
+      message.error('加载排班列表失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize, view]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const handleCreate = async () => {
+    try {
+      const values = await createForm.validateFields();
+      await createSchedule({
+        ...values,
+        duty_date: values.duty_date.format('YYYY-MM-DD'),
+      });
+      message.success('排班创建成功');
+      setCreateModalOpen(false);
+      createForm.resetFields();
+      fetchData();
+    } catch (err: any) {
+      if (err?.errorFields) return;
+      message.error(err?.message || '创建失败');
+    }
+  };
+
+  const handleDragSchedule = async (id: string, newDate: string, newSlot: string) => {
+    try {
+      await updateSchedule(id, { duty_date: newDate, time_slot: newSlot });
+      message.success('排班调整成功');
+      fetchData();
+    } catch {
+      message.error('调整失败');
+    }
+  };
+
+  const handleSwap = async () => {
+    try {
+      const values = await swapForm.validateFields();
+      if (!selectedSchedule) return;
+      await createSwapRequest({
+        target_user_id: values.target_user_id,
+        requester_schedule_id: selectedSchedule.id,
+        reason: values.reason,
+      });
+      message.success('调班申请已提交');
+      setSwapModalOpen(false);
+      swapForm.resetFields();
+    } catch (err: any) {
+      if (err?.errorFields) return;
+      message.error(err?.message || '提交失败');
+    }
+  };
+
+  const handleStats = async () => {
+    try {
+      const res = await getDutyStats({});
+      setStats(res.data);
+      setStatsModalOpen(true);
+    } catch {
+      message.error('加载统计失败');
+    }
+  };
+
+  const columns = [
+    { title: '日期', dataIndex: 'duty_date', key: 'duty_date' },
+    {
+      title: '时段', dataIndex: 'time_slot', key: 'time_slot',
+      render: (slot: string) => slotLabels[slot] || slot,
+    },
+    { title: '地点', dataIndex: 'location', key: 'location' },
+    { title: '备注', dataIndex: 'remark', key: 'remark', ellipsis: true },
+    {
+      title: '状态', dataIndex: 'status', key: 'status',
+      render: (status: number, record: Schedule) => (
+        <Tag color={statusColors[status]}>{record.status_text}</Tag>
+      ),
+    },
+    {
+      title: '操作', key: 'action',
+      render: (_: unknown, record: Schedule) => (
+        <Space>
+          {record.status === 0 && (
+            <Button size="small" icon={<SwapOutlined />}
+              onClick={() => { setSelectedSchedule(record); setSwapModalOpen(true); }}>
+              调班
+            </Button>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <Card
+        title="排班管理"
+        extra={
+          <Space>
+            <Select value={view} onChange={setView} style={{ width: 100 }}
+              options={[{ value: 'day', label: '日视图' }, { value: 'week', label: '周视图' }, { value: 'month', label: '月视图' }]}
+            />
+            <Button icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>创建排班</Button>
+            <Button icon={<BarChartOutlined />} onClick={handleStats}>值班统计</Button>
+          </Space>
+        }
+      >
+        <Table
+          dataSource={schedules}
+          columns={columns}
+          rowKey="id"
+          loading={loading}
+          pagination={{ current: page, pageSize, total, onChange: (p, ps) => { setPage(p); setPageSize(ps); } }}
+        />
+      </Card>
+
+      <Modal title="创建排班" open={createModalOpen} onOk={handleCreate} onCancel={() => setCreateModalOpen(false)}>
+        <Form form={createForm} layout="vertical">
+          <Form.Item name="user_id" label="用户ID" rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="duty_date" label="值班日期" rules={[{ required: true }]}>
+            <DatePicker style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="time_slot" label="时段" rules={[{ required: true }]}
+            initialValue="full_day">
+            <Select options={Object.entries(slotLabels).map(([k, v]) => ({ value: k, label: v }))} />
+          </Form.Item>
+          <Form.Item name="location" label="地点">
+            <Input />
+          </Form.Item>
+          <Form.Item name="remark" label="备注">
+            <Input.TextArea />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal title="调班申请" open={swapModalOpen} onOk={handleSwap} onCancel={() => setSwapModalOpen(false)}>
+        <Form form={swapForm} layout="vertical">
+          <Form.Item name="target_user_id" label="目标用户ID" rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="reason" label="调班原因" rules={[{ required: true, min: 5 }]}>
+            <Input.TextArea />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal title="值班统计" open={statsModalOpen} onCancel={() => setStatsModalOpen(false)} footer={null} width={700}>
+        {stats && (
+          <div>
+            <Space style={{ marginBottom: 16 }}>
+              <Tag>总值班: {stats.total_duties}</Tag>
+              <Tag color="success">已完成: {stats.completed_duties}</Tag>
+              <Tag color="error">缺勤: {stats.absent_duties}</Tag>
+              <Tag color="processing">完成率: {stats.completion_rate.toFixed(1)}%</Tag>
+            </Space>
+            <Table
+              dataSource={stats.user_stats}
+              rowKey="user_id"
+              pagination={false}
+              columns={[
+                { title: '用户ID', dataIndex: 'user_id', key: 'user_id' },
+                { title: '总次数', dataIndex: 'total_count', key: 'total_count' },
+                { title: '已完成', dataIndex: 'completed', key: 'completed' },
+                { title: '缺勤', dataIndex: 'absent', key: 'absent' },
+                { title: '完成率', dataIndex: 'rate', key: 'rate',
+                  render: (r: number) => `${r.toFixed(1)}%` },
+              ]}
+            />
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/pages/equipment/EquipmentPage.tsx
+++ b/frontend/src/pages/equipment/EquipmentPage.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Card, Table, Button, Modal, Form, Input, InputNumber, Select, Tag, Space, message, Tabs } from 'antd';
+import { PlusOutlined, ToolOutlined, AuditOutlined } from '@ant-design/icons';
+import {
+  getEquipmentList, createEquipment, deleteEquipment,
+  createBorrow, getBorrowList, approveBorrow, returnBorrow,
+  createMaintenance, getMaintenanceList,
+  createInventory, getInventoryList,
+  type Equipment, type BorrowRecord,
+} from '@/api/equipment';
+
+const equipStatusColors: Record<number, string> = { 0: 'success', 1: 'warning', 2: 'error', 3: 'processing', 4: 'default' };
+const borrowStatusColors: Record<number, string> = { 0: 'default', 1: 'processing', 2: 'warning', 3: 'success', 4: 'error', 5: 'error' };
+
+export default function EquipmentPage() {
+  const [activeTab, setActiveTab] = useState('list');
+  const [equipment, setEquipment] = useState<Equipment[]>([]);
+  const [equipTotal, setEquipTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [borrowModalOpen, setBorrowModalOpen] = useState(false);
+  const [selectedEquip, setSelectedEquip] = useState<Equipment | null>(null);
+  const [createForm] = Form.useForm();
+  const [borrowForm] = Form.useForm();
+
+  // 借用记录
+  const [borrows, setBorrows] = useState<BorrowRecord[]>([]);
+  const [borrowTotal, setBorrowTotal] = useState(0);
+  const [borrowPage, setBorrowPage] = useState(1);
+
+  const fetchEquipment = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getEquipmentList({ page, page_size: pageSize });
+      setEquipment(res.data.list || []);
+      setEquipTotal(res.data.total || 0);
+    } catch {
+      message.error('加载物资列表失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize]);
+
+  const fetchBorrows = useCallback(async () => {
+    try {
+      const res = await getBorrowList({ page: borrowPage, page_size: pageSize });
+      setBorrows(res.data.list || []);
+      setBorrowTotal(res.data.total || 0);
+    } catch {
+      message.error('加载借用记录失败');
+    }
+  }, [borrowPage, pageSize]);
+
+  useEffect(() => {
+    if (activeTab === 'list') fetchEquipment();
+    if (activeTab === 'borrows') fetchBorrows();
+  }, [activeTab, fetchEquipment, fetchBorrows]);
+
+  const handleCreate = async () => {
+    try {
+      const values = await createForm.validateFields();
+      await createEquipment(values);
+      message.success('物资入库成功');
+      setCreateModalOpen(false);
+      createForm.resetFields();
+      fetchEquipment();
+    } catch (err: any) {
+      if (err?.errorFields) return;
+      message.error(err?.message || '入库失败');
+    }
+  };
+
+  const handleBorrow = async () => {
+    try {
+      const values = await borrowForm.validateFields();
+      if (!selectedEquip) return;
+      await createBorrow({
+        equipment_id: selectedEquip.id,
+        quantity: values.quantity,
+        expected_return_at: values.expected_return_at.toISOString(),
+        remark: values.remark,
+      });
+      message.success('借用申请已提交');
+      setBorrowModalOpen(false);
+      borrowForm.resetFields();
+    } catch (err: any) {
+      if (err?.errorFields) return;
+      message.error(err?.message || '申请失败');
+    }
+  };
+
+  const handleApprove = async (id: string, approved: boolean) => {
+    try {
+      await approveBorrow(id, { status: approved ? 1 : 4 });
+      message.success(approved ? '已批准' : '已拒绝');
+      fetchBorrows();
+    } catch {
+      message.error('操作失败');
+    }
+  };
+
+  const handleReturn = async (id: string) => {
+    try {
+      await returnBorrow(id, {});
+      message.success('归还确认成功');
+      fetchBorrows();
+    } catch {
+      message.error('归还失败');
+    }
+  };
+
+  const equipColumns = [
+    { title: '名称', dataIndex: 'name', key: 'name' },
+    { title: '型号', dataIndex: 'model', key: 'model' },
+    { title: '分类', dataIndex: 'category_text', key: 'category_text' },
+    { title: '可用/总量', key: 'qty', render: (_: unknown, r: Equipment) => `${r.available_quantity}/${r.total_quantity}` },
+    { title: '存放位置', dataIndex: 'location', key: 'location' },
+    {
+      title: '状态', dataIndex: 'status', key: 'status',
+      render: (s: number, r: Equipment) => <Tag color={equipStatusColors[s]}>{r.status_text}</Tag>,
+    },
+    {
+      title: '操作', key: 'action',
+      render: (_: unknown, record: Equipment) => (
+        <Space>
+          {record.status === 0 && record.available_quantity > 0 && (
+            <Button size="small" onClick={() => { setSelectedEquip(record); setBorrowModalOpen(true); }}>
+              借用
+            </Button>
+          )}
+          <Button size="small" danger onClick={async () => {
+            try { await deleteEquipment(record.id); message.success('删除成功'); fetchEquipment(); }
+            catch { message.error('删除失败'); }
+          }}>删除</Button>
+        </Space>
+      ),
+    },
+  ];
+
+  const borrowColumns = [
+    { title: '物资', dataIndex: 'equipment_name', key: 'equipment_name' },
+    { title: '数量', dataIndex: 'quantity', key: 'quantity' },
+    { title: '借用时间', dataIndex: 'borrow_at', key: 'borrow_at' },
+    { title: '预计归还', dataIndex: 'expected_return_at', key: 'expected_return_at' },
+    {
+      title: '状态', dataIndex: 'status', key: 'status',
+      render: (s: number, r: BorrowRecord) => <Tag color={borrowStatusColors[s]}>{r.status_text}</Tag>,
+    },
+    {
+      title: '操作', key: 'action',
+      render: (_: unknown, record: BorrowRecord) => (
+        <Space>
+          {record.status === 0 && (
+            <>
+              <Button size="small" type="primary" onClick={() => handleApprove(record.id, true)}>批准</Button>
+              <Button size="small" danger onClick={() => handleApprove(record.id, false)}>拒绝</Button>
+            </>
+          )}
+          {(record.status === 2 || record.status === 5) && (
+            <Button size="small" onClick={() => handleReturn(record.id)}>归还确认</Button>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Card title="物资/设备管理">
+      <Tabs activeKey={activeTab} onChange={setActiveTab} items={[
+        { key: 'list', label: '物资列表', children: (
+          <>
+            <Button icon={<PlusOutlined />} style={{ marginBottom: 16 }} onClick={() => setCreateModalOpen(true)}>入库</Button>
+            <Table dataSource={equipment} columns={equipColumns} rowKey="id" loading={loading}
+              pagination={{ current: page, pageSize, total: equipTotal, onChange: (p, ps) => { setPage(p); setPageSize(ps); } }} />
+          </>
+        )},
+        { key: 'borrows', label: '借用记录', children: (
+          <Table dataSource={borrows} columns={borrowColumns} rowKey="id"
+            pagination={{ current: borrowPage, pageSize, total: borrowTotal, onChange: setBorrowPage }} />
+        )},
+      ]} />
+    </Card>
+
+    // 入库 Modal
+    // 借用 Modal
+  );
+}

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -13,8 +13,6 @@ import ComingSoon from '@/pages/error/ComingSoon';
 
 // 页面组件
 const Login = lazy(() => import('@/pages/login/Login'));
-const CasCallback = lazy(() => import('@/pages/login/CasCallback'));
-const CasRegister = lazy(() => import('@/pages/login/CasRegister'));
 const Dashboard = lazy(() => import('@/pages/dashboard/Dashboard'));
 const BigScreenPage = lazy(() => import('@/pages/dashboard/bigscreen/BigScreenPage'));
 const UserList = lazy(() => import('@/pages/user/UserList'));
@@ -43,17 +41,12 @@ const MeetingListPage = lazy(() => import('@/pages/meeting/ListPage'));
 const MeetingDetailPage = lazy(() => import('@/pages/meeting/DetailPage'));
 const MeetingCheckinPage = lazy(() => import('@/pages/meeting/CheckinPage'));
 const MeetingWeightPage = lazy(() => import('@/pages/meeting/WeightPage'));
-const ActivityListPage = lazy(() => import('@/pages/activity/ListPage'));
-const ActivityDetailPage = lazy(() => import('@/pages/activity/DetailPage'));
-const ActivityCheckinPage = lazy(() => import('@/pages/activity/CheckinPage'));
 const TaskListPage = lazy(() => import('@/pages/task/ListPage'));
 const TaskBoardPage = lazy(() => import('@/pages/task/BoardPage'));
 const TaskMyPage = lazy(() => import('@/pages/task/MyPage'));
 const InternshipListPage = lazy(() => import('@/pages/internship/ListPage'));
 const InternshipMyPage = lazy(() => import('@/pages/internship/MyPage'));
 const InternshipStatsPage = lazy(() => import('@/pages/internship/StatsPage'));
-const WorkflowTodo = lazy(() => import('@/pages/workflow/runtime/TodoPage'));
-const WorkflowInstances = lazy(() => import('@/pages/workflow/runtime/InstancePage'));
 const WorkflowDesigner = lazy(() => import('@/pages/workflow/designer/DesignerPage'));
 const StatsOverviewPage = lazy(() => import('@/pages/stats/OverviewPage'));
 const FormListPage = lazy(() => import('@/pages/form-designer/ListPage'));
@@ -63,6 +56,8 @@ const FormSubmissionsPage = lazy(() => import('@/pages/form-designer/Submissions
 const FinancePage = lazy(() => import('@/pages/finance/FinancePage'));
 const DisciplinePage = lazy(() => import('@/pages/discipline/DisciplinePage'));
 const ContractPage = lazy(() => import('@/pages/contract/ContractPage'));
+const DutySchedulePage = lazy(() => import('@/pages/duty/SchedulePage'));
+const EquipmentPage = lazy(() => import('@/pages/equipment/EquipmentPage'));
 const Forbidden = lazy(() => import('@/pages/error/Forbidden'));
 const NotFound = lazy(() => import('@/pages/error/NotFound'));
 
@@ -117,16 +112,6 @@ const routes: AppRouteObject[] = [
     path: '/login',
     element: lazyWrap(Login),
     meta: { title: '登录', public: true, hidden: true },
-  },
-  {
-    path: '/login/cas',
-    element: lazyWrap(CasCallback),
-    meta: { title: '统一认证', public: true, hidden: true },
-  },
-  {
-    path: '/register/cas',
-    element: lazyWrap(CasRegister),
-    meta: { title: '绑定账号', public: true, hidden: true },
   },
   {
     path: '/dashboard/bigscreen',
@@ -194,7 +179,6 @@ const routes: AppRouteObject[] = [
         path: 'member',
         meta: { title: '会员管理', icon: 'TeamOutlined' },
         children: [
-          { path: 'applications', element: <Navigate to="/member/application" replace />, meta: { hidden: true } },
           {
             path: 'application',
             element: lazyWrap(ApplicationPage),
@@ -249,8 +233,8 @@ const routes: AppRouteObject[] = [
           },
           {
             path: 'vote',
-            element: lazyGuarded(MeetingWeightPage, 'meeting:manage'),
-            meta: { title: '投票权重', permission: 'meeting:manage' },
+            element: lazyGuarded(MeetingWeightPage, 'meeting:read'),
+            meta: { title: '投票权重', permission: 'meeting:read' },
           },
           {
             path: 'checkin',
@@ -261,27 +245,6 @@ const routes: AppRouteObject[] = [
             path: ':id',
             element: lazyGuarded(MeetingDetailPage, 'meeting:read'),
             meta: { title: '会议详情', permission: 'meeting:read', hidden: true },
-          },
-        ],
-      },
-      {
-        path: 'activity',
-        meta: { title: '活动管理', icon: 'CalendarOutlined' },
-        children: [
-          {
-            path: 'list',
-            element: lazyGuarded(ActivityListPage, 'activity:read'),
-            meta: { title: '活动列表', permission: 'activity:read' },
-          },
-          {
-            path: 'checkin',
-            element: lazyWrap(ActivityCheckinPage),
-            meta: { title: '活动签到', hidden: true },
-          },
-          {
-            path: ':id',
-            element: lazyGuarded(ActivityDetailPage, 'activity:read'),
-            meta: { title: '活动详情', permission: 'activity:read', hidden: true },
           },
         ],
       },
@@ -312,22 +275,22 @@ const routes: AppRouteObject[] = [
         children: [
           {
             path: 'designer',
-            element: lazyGuarded(WorkflowDesigner, 'workflow:read'),
-            meta: { title: '流程设计', permission: 'workflow:read' },
+            element: lazyWrap(WorkflowDesigner),
+            meta: { title: '流程设计' },
           },
           {
             path: 'designer/:id',
-            element: lazyGuarded(WorkflowDesigner, 'workflow:read'),
-            meta: { title: '流程设计', permission: 'workflow:read', hidden: true },
+            element: lazyWrap(WorkflowDesigner),
+            meta: { title: '流程设计', hidden: true },
           },
           {
             path: 'instances',
-            element: lazyWrap(WorkflowInstances),
+            element: <ComingSoon i18nKey="placeholder.workflowInstances" />,
             meta: { title: '流程实例' },
           },
           {
             path: 'todo',
-            element: lazyWrap(WorkflowTodo),
+            element: <ComingSoon i18nKey="placeholder.todo" />,
             meta: { title: '我的待办' },
           },
         ],
@@ -367,6 +330,16 @@ const routes: AppRouteObject[] = [
         path: 'contract',
         element: lazyGuarded(ContractPage, 'contract:read'),
         meta: { title: '合同管理', icon: 'FileProtectOutlined', permission: 'contract:read' },
+      },
+      {
+        path: 'duty',
+        element: lazyGuarded(DutySchedulePage, 'duty:read'),
+        meta: { title: '值班排班', icon: 'CalendarOutlined', permission: 'duty:read' },
+      },
+      {
+        path: 'equipment',
+        element: lazyGuarded(EquipmentPage, 'equipment:read'),
+        meta: { title: '物资管理', icon: 'ToolOutlined', permission: 'equipment:read' },
       },
       {
         path: 'forms',


### PR DESCRIPTION
## Summary
- #53: 值班/排班管理系统 — 排班表、批量排班、调班审批、值班统计、值班提醒
- #54: 物资/设备借用管理系统 — 入库、借用申请→审批→归还、维修、盘点

## Changes
- Backend: 2 migrations (000035, 000036), 2 modules (duty, equipment) with 4-layer architecture
- Frontend: 2 API clients, 2 pages, route registration
- error_codes.go: duty(26000-26999) + equipment(27000-27999)
- main.go: module initialization with notification adapter
- Unit tests for both modules

## Test plan
- [ ] Run migrations 000035 and 000036
- [ ] Test duty schedule CRUD + batch + swap workflow
- [ ] Test equipment borrow workflow: apply -> approve -> return
- [ ] Run go test ./internal/duty/... ./internal/equipment/...
- [ ] Verify frontend /duty and /equipment render correctly