### PR TITLE
fix(auth): CAS 登录 302 加 Referrer-Policy 避免校园网 404

### DIFF
--- a/backend/internal/auth/handler/auth_handler.go
+++ b/backend/internal/auth/handler/auth_handler.go
@@ -217,6 +217,7 @@ func (h *AuthHandler) OAuthLogin(c *gin.Context) {
 // @Success 200 {object} response.Response{data=dto.CASStatusResponse}
 // @Router /auth/cas/status [get]
 func (h *AuthHandler) CASStatus(c *gin.Context) {
+	setCASReferrerPolicy(c)
 	if h.authService == nil {
 		response.OK(c, dto.CASStatusResponse{Enabled: false})
 		return
@@ -232,6 +233,7 @@ func (h *AuthHandler) CASStatus(c *gin.Context) {
 // @Success 302 {string} string "Redirect"
 // @Router /auth/cas/login [get]
 func (h *AuthHandler) CASLogin(c *gin.Context) {
+	setCASReferrerPolicy(c)
 	if h.authService == nil {
 		response.NotImplemented(c, "学校统一认证暂未开通")
 		return
@@ -252,6 +254,7 @@ func (h *AuthHandler) CASLogin(c *gin.Context) {
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
+	// Gin 的 302 会附带一段 <a href> HTML；Referrer-Policy 同时约束自动跳转与该回退页。
 	c.Redirect(http.StatusFound, start.Location)
 }
 
@@ -264,6 +267,7 @@ func (h *AuthHandler) CASLogin(c *gin.Context) {
 // @Success 302 {string} string "Redirect"
 // @Router /auth/cas/callback [get]
 func (h *AuthHandler) CASCallback(c *gin.Context) {
+	setCASReferrerPolicy(c)
 	if h.authService == nil {
 		response.NotImplemented(c, "学校统一认证暂未开通")
 		return
@@ -298,6 +302,7 @@ func (h *AuthHandler) CASCallback(c *gin.Context) {
 // @Failure 400 {object} response.Response
 // @Router /auth/cas/exchange [post]
 func (h *AuthHandler) CASExchange(c *gin.Context) {
+	setCASReferrerPolicy(c)
 	if h.authService == nil {
 		response.NotImplemented(c, "学校统一认证暂未开通")
 		return
@@ -362,7 +367,16 @@ func RegisterRoutes(
 	}
 }
 
-const casStateCookie = "starbyte_cas_state"
+const (
+	casStateCookie    = "starbyte_cas_state"
+	casReferrerPolicy = "no-referrer"
+)
+
+// setCASReferrerPolicy 禁止浏览器把本站 Origin 当作 Referer 带给 authserver。
+// 校园网 openresty 对带 Referer: http://<站点>/ 的 /authserver/login 返回 404。
+func setCASReferrerPolicy(c *gin.Context) {
+	c.Header("Referrer-Policy", casReferrerPolicy)
+}
 
 func requestPublicOrigin(c *gin.Context) string {
 	if c == nil || c.Request == nil {

--- a/backend/internal/auth/handler/cas_handler_test.go
+++ b/backend/internal/auth/handler/cas_handler_test.go
@@ -93,8 +93,26 @@ func TestCASLogin_Redirect(t *testing.T) {
 	c.Request = req
 	h.CASLogin(c)
 	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, casReferrerPolicy, w.Header().Get("Referrer-Policy"))
 	assert.Contains(t, w.Header().Get("Location"), "authserver.smbu.edu.cn")
 	assert.Contains(t, w.Header().Get("Set-Cookie"), casStateCookie)
+}
+
+func TestCASLogin_RedirectSetsNoReferrer(t *testing.T) {
+	h := NewAuthHandler(casStubService{
+		enabled: true,
+		login:   "https://authserver.smbu.edu.cn/authserver/login?service=http%3A%2F%2F10.0.0.8%2Fapi%2Fv1%2Fauth%2Fcas%2Fcallback",
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/cas/login", nil)
+	req.Host = "10.0.0.8"
+	c.Request = req
+	h.CASLogin(c)
+	require.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "no-referrer", w.Header().Get("Referrer-Policy"))
+	assert.Contains(t, w.Header().Get("Location"), "https://authserver.smbu.edu.cn/authserver/login?service=")
+	assert.Contains(t, w.Header().Get("Location"), "10.0.0.8")
 }
 
 func TestCASCallback_Redirect(t *testing.T) {
@@ -104,6 +122,7 @@ func TestCASCallback_Redirect(t *testing.T) {
 	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/auth/cas/callback?ticket=ST-1&state=s", nil)
 	h.CASCallback(c)
 	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, casReferrerPolicy, w.Header().Get("Referrer-Policy"))
 	assert.Contains(t, w.Header().Get("Location"), "/login/cas?code=abc")
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

校园网 CAS 登录时，浏览器跟随 StarByte `GET /api/v1/auth/cas/login` 的 302 会带上 `Referer: http://<站点>/`。`authserver.smbu.edu.cn` 前的 openresty 对该 Referer 返回 404，Chrome 因此看到错误页。

本 PR 在 CAS 登录 302（以及相关 CAS 响应）上设置 `Referrer-Policy: no-referrer`，浏览器不再向 authserver 发送 Referer。Gin 的 302 回退 HTML 与该响应共用同一响应头。

**未改** CAS `service` URL 拼装与 IP 回调行为。

## 关联 Issue

无对应 Issue（校园网 curl 已确认根因）。

## 测试方式

1. `go test ./internal/auth/handler/ -count=1`（`TestCASLogin_RedirectSetsNoReferrer` 断言 302 带 `Referrer-Policy: no-referrer`，Location 仍指向 authserver 且含 `service=`）
2. 浏览器点「学校统一认证」：应 302 到 `https://authserver.smbu.edu.cn/authserver/login?service=http://<IP>/api/v1/auth/cas/callback`，且该请求无 Referer
3. 对比：不带 Referer 的 curl 对同一 URL 返回 200；带 `Referer: http://<站点>/` 仍会 404（学校侧行为，本 PR 只避免浏览器带上它）

## 截图 / GIF

无前端变更。

## 注意事项

- 不影响 CAS service / callback IP 逻辑
- 仅 auth 模块 CAS 响应头；其他登录方式不变
- 无遗留 TODO

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测
- [x] 已添加/更新必要的文档
- [ ] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2772521d-527c-5cef-a18b-9916d3b4afb1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2772521d-527c-5cef-a18b-9916d3b4afb1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

