### PR TITLE
fix(notification): 允许内网 IP 同源 WebSocket Origin

### DIFF
--- a/backend/internal/notification/handler/websocket_handler.go
+++ b/backend/internal/notification/handler/websocket_handler.go
@@ -3,7 +3,10 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/internal/notification/service"
@@ -44,7 +47,8 @@ type WSHandler struct {
 }
 
 // NewWSHandler 创建 WebSocket 处理器
-// allowedOrigins 为空时允许所有来源（开发模式），非空时仅允许列表中的来源
+// allowedOrigins 为空时允许所有来源（开发模式）；非空时允许空 Origin、
+// CORS 白名单中的来源，以及与请求 Host 同主机的 Origin（忽略端口差异）。
 func NewWSHandler(hub service.HubManager, jwtConfig *config.JWTConfig, allowedOrigins []string) *WSHandler {
 	originSet := make(map[string]bool)
 	for _, origin := range allowedOrigins {
@@ -57,18 +61,44 @@ func NewWSHandler(hub service.HubManager, jwtConfig *config.JWTConfig, allowedOr
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 			CheckOrigin: func(r *http.Request) bool {
-				// 未配置允许来源时，允许所有（开发模式）
-				if len(originSet) == 0 {
-					return true
-				}
-				origin := r.Header.Get("Origin")
-				if origin == "" {
-					return true // 非浏览器客户端（如 curl）无 Origin 头
-				}
-				return originSet[origin]
+				return checkWSOrigin(r, originSet)
 			},
 		},
 	}
+}
+
+// checkWSOrigin 校验 WebSocket 升级请求的 Origin。
+// 允许：空 Origin、开发模式（白名单为空）、CORS 白名单命中、与请求 Host 同主机。
+func checkWSOrigin(r *http.Request, allowed map[string]bool) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	if allowed[origin] {
+		return true
+	}
+	return originMatchesRequestHost(origin, r.Host)
+}
+
+func originMatchesRequestHost(origin, reqHost string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return strings.EqualFold(stripHostPort(u.Host), stripHostPort(reqHost))
+}
+
+func stripHostPort(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return host[1 : len(host)-1]
+	}
+	return host
 }
 
 // HandleConnection GET /ws/notifications

--- a/backend/internal/notification/handler/websocket_handler_test.go
+++ b/backend/internal/notification/handler/websocket_handler_test.go
@@ -1,0 +1,93 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckWSOrigin(t *testing.T) {
+	prodAllowed := map[string]bool{
+		"https://starbyte.smbu.edu.cn": true,
+		"https://starbyte.com":         true,
+	}
+
+	tests := []struct {
+		name    string
+		allowed map[string]bool
+		origin  string
+		host    string
+		want    bool
+	}{
+		{
+			name:    "intranet IP origin matches Host",
+			allowed: prodAllowed,
+			origin:  "http://10.100.13.17",
+			host:    "10.100.13.17",
+			want:    true,
+		},
+		{
+			name:    "intranet IP origin matches Host ignoring proxy port",
+			allowed: prodAllowed,
+			origin:  "http://10.100.13.17",
+			host:    "10.100.13.17:8080",
+			want:    true,
+		},
+		{
+			name:    "configured CORS origin",
+			allowed: prodAllowed,
+			origin:  "https://starbyte.smbu.edu.cn",
+			host:    "backend.internal",
+			want:    true,
+		},
+		{
+			name:    "empty origin allowed",
+			allowed: prodAllowed,
+			origin:  "",
+			host:    "10.100.13.17",
+			want:    true,
+		},
+		{
+			name:    "dev empty allowlist permits any origin",
+			allowed: map[string]bool{},
+			origin:  "https://evil.example",
+			host:    "10.100.13.17",
+			want:    true,
+		},
+		{
+			name:    "cross-site origin rejected",
+			allowed: prodAllowed,
+			origin:  "https://evil.example",
+			host:    "10.100.13.17",
+			want:    false,
+		},
+		{
+			name:    "malformed origin rejected",
+			allowed: prodAllowed,
+			origin:  "://not-a-url",
+			host:    "10.100.13.17",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/ws/notifications", nil)
+			r.Host = tt.host
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			assert.Equal(t, tt.want, checkWSOrigin(r, tt.allowed))
+		})
+	}
+}
+
+func TestWSHandlerCheckOrigin_IPMatchesHost(t *testing.T) {
+	h := NewWSHandler(nil, nil, []string{"https://starbyte.smbu.edu.cn"})
+	r := httptest.NewRequest(http.MethodGet, "/ws/notifications", nil)
+	r.Host = "10.100.13.17"
+	r.Header.Set("Origin", "http://10.100.13.17")
+	assert.True(t, h.upgrader.CheckOrigin(r))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

生产环境 `/ws/notifications` 在 `http://10.100.13.17/` 下对已登录管理员返回 403，日志为 `websocket: request origin not allowed by Upgrader.CheckOrigin`。HTTP API 正常。

原因是 `CheckOrigin` 只做 CORS 白名单精确匹配，而 `config.prod.yaml` 只有域名（如 `https://starbyte.smbu.edu.cn`），不包含内网 IP Origin。

本次将 WebSocket Origin 校验改为：

- 空 Origin（非浏览器客户端）允许
- 白名单为空时保持开发模式全放行
- Origin 命中现有 CORS `allowed_origins` 允许
- Origin 主机与请求 `Host` 相同则允许（忽略端口，适配反代）
- 其余跨站 Origin 拒绝

未在生产环境把 `CheckOrigin` 改成恒 `true`。

## 关联 Issue

无固定 Issue 编号（部署现场：`http://10.100.13.17/` 通知 WebSocket 403）。

## 测试方式

1. `cd backend && go test -count=1 ./internal/notification/handler/ -run 'TestCheckWSOrigin|TestWSHandlerCheckOrigin'`
2. 用例覆盖 `Origin: http://10.100.13.17` + `Host: 10.100.13.17` 应通过；跨站 `https://evil.example` 应拒绝
3. 部署后用管理员账号打开 `http://10.100.13.17/`，确认 `/ws/notifications` 可升级

## 截图 / GIF

后端变更，无 UI 截图。

## 注意事项

- 仅影响通知 WebSocket 升级校验；HTTP CORS 中间件未改
- 将来切到 `https://starbyte.smbu.edu.cn` 时，同源 Host 匹配与现有 CORS 白名单均可放行
- 未关闭生产 `CheckOrigin`

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测
- [ ] 已添加/更新必要的文档
- [x] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eda2bc5-075f-5f6d-929e-6df4edc02c55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eda2bc5-075f-5f6d-929e-6df4edc02c55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

