### PR TITLE
fix(deploy): 硬化 K8s/Helm/CD（替代 #145）

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,164 @@
+# StarByte 镜像构建 / 可选集群部署
+#
+# 默认只接受 workflow_dispatch。不会在 push main / tag 时自动部署。
+# 学校内网当前用 Docker Compose；集群部署必须人工点 Run workflow，
+# 且勾选 deploy=true，并具备 GitHub Environment 与 KUBE_CONFIG_DATA。
+name: CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "目标 Environment 名称（用于保护规则；不会因 push main 触发）"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - prod
+      image_tag:
+        description: "镜像 tag（留空则用 sha-<短哈希>）"
+        required: false
+        type: string
+        default: ""
+      deploy:
+        description: "构建后是否 helm upgrade 到集群（默认否）"
+        required: true
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  # 与 Helm values / raw k8s 对齐，不用 github.repository/backend
+  BACKEND_IMAGE: ghcr.io/yogdunana/starbyte-backend
+  FRONTEND_IMAGE: ghcr.io/yogdunana/starbyte-frontend
+  NAMESPACE: starbyte
+
+jobs:
+  resolve-tag:
+    name: Resolve image tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: tag
+        run: |
+          if [ -n "${{ github.event.inputs.image_tag }}" ]; then
+            TAG="${{ github.event.inputs.image_tag }}"
+          else
+            TAG="sha-${GITHUB_SHA::7}"
+          fi
+          if echo "$TAG" | grep -qE '[/:]'; then
+            echo "image_tag 只能是 tag，不能是完整镜像 URL: $TAG" >&2
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Using tag ${TAG}"
+
+  build-backend:
+    name: Build & Push Backend
+    needs: resolve-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: backend
+          target: production
+          push: true
+          tags: |
+            ${{ env.BACKEND_IMAGE }}:${{ needs.resolve-tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-frontend:
+    name: Build & Push Frontend
+    needs: resolve-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: frontend
+          target: production
+          push: true
+          tags: |
+            ${{ env.FRONTEND_IMAGE }}:${{ needs.resolve-tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to Kubernetes (opt-in)
+    needs: [resolve-tag, build-backend, build-frontend]
+    if: ${{ github.event.inputs.deploy == 'true' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require kubeconfig
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
+        run: |
+          if [ -z "$KUBE_CONFIG_DATA" ]; then
+            echo "未配置 secrets.KUBE_CONFIG_DATA。学校环境请继续用 Docker Compose，不要为了点亮本 job 而写入未知集群凭证。" >&2
+            exit 1
+          fi
+
+      - name: Set values file
+        id: env
+        run: |
+          if [ "${{ github.event.inputs.environment }}" = "prod" ]; then
+            echo "values=values-prod.yaml" >> "$GITHUB_OUTPUT"
+          else
+            echo "values=values-dev.yaml" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up kubeconfig
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "$KUBE_CONFIG_DATA" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - uses: azure/setup-helm@v3
+        with:
+          version: "v3.14.0"
+
+      - name: Helm upgrade (repository + tag 拆开)
+        run: |
+          TAG="${{ needs.resolve-tag.outputs.tag }}"
+          helm upgrade --install starbyte deploy/helm/starbyte \
+            --namespace "${{ env.NAMESPACE }}" --create-namespace \
+            --values "deploy/helm/starbyte/${{ steps.env.outputs.values }}" \
+            --set backend.image.repository="${{ env.BACKEND_IMAGE }}" \
+            --set backend.image.tag="${TAG}" \
+            --set frontend.image.repository="${{ env.FRONTEND_IMAGE }}" \
+            --set frontend.image.tag="${TAG}" \
+            --wait --timeout 5m
+
+      - name: Verify rollout
+        run: |
+          kubectl rollout status deployment/starbyte-backend -n "${{ env.NAMESPACE }}" --timeout=3m
+          kubectl rollout status deployment/starbyte-frontend -n "${{ env.NAMESPACE }}" --timeout=3m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,3 +213,21 @@ jobs:
           if [ $SIZE_MB -gt 100 ]; then
             echo "::warning::前端镜像超过 100MB，建议优化"
           fi
+
+  # ─────────────────────────────────────────────────────────
+  # Helm / Kustomize 静态校验（不部署集群）
+  # ─────────────────────────────────────────────────────────
+  helm-lint:
+    name: Helm Lint & Template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: "v3.14.0"
+
+      - name: helm lint + template 断言
+        run: bash deploy/helm/starbyte/ci-check.sh
+

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ pnpm-debug.log*
 .env.*.local
 *.local
 
+# Kubernetes 明文 Secret（只允许提交 *.example）
+deploy/k8s/secret.yaml
+deploy/k8s/**/secret.yaml
+
+
 # IDE
 .idea/
 .vscode/

--- a/deploy/helm/starbyte/.helmignore
+++ b/deploy/helm/starbyte/.helmignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+*.md
+ci-check.sh
+.DS_Store
+*.tgz

--- a/deploy/helm/starbyte/Chart.yaml
+++ b/deploy/helm/starbyte/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: starbyte
+description: StarByte 可选 Kubernetes Helm Chart（学校内网默认仍用 Docker Compose）
+type: application
+version: 1.0.1
+appVersion: "1.0.0"
+keywords:
+  - starbyte
+  - management-system
+  - go
+  - react
+maintainers:
+  - name: StarByte Team

--- a/deploy/helm/starbyte/README.md
+++ b/deploy/helm/starbyte/README.md
@@ -1,0 +1,23 @@
+# StarByte Helm Chart
+
+学校默认部署仍是 `deploy/docker-compose.yml`。本 Chart 供实验集群使用，**不会**随 `main` 自动发布。
+
+```bash
+# 开发（允许 chart 自建本地 Secret）
+helm upgrade --install starbyte . \
+  -n starbyte-dev --create-namespace \
+  -f values-dev.yaml
+
+# 生产：先创建 Secret，再
+helm upgrade --install starbyte . \
+  -n starbyte --create-namespace \
+  -f values-prod.yaml \
+  --set backend.image.repository=ghcr.io/yogdunana/starbyte-backend \
+  --set backend.image.tag=sha-abc1234 \
+  --set frontend.image.repository=ghcr.io/yogdunana/starbyte-frontend \
+  --set frontend.image.tag=sha-abc1234
+```
+
+`image.tag` 只能是 tag。传入完整镜像 URL 会被 helper 拒绝。
+
+静态检查：`./ci-check.sh`（需要本机 `helm`）。

--- a/deploy/helm/starbyte/ci-check.sh
+++ b/deploy/helm/starbyte/ci-check.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# helm lint + template 静态校验（CI 与本地共用）
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+CHART="${ROOT}/deploy/helm/starbyte"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+helm lint "$CHART"
+helm lint "$CHART" -f "${CHART}/values-dev.yaml"
+helm lint "$CHART" -f "${CHART}/values-prod.yaml"
+
+echo "==> template values-dev"
+helm template starbyte "$CHART" -n starbyte-dev -f "${CHART}/values-dev.yaml" > "${OUT}/dev.yaml"
+
+echo "==> template values-prod"
+helm template starbyte "$CHART" -n starbyte -f "${CHART}/values-prod.yaml" > "${OUT}/prod.yaml"
+
+# 生产不得渲染 Secret
+if grep -q '^kind: Secret$' "${OUT}/prod.yaml"; then
+  echo "values-prod 不应渲染 Secret（secrets.create 必须为 false）" >&2
+  exit 1
+fi
+
+# 默认不得渲染 Ingress
+if grep -q '^kind: Ingress$' "${OUT}/prod.yaml"; then
+  echo "values-prod 默认不应渲染 Ingress" >&2
+  exit 1
+fi
+if grep -q '^kind: Ingress$' "${OUT}/dev.yaml"; then
+  echo "values-dev 默认不应渲染 Ingress" >&2
+  exit 1
+fi
+
+# 不得出现 Let's Encrypt / cert-manager 默认依赖
+if grep -Eiq 'letsencrypt|cert-manager.io' "${OUT}/prod.yaml" "${OUT}/dev.yaml"; then
+  echo "渲染结果不应默认依赖 Let's Encrypt / cert-manager" >&2
+  exit 1
+fi
+
+# 镜像必须是 repository:tag，且 tag 不是完整 URL
+if ! grep -q 'image: "ghcr.io/yogdunana/starbyte-backend:1.0.0"' "${OUT}/prod.yaml"; then
+  echo "backend 镜像未按 repository+tag 拼接" >&2
+  grep -n 'starbyte-backend' "${OUT}/prod.yaml" || true
+  exit 1
+fi
+if ! grep -q 'image: "ghcr.io/yogdunana/starbyte-frontend:1.0.0"' "${OUT}/prod.yaml"; then
+  echo "frontend 镜像未按 repository+tag 拼接" >&2
+  exit 1
+fi
+
+# Secret key 对齐：开发 Secret 必须含后端实际读取的 key
+for key in DB_PASSWORD REDIS_PASSWORD MINIO_ACCESS_KEY MINIO_SECRET_KEY JWT_SECRET; do
+  if ! grep -q "^  ${key}:" "${OUT}/dev.yaml"; then
+    echo "dev Secret 缺少 key ${key}" >&2
+    exit 1
+  fi
+done
+
+# 传入完整镜像 URL 作为 tag 必须失败
+if helm template starbyte "$CHART" -n starbyte \
+  --set backend.image.tag='ghcr.io/yogdunana/starbyte-backend:latest' \
+  >"${OUT}/bad.yaml" 2>"${OUT}/bad.err"; then
+  echo "应拒绝把完整镜像 URL 当作 image.tag" >&2
+  exit 1
+fi
+if ! grep -q 'image.tag 只能是 tag' "${OUT}/bad.err"; then
+  echo "tag 校验错误信息不匹配:" >&2
+  cat "${OUT}/bad.err" >&2
+  exit 1
+fi
+
+# 生产若误开 create 且无 allowInsecure，必须失败
+if helm template starbyte "$CHART" -n starbyte -f "${CHART}/values-prod.yaml" \
+  --set secrets.create=true \
+  >"${OUT}/prod-secret.yaml" 2>"${OUT}/prod-secret.err"; then
+  echo "prod + secrets.create=true 应失败" >&2
+  exit 1
+fi
+
+# kustomize 默认清单可构建，且不含 Ingress/Secret
+if command -v kustomize >/dev/null 2>&1; then
+  echo "==> kustomize build"
+  kustomize build "${ROOT}/deploy/k8s" > "${OUT}/kust.yaml"
+elif command -v kubectl >/dev/null 2>&1; then
+  echo "==> kubectl kustomize"
+  kubectl kustomize "${ROOT}/deploy/k8s" > "${OUT}/kust.yaml"
+fi
+if [ -f "${OUT}/kust.yaml" ]; then
+  if grep -q '^kind: Ingress$' "${OUT}/kust.yaml"; then
+    echo "默认 kustomization 不应包含 Ingress" >&2
+    exit 1
+  fi
+  if grep -q '^kind: Secret$' "${OUT}/kust.yaml"; then
+    echo "默认 kustomization 不应包含 Secret" >&2
+    exit 1
+  fi
+fi
+
+echo "✅ helm lint / template / 安全断言通过"

--- a/deploy/helm/starbyte/templates/NOTES.txt
+++ b/deploy/helm/starbyte/templates/NOTES.txt
@@ -1,0 +1,25 @@
+StarByte Helm release: {{ .Release.Name }} (ns={{ .Release.Namespace }})
+
+学校内网默认部署路径仍是 Docker Compose：
+  docker compose -f deploy/docker-compose.yml up -d
+
+本 Chart 不会也不应在 push main 时自动部署。CD 仅 workflow_dispatch，且默认只构建镜像。
+
+镜像（repository + tag 拆开）：
+  backend:  {{ include "starbyte.image" .Values.backend.image }}
+  frontend: {{ include "starbyte.image" .Values.frontend.image }}
+
+Secret:
+{{- if .Values.secrets.create }}
+  chart 已创建开发用 Secret（allowInsecure=true）。不要把这套 values 用于生产。
+{{- else }}
+  secrets.create=false。请确认集群已有 Secret：
+    {{ default (include "starbyte.secret.fullname" .) .Values.secrets.existingSecret }}
+  必填 key：DB_PASSWORD REDIS_PASSWORD MINIO_ACCESS_KEY MINIO_SECRET_KEY JWT_SECRET
+{{- end }}
+
+Ingress: {{ .Values.ingress.enabled }}（默认 false，不需要 Let's Encrypt）
+
+访问（未开 Ingress 时）：
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "starbyte.frontend.fullname" . }} 8081:80
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "starbyte.backend.fullname" . }} 8080:8080

--- a/deploy/helm/starbyte/templates/_helpers.tpl
+++ b/deploy/helm/starbyte/templates/_helpers.tpl
@@ -1,0 +1,95 @@
+{{- /* StarByte Helm helpers — 硬化自 #145 */ -}}
+
+{{/*
+标准 fullname：release 名已包含 chart 名时不再重复拼接。
+helm install starbyte ...  → starbyte-backend，而不是 starbyte-starbyte-backend
+*/}}
+{{- define "starbyte.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "starbyte.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "starbyte.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "starbyte.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: starbyte
+{{- end }}
+
+{{- define "starbyte.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "starbyte.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+镜像引用：repository + tag 必须拆开。
+若 tag 含 "/" 或看起来像完整镜像 URL，直接 fail，避免重蹈 #145
+`--set backend.image.tag=ghcr.io/.../starbyte-backend:latest` 的覆写事故。
+*/}}
+{{- define "starbyte.image" -}}
+{{- $repo := required "image.repository is required" .repository -}}
+{{- $tag := required "image.tag is required" .tag -}}
+{{- if or (contains "/" ($tag | toString)) (contains ":" ($tag | toString)) }}
+{{- fail (printf "image.tag 只能是 tag（如 1.0.0 / sha-abc123），不能是完整镜像 URL：%s" $tag) }}
+{{- end }}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end }}
+
+{{- define "starbyte.storageClass" -}}
+{{- $local := .local -}}
+{{- $global := .global -}}
+{{- if $local -}}
+{{- $local -}}
+{{- else if $global -}}
+{{- $global -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "starbyte.backend.fullname" -}}
+{{- printf "%s-backend" (include "starbyte.fullname" .) -}}
+{{- end }}
+
+{{- define "starbyte.frontend.fullname" -}}
+{{- printf "%s-frontend" (include "starbyte.fullname" .) -}}
+{{- end }}
+
+{{- define "starbyte.postgres.fullname" -}}
+{{- printf "%s-postgres" (include "starbyte.fullname" .) -}}
+{{- end }}
+
+{{- define "starbyte.redis.fullname" -}}
+{{- printf "%s-redis" (include "starbyte.fullname" .) -}}
+{{- end }}
+
+{{- define "starbyte.minio.fullname" -}}
+{{- printf "%s-minio" (include "starbyte.fullname" .) -}}
+{{- end }}
+
+{{- define "starbyte.secret.fullname" -}}
+{{- printf "%s-secret" (include "starbyte.fullname" .) -}}
+{{- end }}
+
+{{- define "starbyte.configmap.fullname" -}}
+{{- printf "%s-config" (include "starbyte.fullname" .) -}}
+{{- end }}
+
+{{- define "starbyte.ingress.fullname" -}}
+{{- printf "%s-ingress" (include "starbyte.fullname" .) -}}
+{{- end }}

--- a/deploy/helm/starbyte/templates/backend-deployment.yaml
+++ b/deploy/helm/starbyte/templates/backend-deployment.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.backend.enabled }}
+{{- $secretName := default (include "starbyte.secret.fullname" .) .Values.secrets.existingSecret }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "starbyte.backend.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      serviceAccountName: default
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ include "starbyte.image" .Values.backend.image | quote }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - name: http-backend
+              containerPort: {{ .Values.backend.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "starbyte.configmap.fullname" . }}
+            - secretRef:
+                name: {{ $secretName }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          {{- if .Values.backend.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.backend.probes.startup.path | quote }}
+              port: http-backend
+            initialDelaySeconds: {{ .Values.backend.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.backend.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.backend.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.backend.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.backend.probes.liveness.path | quote }}
+              port: http-backend
+            initialDelaySeconds: {{ .Values.backend.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.backend.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.backend.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.backend.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.backend.probes.readiness.path | quote }}
+              port: http-backend
+            initialDelaySeconds: {{ .Values.backend.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.backend.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.backend.probes.readiness.failureThreshold }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/backend-service.yaml
+++ b/deploy/helm/starbyte/templates/backend-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.backend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.backend.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - name: http-backend
+      port: {{ .Values.backend.service.port }}
+      targetPort: http-backend
+      protocol: TCP
+      {{- if and (eq .Values.backend.service.type "NodePort") .Values.backend.service.nodePort }}
+      nodePort: {{ .Values.backend.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+{{- end }}

--- a/deploy/helm/starbyte/templates/configmap.yaml
+++ b/deploy/helm/starbyte/templates/configmap.yaml
@@ -1,0 +1,44 @@
+{{- if or .Values.backend.enabled .Values.frontend.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "starbyte.configmap.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+data:
+  APP_ENV: {{ .Values.backend.env.appEnv | quote }}
+  LOG_LEVEL: {{ .Values.backend.env.logLevel | quote }}
+  CONFIG_PATH: {{ .Values.backend.env.configPath | quote }}
+  TZ: "Asia/Shanghai"
+
+  {{- if .Values.postgres.enabled }}
+  DB_HOST: {{ include "starbyte.postgres.fullname" . | quote }}
+  DB_PORT: {{ .Values.postgres.config.port | quote }}
+  DB_USER: {{ .Values.postgres.config.user | quote }}
+  DB_NAME: {{ .Values.postgres.config.db | quote }}
+  DB_SSLMODE: "disable"
+  {{- end }}
+
+  {{- if .Values.redis.enabled }}
+  REDIS_HOST: {{ include "starbyte.redis.fullname" . | quote }}
+  REDIS_PORT: {{ .Values.redis.config.port | quote }}
+  REDIS_DB: "0"
+  {{- end }}
+
+  {{- if .Values.minio.enabled }}
+  MINIO_ENDPOINT: {{ printf "%s:%v" (include "starbyte.minio.fullname" .) .Values.minio.config.port | quote }}
+  MINIO_USE_SSL: "false"
+  MINIO_BUCKET: {{ .Values.minio.bucket | quote }}
+  {{- end }}
+
+  SKIP_MIGRATION: {{ .Values.backend.env.skipMigration | quote }}
+  MIGRATION_FAIL_FATAL: {{ .Values.backend.env.migrationFailFatal | quote }}
+  SKIP_BUCKET_CREATE: {{ .Values.backend.env.skipBucketCreate | quote }}
+
+  CAS_ENABLED: {{ .Values.backend.env.casEnabled | quote }}
+  CAS_SERVER_URL: {{ .Values.backend.env.casServerUrl | quote }}
+  CAS_SERVICE_URL: {{ .Values.backend.env.casServiceUrl | quote }}
+  CAS_FRONTEND_URL: {{ .Values.backend.env.casFrontendUrl | quote }}
+  CAS_ALLOW_AUTO_PROVISION: {{ .Values.backend.env.casAllowAutoProvision | quote }}
+  CAS_DEFAULT_ROLE: {{ .Values.backend.env.casDefaultRole | quote }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/frontend-deployment.yaml
+++ b/deploy/helm/starbyte/templates/frontend-deployment.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "starbyte.frontend.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      serviceAccountName: default
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: {{ include "starbyte.image" .Values.frontend.image | quote }}
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http-frontend
+              containerPort: {{ .Values.frontend.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "starbyte.configmap.fullname" . }}
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          {{- if .Values.frontend.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.frontend.probes.liveness.path | quote }}
+              port: http-frontend
+            initialDelaySeconds: {{ .Values.frontend.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.frontend.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.frontend.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.frontend.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.frontend.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.frontend.probes.readiness.path | quote }}
+              port: http-frontend
+            initialDelaySeconds: {{ .Values.frontend.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.frontend.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.frontend.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.frontend.probes.readiness.failureThreshold }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/frontend-service.yaml
+++ b/deploy/helm/starbyte/templates/frontend-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.frontend.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - name: http-frontend
+      port: {{ .Values.frontend.service.port }}
+      targetPort: http-frontend
+      protocol: TCP
+      {{- if and (eq .Values.frontend.service.type "NodePort") .Values.frontend.service.nodePort }}
+      nodePort: {{ .Values.frontend.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+{{- end }}

--- a/deploy/helm/starbyte/templates/ingress.yaml
+++ b/deploy/helm/starbyte/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "starbyte.ingress.fullname" . -}}
+{{- $backendFullName := include "starbyte.backend.fullname" . -}}
+{{- $frontendFullName := include "starbyte.frontend.fullname" . -}}
+{{- if not .Values.ingress.hosts }}
+{{- fail "ingress.enabled=true 时必须填写 ingress.hosts；内网默认请保持 enabled=false" }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ if eq .serviceName "backend" }}{{ $backendFullName }}{{ else if eq .serviceName "frontend" }}{{ $frontendFullName }}{{ else }}{{ .serviceName }}{{ end }}
+                port:
+                  number: {{ .servicePort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/minio-deployment.yaml
+++ b/deploy/helm/starbyte/templates/minio-deployment.yaml
@@ -1,0 +1,133 @@
+{{- if .Values.minio.enabled }}
+{{- $secretName := default (include "starbyte.secret.fullname" .) .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.minio.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-api
+      port: {{ .Values.minio.config.port }}
+      targetPort: http-api
+      protocol: TCP
+    - name: http-console
+      port: {{ .Values.minio.config.consolePort }}
+      targetPort: http-console
+      protocol: TCP
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "starbyte.minio.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- $storageClass := include "starbyte.storageClass" (dict "local" .Values.minio.storage.storageClass "global" .Values.global.storageClass) }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.minio.storage.size | quote }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "starbyte.minio.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  replicas: {{ .Values.minio.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: minio
+    spec:
+      serviceAccountName: default
+      {{- with .Values.minio.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.minio.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: minio
+          image: {{ include "starbyte.image" .Values.minio.image | quote }}
+          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          {{- with .Values.minio.config.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http-api
+              containerPort: {{ .Values.minio.config.port }}
+              protocol: TCP
+            - name: http-console
+              containerPort: {{ .Values.minio.config.consolePort }}
+              protocol: TCP
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ .Values.minio.rootUser.secretKey }}
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ .Values.minio.rootPassword.secretKey }}
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "starbyte.configmap.fullname" . }}
+                  key: TZ
+          resources:
+            {{- toYaml .Values.minio.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: http-api
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: http-api
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "starbyte.minio.fullname" . }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/namespace.yaml
+++ b/deploy/helm/starbyte/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name | quote }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/postgres-statefulset.yaml
+++ b/deploy/helm/starbyte/templates/postgres-statefulset.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.postgres.enabled }}
+{{- $secretName := default (include "starbyte.secret.fullname" .) .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.postgres.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp-postgres
+      port: {{ .Values.postgres.config.port }}
+      targetPort: tcp-postgres
+      protocol: TCP
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "starbyte.postgres.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: {{ include "starbyte.postgres.fullname" . }}
+  replicas: {{ .Values.postgres.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      serviceAccountName: default
+      {{- with .Values.postgres.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgres
+          image: {{ include "starbyte.image" .Values.postgres.image | quote }}
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          ports:
+            - name: tcp-postgres
+              containerPort: {{ .Values.postgres.config.port }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "starbyte.configmap.fullname" . }}
+                  key: DB_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "starbyte.configmap.fullname" . }}
+                  key: DB_NAME
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ .Values.postgres.password.secretKey }}
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "starbyte.configmap.fullname" . }}
+                  key: TZ
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "starbyte.labels" . | nindent 10 }}
+          app.kubernetes.io/component: postgres
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- $storageClass := include "starbyte.storageClass" (dict "local" .Values.postgres.storage.storageClass "global" .Values.global.storageClass) }}
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage.size | quote }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/redis-statefulset.yaml
+++ b/deploy/helm/starbyte/templates/redis-statefulset.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.redis.enabled }}
+{{- $secretName := default (include "starbyte.secret.fullname" .) .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "starbyte.redis.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp-redis
+      port: {{ .Values.redis.config.port }}
+      targetPort: tcp-redis
+      protocol: TCP
+  selector:
+    {{- include "starbyte.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "starbyte.redis.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "starbyte.redis.fullname" . }}
+  replicas: {{ .Values.redis.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starbyte.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "starbyte.labels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      serviceAccountName: default
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: {{ include "starbyte.image" .Values.redis.image | quote }}
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: tcp-redis
+              containerPort: {{ .Values.redis.config.port }}
+              protocol: TCP
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ .Values.redis.password.secretKey }}
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "starbyte.configmap.fullname" . }}
+                  key: TZ
+          command:
+            - sh
+            - -c
+            - redis-server --appendonly yes --requirepass "$REDIS_PASSWORD"
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping | grep -q PONG
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping | grep -q PONG
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "starbyte.labels" . | nindent 10 }}
+          app.kubernetes.io/component: redis
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- $storageClass := include "starbyte.storageClass" (dict "local" .Values.redis.storage.storageClass "global" .Values.global.storageClass) }}
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage.size | quote }}
+{{- end }}

--- a/deploy/helm/starbyte/templates/secret.yaml
+++ b/deploy/helm/starbyte/templates/secret.yaml
@@ -1,0 +1,44 @@
+{{- /*
+Secret 仅在 secrets.create=true 且 allowInsecure=true 时渲染（开发）。
+生产必须 secrets.create=false，由 Sealed Secrets / External Secrets / 手工 Secret 提供。
+
+统一 key（与 raw k8s secret.yaml.example、docker-compose、backend config.Load 对齐）：
+  DB_PASSWORD
+  REDIS_PASSWORD
+  MINIO_ACCESS_KEY
+  MINIO_SECRET_KEY
+  JWT_SECRET
+同时写入容器侧别名，避免 StatefulSet/MinIO 读另一套名字：
+  POSTGRES_PASSWORD = DB_PASSWORD
+  MINIO_ROOT_USER = MINIO_ACCESS_KEY
+  MINIO_ROOT_PASSWORD = MINIO_SECRET_KEY
+*/ -}}
+{{- if .Values.secrets.create }}
+{{- if not .Values.secrets.allowInsecure }}
+{{- fail "secrets.create=true 仅允许配合 secrets.allowInsecure=true（开发）。生产请设 secrets.create=false，并预先创建 Secret。" }}
+{{- end }}
+{{- $data := .Values.secrets.secretData | default dict }}
+{{- $required := list "DB_PASSWORD" "REDIS_PASSWORD" "MINIO_ACCESS_KEY" "MINIO_SECRET_KEY" "JWT_SECRET" }}
+{{- range $required }}
+{{- $val := index $data . | default "" | toString }}
+{{- if or (eq $val "") (hasPrefix "change-me" $val) }}
+{{- fail (printf "secrets.secretData.%s 为空或仍是 change-me-* 占位，拒绝渲染" .) }}
+{{- end }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "starbyte.secret.fullname" . }}
+  labels:
+    {{- include "starbyte.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  DB_PASSWORD: {{ $data.DB_PASSWORD | quote }}
+  POSTGRES_PASSWORD: {{ $data.DB_PASSWORD | quote }}
+  REDIS_PASSWORD: {{ $data.REDIS_PASSWORD | quote }}
+  MINIO_ACCESS_KEY: {{ $data.MINIO_ACCESS_KEY | quote }}
+  MINIO_SECRET_KEY: {{ $data.MINIO_SECRET_KEY | quote }}
+  MINIO_ROOT_USER: {{ $data.MINIO_ACCESS_KEY | quote }}
+  MINIO_ROOT_PASSWORD: {{ $data.MINIO_SECRET_KEY | quote }}
+  JWT_SECRET: {{ $data.JWT_SECRET | quote }}
+{{- end }}

--- a/deploy/helm/starbyte/values-dev.yaml
+++ b/deploy/helm/starbyte/values-dev.yaml
@@ -1,0 +1,99 @@
+# 本地 / 实验集群覆盖。禁止用于生产。
+# helm upgrade --install starbyte deploy/helm/starbyte \
+#   -n starbyte-dev --create-namespace -f deploy/helm/starbyte/values-dev.yaml
+
+global:
+  imagePullPolicy: IfNotPresent
+  storageClass: ""
+
+namespace:
+  name: starbyte-dev
+  create: false
+
+backend:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  env:
+    appEnv: development
+    logLevel: debug
+  probes:
+    liveness:
+      initialDelaySeconds: 15
+    readiness:
+      initialDelaySeconds: 5
+    startup:
+      initialDelaySeconds: 5
+  service:
+    type: NodePort
+    port: 8080
+    targetPort: 8080
+    nodePort: 30080
+
+frontend:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+  service:
+    type: NodePort
+    port: 80
+    targetPort: 80
+    nodePort: 30081
+
+postgres:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  storage:
+    size: 5Gi
+
+redis:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+  storage:
+    size: 1Gi
+
+minio:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  storage:
+    size: 5Gi
+
+ingress:
+  enabled: false
+  tls: []
+
+# 仅开发允许 chart 自建 Secret。值是本地占位，不是生产口令。
+secrets:
+  create: true
+  allowInsecure: true
+  secretData:
+    DB_PASSWORD: "dev-only-postgres-password"
+    REDIS_PASSWORD: "dev-only-redis-password"
+    MINIO_ACCESS_KEY: "dev-only-minio-access"
+    MINIO_SECRET_KEY: "dev-only-minio-secret"
+    JWT_SECRET: "dev-only-jwt-secret-not-for-prod"

--- a/deploy/helm/starbyte/values-prod.yaml
+++ b/deploy/helm/starbyte/values-prod.yaml
@@ -1,0 +1,133 @@
+# 生产 / 内网集群覆盖。
+# helm upgrade --install starbyte deploy/helm/starbyte \
+#   -n starbyte --create-namespace \
+#   -f deploy/helm/starbyte/values-prod.yaml
+#
+# 部署前必须：
+# 1. 集群中已有 Secret（默认名 <release>-secret），key 见 secret.yaml 注释
+# 2. 不要把明文口令写进本文件或 Git
+# 3. 内网默认不启用 Ingress / Let's Encrypt
+
+global:
+  imagePullPolicy: IfNotPresent
+  storageClass: ""
+
+namespace:
+  name: starbyte
+  create: false
+
+backend:
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  env:
+    appEnv: production
+    logLevel: warn
+  probes:
+    liveness:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      failureThreshold: 3
+    readiness:
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      failureThreshold: 3
+    startup:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      failureThreshold: 30
+  service:
+    type: ClusterIP
+    port: 8080
+    targetPort: 8080
+    nodePort: null
+
+frontend:
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  probes:
+    liveness:
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      failureThreshold: 3
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 3
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 80
+    nodePort: null
+
+postgres:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+  storage:
+    size: 50Gi
+
+redis:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 10Gi
+
+minio:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  storage:
+    size: 200Gi
+
+# 内网默认：不建 Ingress，也不依赖 cert-manager / Let's Encrypt。
+# 需要七层入口时再打开，并按需补 host；TLS 完全可选。
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+  # 示例（保持注释，避免占位域名被当成生产配置）：
+  # hosts:
+  #   - host: starbyte.internal
+  #     paths:
+  #       - path: /
+  #         pathType: Prefix
+  #         serviceName: frontend
+  #         servicePort: 80
+  #       - path: /api/
+  #         pathType: Prefix
+  #         serviceName: backend
+  #         servicePort: 8080
+  hosts: []
+  tls: []
+
+# 强制：不创建、不继承 change-me / 明文口令
+secrets:
+  create: false
+  allowInsecure: false
+  existingSecret: ""
+  secretData: {}

--- a/deploy/helm/starbyte/values.yaml
+++ b/deploy/helm/starbyte/values.yaml
@@ -1,0 +1,218 @@
+# StarByte Helm 默认值（内网友好、不自动上集群）
+# 学校当前生产路径仍是 deploy/docker-compose.yml。
+# 开发覆盖：values-dev.yaml；生产覆盖：values-prod.yaml（禁止创建明文 Secret）。
+
+fullnameOverride: ""
+nameOverride: ""
+
+global:
+  # 与 CD / 清单统一：ghcr.io/yogdunana/starbyte-backend，不是 ghcr.io/Yogdunana/StarByte/backend
+  imageRegistry: ghcr.io/yogdunana
+  imagePullPolicy: IfNotPresent
+  storageClass: ""
+  imagePullSecrets: []
+
+namespace:
+  name: starbyte
+  # 用 helm --namespace --create-namespace，避免模板再造 Namespace
+  create: false
+
+backend:
+  enabled: true
+  image:
+    repository: ghcr.io/yogdunana/starbyte-backend
+    tag: "1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  env:
+    appEnv: production
+    configPath: configs/config.yaml
+    logLevel: info
+    casEnabled: "true"
+    casServerUrl: https://authserver.smbu.edu.cn/authserver
+    casServiceUrl: ""
+    casFrontendUrl: ""
+    casAllowAutoProvision: "true"
+    casDefaultRole: member
+    skipMigration: "false"
+    migrationFailFatal: "true"
+    skipBucketCreate: "false"
+  probes:
+    liveness:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      path: /health/ready
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    startup:
+      enabled: true
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+  service:
+    type: ClusterIP
+    port: 8080
+    targetPort: 8080
+    nodePort: null
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+frontend:
+  enabled: true
+  image:
+    repository: ghcr.io/yogdunana/starbyte-frontend
+    tag: "1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  probes:
+    liveness:
+      enabled: true
+      path: /
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      path: /
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 80
+    nodePort: null
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+postgres:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16-alpine"
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 20Gi
+    storageClass: ""
+  config:
+    user: starbyte
+    db: starbyte
+    port: 5432
+  # 与 raw k8s / docker-compose / config.Load 对齐
+  password:
+    secretKey: DB_PASSWORD
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7-alpine"
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  storage:
+    size: 5Gi
+    storageClass: ""
+  config:
+    port: 6379
+  password:
+    secretKey: REDIS_PASSWORD
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+minio:
+  enabled: true
+  image:
+    repository: minio/minio
+    tag: "RELEASE.2024-08-17T01-16-21Z"
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  storage:
+    size: 50Gi
+    storageClass: ""
+  config:
+    port: 9000
+    consolePort: 9001
+    args:
+      - server
+      - /data
+      - --console-address
+      - ":9001"
+  # 容器读 MINIO_ROOT_*，Secret 里同时提供 MINIO_ACCESS_KEY / MINIO_SECRET_KEY 给后端 envFrom
+  rootUser:
+    secretKey: MINIO_ACCESS_KEY
+  rootPassword:
+    secretKey: MINIO_SECRET_KEY
+  bucket: starbyte
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# 内网默认：NodePort / 集群 IP 即可，不强制 Ingress，更不要求 Let's Encrypt
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+  hosts: []
+  tls: []
+
+# 默认不创建 Secret。生产必须由集群已有 Secret / Sealed / External Secrets 提供。
+# 仅 values-dev.yaml 允许 allowInsecure + create。
+secrets:
+  create: false
+  allowInsecure: false
+  existingSecret: ""
+  secretData: {}

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,86 @@
+# StarByte Kubernetes 清单（可选）
+
+**学校当前生产部署以 Docker Compose 为准**，见 `deploy/docker-compose.yml` 与 `docs/deployment.md`。
+本目录是学习 / 预研模板，合入仓库**不会**让 `main` 自动往集群部署。
+
+## 目录
+
+```
+deploy/k8s/
+├── kustomization.yaml           # 默认清单（不含 Secret / Ingress）
+├── namespace.yaml
+├── configmap.yaml
+├── secret.yaml.example          # 复制为 secret.yaml 后填写，勿提交
+├── postgres-statefulset.yaml
+├── redis-statefulset.yaml
+├── minio-deployment.yaml
+├── backend-deployment.yaml
+├── backend-service.yaml
+├── frontend-deployment.yaml
+├── frontend-service.yaml
+├── ingress.yaml                 # 可选，默认不 apply
+├── rollback.sh                  # ./rollback.sh backend|frontend|all
+├── blue-green/
+│   ├── README.md
+│   ├── *-deployment-{blue,green}.yaml
+│   ├── service-blue-green.yaml
+│   └── switch.sh
+└── canary/
+    ├── README.md
+    ├── backend-canary-deployment.yaml
+    ├── frontend-canary-deployment.yaml
+    ├── canary-services.yaml
+    └── canary-ingress.yaml
+```
+
+Helm Chart：`deploy/helm/starbyte/`。
+
+## 密钥 key（Helm 与 raw k8s 相同）
+
+| Secret key | 用途 |
+|------------|------|
+| `DB_PASSWORD` | Postgres `POSTGRES_PASSWORD` + 后端 `DB_PASSWORD` |
+| `REDIS_PASSWORD` | Redis / 后端 |
+| `MINIO_ACCESS_KEY` | MinIO `MINIO_ROOT_USER` + 后端 |
+| `MINIO_SECRET_KEY` | MinIO `MINIO_ROOT_PASSWORD` + 后端 |
+| `JWT_SECRET` | 后端 JWT |
+
+镜像名与 Chart 一致：`ghcr.io/yogdunana/starbyte-backend`、`ghcr.io/yogdunana/starbyte-frontend`。
+
+## 快速部署（实验集群）
+
+```bash
+cp deploy/k8s/secret.yaml.example deploy/k8s/secret.yaml
+# 编辑 secret.yaml，填入真实 base64 值
+kubectl apply -f deploy/k8s/secret.yaml
+kubectl apply -k deploy/k8s/
+kubectl get pods -n starbyte
+```
+
+Helm（生产覆盖禁止自建 Secret）：
+
+```bash
+# 先创建 Secret，再
+helm upgrade --install starbyte deploy/helm/starbyte \
+  --namespace starbyte --create-namespace \
+  --values deploy/helm/starbyte/values-prod.yaml \
+  --set backend.image.repository=ghcr.io/yogdunana/starbyte-backend \
+  --set backend.image.tag=1.0.0 \
+  --set frontend.image.repository=ghcr.io/yogdunana/starbyte-frontend \
+  --set frontend.image.tag=1.0.0
+```
+
+Ingress 默认关闭。需要时再 `kubectl apply -f deploy/k8s/ingress.yaml`，不必上 Let's Encrypt。
+
+## 回滚 / 蓝绿 / 金丝雀
+
+```bash
+./deploy/k8s/rollback.sh backend
+./deploy/k8s/rollback.sh frontend
+./deploy/k8s/rollback.sh all
+
+./deploy/k8s/blue-green/switch.sh green
+./deploy/k8s/blue-green/switch.sh status
+```
+
+金丝雀文档与文件名以 `canary/README.md` 为准（Service 在 `canary-services.yaml`）。

--- a/deploy/k8s/backend-deployment.yaml
+++ b/deploy/k8s/backend-deployment.yaml
@@ -1,0 +1,64 @@
+# 后端：ghcr.io/yogdunana/starbyte-backend（与 Helm values 一致，不是 StarByte/backend）
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-backend
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+      app.kubernetes.io/instance: starbyte
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: backend
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/yogdunana/starbyte-backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: starbyte-config
+            - secretRef:
+                name: starbyte-secret
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/deploy/k8s/backend-service.yaml
+++ b/deploy/k8s/backend-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-backend
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/instance: starbyte

--- a/deploy/k8s/blue-green/README.md
+++ b/deploy/k8s/blue-green/README.md
@@ -1,0 +1,50 @@
+# StarByte 蓝绿部署（学习模板）
+
+与 Docker Compose 生产路径并行存在，**不要**在未规划的集群上当默认发布方式。
+
+## 策略
+
+维护 Blue / Green 两套 Deployment，Service 用 `selector.version` 切流量。
+
+`switch.sh` 使用 JSON patch **只改** `/spec/selector/version`，并校验 `app` / `component` 仍在。
+不要用只含 `version` 的 merge/strategic patch，那会整表替换 selector。
+
+## 使用
+
+### 1. 初始（Blue 接流量）
+
+```bash
+kubectl apply -f deploy/k8s/blue-green/backend-deployment-blue.yaml
+kubectl apply -f deploy/k8s/blue-green/backend-deployment-green.yaml
+kubectl apply -f deploy/k8s/blue-green/frontend-deployment-blue.yaml
+kubectl apply -f deploy/k8s/blue-green/frontend-deployment-green.yaml
+kubectl apply -f deploy/k8s/blue-green/service-blue-green.yaml
+```
+
+### 2. 发布到空闲色
+
+```bash
+kubectl set image deployment/starbyte-backend-green \
+  backend=ghcr.io/yogdunana/starbyte-backend:v2.0.0 -n starbyte
+kubectl set image deployment/starbyte-frontend-green \
+  frontend=ghcr.io/yogdunana/starbyte-frontend:v2.0.0 -n starbyte
+kubectl rollout status deployment/starbyte-backend-green -n starbyte
+kubectl rollout status deployment/starbyte-frontend-green -n starbyte
+```
+
+### 3. 切换 / 回滚
+
+```bash
+./deploy/k8s/blue-green/switch.sh green
+./deploy/k8s/blue-green/switch.sh status
+# 回滚
+./deploy/k8s/blue-green/switch.sh blue
+```
+
+滚动更新回滚（非蓝绿）见 `../rollback.sh`：
+
+```bash
+./deploy/k8s/rollback.sh backend
+./deploy/k8s/rollback.sh frontend
+./deploy/k8s/rollback.sh all
+```

--- a/deploy/k8s/blue-green/backend-deployment-blue.yaml
+++ b/deploy/k8s/blue-green/backend-deployment-blue.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-backend-blue
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+    version: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: starbyte
+      component: backend
+      version: blue
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: backend
+        version: blue
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/yogdunana/starbyte-backend:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: starbyte-config
+            - secretRef:
+                name: starbyte-secret
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/deploy/k8s/blue-green/backend-deployment-green.yaml
+++ b/deploy/k8s/blue-green/backend-deployment-green.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-backend-green
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+    version: green
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: starbyte
+      component: backend
+      version: green
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: backend
+        version: green
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/yogdunana/starbyte-backend:latest
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: starbyte-config
+            - secretRef:
+                name: starbyte-secret
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/deploy/k8s/blue-green/frontend-deployment-blue.yaml
+++ b/deploy/k8s/blue-green/frontend-deployment-blue.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-frontend-blue
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+    version: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: starbyte
+      component: frontend
+      version: blue
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: frontend
+        version: blue
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/yogdunana/starbyte-frontend:latest
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/deploy/k8s/blue-green/frontend-deployment-green.yaml
+++ b/deploy/k8s/blue-green/frontend-deployment-green.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-frontend-green
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+    version: green
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: starbyte
+      component: frontend
+      version: green
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: frontend
+        version: green
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/yogdunana/starbyte-frontend:latest
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/deploy/k8s/blue-green/service-blue-green.yaml
+++ b/deploy/k8s/blue-green/service-blue-green.yaml
@@ -1,0 +1,40 @@
+# 通过 selector.version 切换流量。patch 时必须保留 app / component，见 switch.sh。
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-backend-bg
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: starbyte
+    component: backend
+    version: blue
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-frontend-bg
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: starbyte
+    component: frontend
+    version: blue
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP

--- a/deploy/k8s/blue-green/switch.sh
+++ b/deploy/k8s/blue-green/switch.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# 蓝绿流量切换。
+#   ./switch.sh green
+#   ./switch.sh blue
+#   ./switch.sh status
+#
+# #145 的 merge patch 只写 version，会整表替换 selector，丢掉 app/component。
+# 这里用 JSON patch 只改 /spec/selector/version，并校验其余 label 仍在。
+set -euo pipefail
+
+NAMESPACE="${STARBYTE_NAMESPACE:-starbyte}"
+
+assert_selector() {
+  local svc="$1"
+  local component="$2"
+  local expected_version="$3"
+  local app version comp
+  app="$(kubectl get svc "$svc" -n "$NAMESPACE" -o jsonpath='{.spec.selector.app}')"
+  comp="$(kubectl get svc "$svc" -n "$NAMESPACE" -o jsonpath='{.spec.selector.component}')"
+  version="$(kubectl get svc "$svc" -n "$NAMESPACE" -o jsonpath='{.spec.selector.version}')"
+  if [[ "$app" != "starbyte" || "$comp" != "$component" || "$version" != "$expected_version" ]]; then
+    echo "❌ ${svc} selector 异常: app=${app} component=${comp} version=${version}" >&2
+    echo "   期望: app=starbyte component=${component} version=${expected_version}" >&2
+    exit 1
+  fi
+}
+
+patch_version() {
+  local svc="$1"
+  local component="$2"
+  local target="$3"
+  # 只替换 version，避免 wipe app/component
+  kubectl patch service "$svc" -n "$NAMESPACE" --type=json \
+    -p "[{\"op\":\"replace\",\"path\":\"/spec/selector/version\",\"value\":\"${target}\"}]"
+  assert_selector "$svc" "$component" "$target"
+}
+
+case "${1:-status}" in
+  blue|green)
+    TARGET="$1"
+    echo "🔄 切换流量到 ${TARGET}..."
+
+    echo "  → 扩容 ${TARGET} 环境..."
+    kubectl scale deployment "starbyte-backend-${TARGET}" --replicas=2 -n "$NAMESPACE"
+    kubectl scale deployment "starbyte-frontend-${TARGET}" --replicas=2 -n "$NAMESPACE"
+
+    echo "  → 等待 ${TARGET} 就绪..."
+    kubectl rollout status "deployment/starbyte-backend-${TARGET}" -n "$NAMESPACE" --timeout=3m
+    kubectl rollout status "deployment/starbyte-frontend-${TARGET}" -n "$NAMESPACE" --timeout=3m
+
+    echo "  → JSON patch selector.version=${TARGET}（保留 app/component）..."
+    patch_version starbyte-backend-bg backend "$TARGET"
+    patch_version starbyte-frontend-bg frontend "$TARGET"
+
+    OTHER=$([ "$TARGET" = "blue" ] && echo "green" || echo "blue")
+    echo "  → 缩容 ${OTHER} 环境（0 副本）..."
+    kubectl scale deployment "starbyte-backend-${OTHER}" --replicas=0 -n "$NAMESPACE"
+    kubectl scale deployment "starbyte-frontend-${OTHER}" --replicas=0 -n "$NAMESPACE"
+
+    echo "✅ 流量已切换到 ${TARGET}，selector 仍含 app/component"
+    ;;
+
+  status)
+    echo "📊 蓝绿部署状态 (namespace: ${NAMESPACE})"
+    echo "──────────────────────────────────────────"
+    for svc in starbyte-backend-bg starbyte-frontend-bg; do
+      SELECTOR="$(kubectl get svc "$svc" -n "$NAMESPACE" \
+        -o jsonpath='app={.spec.selector.app} component={.spec.selector.component} version={.spec.selector.version}' \
+        2>/dev/null || echo "N/A")"
+      echo "  ${svc} → ${SELECTOR}"
+    done
+    echo ""
+    echo "Deployments:"
+    kubectl get deployments -n "$NAMESPACE" \
+      -l 'app in (starbyte),component in (backend,frontend)' \
+      -o custom-columns=NAME:.metadata.name,REPLICAS:.spec.replicas,READY:.status.readyReplicas,VERSION:.metadata.labels.version \
+      2>/dev/null || echo "  (无部署)"
+    ;;
+
+  *)
+    echo "用法: $0 {blue|green|status}"
+    exit 1
+    ;;
+esac

--- a/deploy/k8s/canary/README.md
+++ b/deploy/k8s/canary/README.md
@@ -1,0 +1,52 @@
+# StarByte 金丝雀发布（学习模板）
+
+依赖 **Nginx Ingress Controller** 的 `nginx.ingress.kubernetes.io/canary-*`。
+学校内网默认没有 Ingress / Let's Encrypt，不要把本目录当默认部署路径。
+
+## 文件名（与仓库一致）
+
+| 用途 | 实际文件 |
+|------|----------|
+| 后端金丝雀 Deployment | `backend-canary-deployment.yaml` |
+| 前端金丝雀 Deployment | `frontend-canary-deployment.yaml` |
+| 前后端 Service（合并） | `canary-services.yaml` |
+| 金丝雀 Ingress | `canary-ingress.yaml` |
+
+没有 `backend-canary-service.yaml` / `frontend-canary-service.yaml`。
+
+## 使用
+
+主流量仍走 `deploy/k8s/` 的稳定 Deployment。需要七层入口时再单独 `kubectl apply -f deploy/k8s/ingress.yaml`。
+
+```bash
+kubectl apply -f deploy/k8s/canary/backend-canary-deployment.yaml
+kubectl apply -f deploy/k8s/canary/frontend-canary-deployment.yaml
+kubectl apply -f deploy/k8s/canary/canary-services.yaml
+kubectl apply -f deploy/k8s/canary/canary-ingress.yaml
+```
+
+调权重：
+
+```bash
+kubectl annotate ingress starbyte-canary-ingress \
+  nginx.ingress.kubernetes.io/canary-weight=30 \
+  -n starbyte --overwrite
+```
+
+回滚：权重改回 `0`，或 `kubectl delete -f deploy/k8s/canary/`。
+
+滚动更新回滚（稳定轨）使用：
+
+```bash
+./deploy/k8s/rollback.sh backend
+./deploy/k8s/rollback.sh frontend
+./deploy/k8s/rollback.sh all
+```
+
+按 Header 灰度（可选）：
+
+```yaml
+annotations:
+  nginx.ingress.kubernetes.io/canary-by-header: "X-Canary"
+  nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+```

--- a/deploy/k8s/canary/backend-canary-deployment.yaml
+++ b/deploy/k8s/canary/backend-canary-deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-backend-canary
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+    track: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: starbyte
+      component: backend
+      track: canary
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: backend
+        track: canary
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/yogdunana/starbyte-backend:canary
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: starbyte-config
+            - secretRef:
+                name: starbyte-secret
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30

--- a/deploy/k8s/canary/canary-ingress.yaml
+++ b/deploy/k8s/canary/canary-ingress.yaml
@@ -1,0 +1,34 @@
+# 依赖 Nginx Ingress Controller 的 canary 注解。内网无 Ingress 时不要 apply。
+# 无 TLS / 无 Let's Encrypt。
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: starbyte-canary-ingress
+  namespace: starbyte
+  labels:
+    app: starbyte
+    track: canary
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "10"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: starbyte.internal
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: starbyte-backend-canary
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: starbyte-frontend-canary
+                port:
+                  number: 80

--- a/deploy/k8s/canary/canary-services.yaml
+++ b/deploy/k8s/canary/canary-services.yaml
@@ -1,0 +1,42 @@
+# 金丝雀 Service（单一文件，文档请引用本文件名，不要写成 backend-canary-service.yaml）
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-backend-canary
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: backend
+    track: canary
+spec:
+  type: ClusterIP
+  selector:
+    app: starbyte
+    component: backend
+    track: canary
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-frontend-canary
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+    track: canary
+spec:
+  type: ClusterIP
+  selector:
+    app: starbyte
+    component: frontend
+    track: canary
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP

--- a/deploy/k8s/canary/frontend-canary-deployment.yaml
+++ b/deploy/k8s/canary/frontend-canary-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-frontend-canary
+  namespace: starbyte
+  labels:
+    app: starbyte
+    component: frontend
+    track: canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: starbyte
+      component: frontend
+      track: canary
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: starbyte
+        component: frontend
+        track: canary
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/yogdunana/starbyte-frontend:canary
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,39 @@
+# 非敏感配置，key 与 docker-compose.yml / backend config.Load 对齐。
+# 密码与 JWT 见 secret.yaml.example。
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: starbyte-config
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: starbyte
+    app.kubernetes.io/part-of: starbyte
+data:
+  APP_ENV: "prod"
+  TZ: "Asia/Shanghai"
+  CONFIG_PATH: "configs/config.yaml"
+
+  DB_HOST: "postgres-starbyte"
+  DB_PORT: "5432"
+  DB_USER: "starbyte"
+  DB_NAME: "starbyte"
+  DB_SSLMODE: "disable"
+
+  REDIS_HOST: "redis-starbyte"
+  REDIS_PORT: "6379"
+  REDIS_DB: "0"
+
+  MINIO_ENDPOINT: "minio-starbyte:9000"
+  MINIO_USE_SSL: "false"
+  MINIO_BUCKET: "starbyte"
+
+  SKIP_MIGRATION: "false"
+  MIGRATION_FAIL_FATAL: "true"
+  SKIP_BUCKET_CREATE: "false"
+
+  CAS_ENABLED: "true"
+  CAS_SERVER_URL: "https://authserver.smbu.edu.cn/authserver"
+  CAS_SERVICE_URL: ""
+  CAS_FRONTEND_URL: ""
+  CAS_ALLOW_AUTO_PROVISION: "true"
+  CAS_DEFAULT_ROLE: "member"

--- a/deploy/k8s/frontend-deployment.yaml
+++ b/deploy/k8s/frontend-deployment.yaml
@@ -1,0 +1,59 @@
+# 前端：ghcr.io/yogdunana/starbyte-frontend
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starbyte-frontend
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+      app.kubernetes.io/instance: starbyte
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/yogdunana/starbyte-frontend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/deploy/k8s/frontend-service.yaml
+++ b/deploy/k8s/frontend-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: starbyte-frontend
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: starbyte

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,0 +1,37 @@
+# 可选 Ingress。默认 kustomization 不引用本文件。
+# 内网用 ClusterIP + port-forward / NodePort 即可，不需要 Let's Encrypt。
+# 启用：kubectl apply -f deploy/k8s/ingress.yaml
+# 把 host 换成内网域名或删掉 host 字段（部分控制器要求 host）。
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: starbyte-ingress
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: starbyte
+    app.kubernetes.io/part-of: starbyte
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: starbyte.internal
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: starbyte-backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: starbyte-frontend
+                port:
+                  number: 80

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,23 @@
+# 用法: kubectl apply -k deploy/k8s/
+# Secret、Ingress 不在默认清单中（内网可不配七层入口，也不提交明文密钥）。
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: starbyte
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - postgres-statefulset.yaml
+  - redis-statefulset.yaml
+  - minio-deployment.yaml
+  - backend-deployment.yaml
+  - backend-service.yaml
+  - frontend-deployment.yaml
+  - frontend-service.yaml
+
+images:
+  - name: ghcr.io/yogdunana/starbyte-backend
+    newTag: latest
+  - name: ghcr.io/yogdunana/starbyte-frontend
+    newTag: latest

--- a/deploy/k8s/minio-deployment.yaml
+++ b/deploy/k8s/minio-deployment.yaml
@@ -1,0 +1,127 @@
+# MinIO。Secret key：MINIO_ACCESS_KEY / MINIO_SECRET_KEY（容器映射为 ROOT_USER / ROOT_PASSWORD）
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+    - name: console
+      port: 9001
+      targetPort: 9001
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: starbyte
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+      app.kubernetes.io/instance: starbyte
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2024-08-17T01-16-21Z
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - minio server /data --console-address ":9001"
+          ports:
+            - name: s3
+              containerPort: 9000
+              protocol: TCP
+            - name: console
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: starbyte-secret
+                  key: MINIO_ACCESS_KEY
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: starbyte-secret
+                  key: MINIO_SECRET_KEY
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: TZ
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: s3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: s3
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-starbyte-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-starbyte-data
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,9 @@
+# Namespace：starbyte。学校内网默认仍走 Docker Compose，本清单仅在明确要上集群时使用。
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: starbyte
+  labels:
+    app.kubernetes.io/name: starbyte
+    app.kubernetes.io/part-of: starbyte
+    app.kubernetes.io/managed-by: kubectl

--- a/deploy/k8s/postgres-statefulset.yaml
+++ b/deploy/k8s/postgres-statefulset.yaml
@@ -1,0 +1,118 @@
+# PostgreSQL 16。密码 key：DB_PASSWORD（与 Helm / compose 对齐）
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: starbyte
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  serviceName: postgres-starbyte
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/instance: starbyte
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: DB_NAME
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: DB_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: starbyte-secret
+                  key: DB_PASSWORD
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: TZ
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: postgres
+          app.kubernetes.io/instance: starbyte
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/deploy/k8s/redis-statefulset.yaml
+++ b/deploy/k8s/redis-statefulset.yaml
@@ -1,0 +1,110 @@
+# Redis 7。密码 key：REDIS_PASSWORD
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: starbyte
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-starbyte
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: starbyte
+    app.kubernetes.io/part-of: starbyte
+spec:
+  serviceName: redis-starbyte
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/instance: starbyte
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/instance: starbyte
+        app.kubernetes.io/part-of: starbyte
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          command:
+            - /bin/sh
+            - -c
+            - redis-server --requirepass "$REDIS_PASSWORD" --appendonly yes
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: starbyte-secret
+                  key: REDIS_PASSWORD
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: starbyte-config
+                  key: TZ
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping | grep PONG
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping | grep PONG
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: redis
+          app.kubernetes.io/instance: starbyte
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi

--- a/deploy/k8s/rollback.sh
+++ b/deploy/k8s/rollback.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# 回滚 backend / frontend（kubectl rollout undo）
+#
+# 用法:
+#   ./rollback.sh backend              # 或 starbyte-backend
+#   ./rollback.sh frontend             # 或 starbyte-frontend
+#   ./rollback.sh all
+#   ./rollback.sh backend starbyte     # 第二参数为 namespace
+set -euo pipefail
+
+TARGET="${1:-backend}"
+NAMESPACE="${2:-${STARBYTE_NAMESPACE:-starbyte}}"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+resolve_name() {
+  case "$1" in
+    backend|starbyte-backend) echo "starbyte-backend" ;;
+    frontend|starbyte-frontend) echo "starbyte-frontend" ;;
+    all) echo "all" ;;
+    *)
+      echo -e "${RED}错误: 仅支持 backend | frontend | all | starbyte-backend | starbyte-frontend${NC}" >&2
+      echo "用法: $0 {backend|frontend|all} [namespace]" >&2
+      exit 1
+      ;;
+  esac
+}
+
+rollback_one() {
+  local name="$1"
+  echo -e "${YELLOW}=== 回滚 ${name} (ns=${NAMESPACE}) ===${NC}"
+  kubectl rollout history "deployment/${name}" -n "${NAMESPACE}"
+  kubectl rollout undo "deployment/${name}" -n "${NAMESPACE}"
+  kubectl rollout status "deployment/${name}" -n "${NAMESPACE}" --timeout=5m
+  echo -e "${GREEN}✅ ${name} 回滚完成${NC}"
+}
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo -e "${RED}错误: 未检测到 kubectl${NC}" >&2
+  exit 1
+fi
+
+RESOLVED="$(resolve_name "${TARGET}")"
+if [[ "${RESOLVED}" == "all" ]]; then
+  rollback_one starbyte-backend
+  rollback_one starbyte-frontend
+else
+  rollback_one "${RESOLVED}"
+fi

--- a/deploy/k8s/secret.yaml.example
+++ b/deploy/k8s/secret.yaml.example
@@ -1,0 +1,32 @@
+# Secret 示例。禁止把填好真实值的 secret.yaml 提交进 Git。
+#
+# 复制：cp deploy/k8s/secret.yaml.example deploy/k8s/secret.yaml
+# 生成：echo -n 'your-real-secret' | base64
+#
+# key 与 Helm chart / docker-compose / backend config.Load 对齐：
+#   DB_PASSWORD
+#   REDIS_PASSWORD
+#   MINIO_ACCESS_KEY   （MinIO 容器作 MINIO_ROOT_USER）
+#   MINIO_SECRET_KEY   （MinIO 容器作 MINIO_ROOT_PASSWORD）
+#   JWT_SECRET
+# 可选别名（与 compose 变量同值，方便对照）：
+#   POSTGRES_PASSWORD / MINIO_ROOT_USER / MINIO_ROOT_PASSWORD
+apiVersion: v1
+kind: Secret
+metadata:
+  name: starbyte-secret
+  namespace: starbyte
+  labels:
+    app.kubernetes.io/name: starbyte
+    app.kubernetes.io/part-of: starbyte
+type: Opaque
+data:
+  # 下列均为 echo -n 'changeme' | base64，部署前必须替换
+  DB_PASSWORD: Y2hhbmdlbWU=
+  POSTGRES_PASSWORD: Y2hhbmdlbWU=
+  REDIS_PASSWORD: Y2hhbmdlbWU=
+  MINIO_ACCESS_KEY: Y2hhbmdlbWU=
+  MINIO_SECRET_KEY: Y2hhbmdlbWU=
+  MINIO_ROOT_USER: Y2hhbmdlbWU=
+  MINIO_ROOT_PASSWORD: Y2hhbmdlbWU=
+  JWT_SECRET: Y2hhbmdlbWU=

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,3 +94,15 @@ cat starbyte-2026-09-07.sql | docker exec -i starbyte-postgres psql -U starbyte 
 ```
 
 MinIO 桶与 Postgres 一起备份。恢复后执行 `make migrate-up` 确认 schema 版本。
+
+## Kubernetes / Helm（可选，非默认）
+
+漏测与学校内网**继续用上面的 Docker Compose**。`deploy/k8s/` 与 `deploy/helm/starbyte/` 是预研模板：
+
+- 合入 `main` **不会**自动往任何集群部署。`.github/workflows/cd.yml` 仅 `workflow_dispatch`，且默认只推镜像、不 `helm upgrade`。
+- 默认不启用 Ingress，也不依赖 Let's Encrypt / cert-manager。
+- 生产 values（`values-prod.yaml`）`secrets.create: false`，须事先创建 Secret。key 与 Compose 一致：`DB_PASSWORD`、`REDIS_PASSWORD`、`MINIO_ACCESS_KEY`、`MINIO_SECRET_KEY`、`JWT_SECRET`。
+- 镜像名：`ghcr.io/yogdunana/starbyte-backend`、`ghcr.io/yogdunana/starbyte-frontend`（repository 与 tag 拆开设置）。
+
+说明与操作见 `deploy/k8s/README.md`。
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

从被拒的 [#145](https://github.com/Yogdunana/StarByte/pull/145) 移植可用的 K8s / Helm / 蓝绿 / 金丝雀模板，并按评审意见硬化。**学校内网当前仍以 Docker Compose 为准**；本 PR **不会**让 `main` 自动部署到任何集群。

相对 #145 的硬性修复：

1. **CD 仅 `workflow_dispatch`**：无 `push: main` / tag 自动部署。默认只构建并推送镜像；必须手动勾选 `deploy=true` 才会 `helm upgrade`，且走 GitHub Environment。
2. **Helm 镜像接线**：`--set backend.image.repository` + `--set backend.image.tag` 拆开；helper 拒绝把完整 URL 当 tag。GHCR 名与 chart 对齐：`ghcr.io/yogdunana/starbyte-backend` / `starbyte-frontend`（不再用 `ghcr.io/Yogdunana/StarByte/backend`）。
3. **`values-prod`**：`secrets.create: false`，`secretData: {}`，`allowInsecure: false`。误开 `create=true` 会 `fail`；`change-me-*` 不会进入生产渲染。
4. **蓝绿 `switch.sh`**：JSON patch 只改 `/spec/selector/version`，并校验 `app` / `component` 仍在，避免 merge patch 整表替换 selector。
5. **Secret key 对齐** Helm 与 raw k8s / Compose / `config.Load`：`DB_PASSWORD`、`REDIS_PASSWORD`、`MINIO_ACCESS_KEY`、`MINIO_SECRET_KEY`、`JWT_SECRET`。回滚脚本接受 `backend|frontend|all`；金丝雀文档使用实际文件名 `canary-services.yaml`。
6. **CI**：新增 `helm-lint` job，跑 `deploy/helm/starbyte/ci-check.sh`（lint + template + 安全断言 + kustomize）。
7. **内网默认**：Ingress 关闭，不进默认 kustomization；无 Let's Encrypt / cert-manager 依赖。

请**不要合并 #145**。本 PR 亦不关闭 #102（真正上集群后再验收）。

## 关联 Issue

Related to #102（替代 #145，不 Closes，避免把「已上生产 K8s」写进完成态）

## 测试方式

1. `bash deploy/helm/starbyte/ci-check.sh`（本地已通过：lint / template / 生产不渲染 Secret 与 Ingress / 拒绝完整镜像 URL 当 tag）
2. `kubectl kustomize deploy/k8s`：无 Ingress、无 Secret；镜像为 `ghcr.io/yogdunana/starbyte-{backend,frontend}`
3. 阅读 `.github/workflows/cd.yml`：`on` 只有 `workflow_dispatch`，`deploy` 默认 `false`
4. **未**对真实集群做 e2e（学校环境没有这套 K8s）

## 截图 / GIF

无前端变更。

| 页面/功能 | 截图 |
|----------|------|
| 无前端变更 | — |

## 注意事项 / 残留风险

- **Compose 仍是唯一生产路径。** 合入本 PR 不等于可以下线 `deploy/docker-compose.yml`。两套编排并存，配置漂移要靠文档约束。
- **GitHub Environment 若未配保护规则**，拥有 Actions 写权限的人仍可手动 `deploy=true`。请在真正使用前给 `dev` / `prod` 加 required reviewers，并谨慎配置 `KUBE_CONFIG_DATA`。
- **一旦写入 `KUBE_CONFIG_DATA` 并勾选部署**，就会对集群做 helm upgrade。不要为了「点亮 CD」把未知集群凭证放进仓库 Secrets。
- **Chart 内嵌 Postgres / Redis / MinIO** 是单副本学习模板，不是托管数据库；生产数据面仍建议沿用现有 Compose 或外部实例。
- **蓝绿 / 金丝雀未接入 CD**，且金丝雀依赖 Nginx Ingress。内网无 Ingress 时不要 apply canary Ingress。
- **GHCR 私有包** 需要集群 `imagePullSecrets`；本模板默认未创建。
- **PVC 不会随 helm uninstall 自动清掉**，实验集群要注意残留卷。
- **未做真实集群 rollout / 回滚演练**；`switch.sh` / `rollback.sh` 只在脚本层修了 #145 的逻辑洞。
- raw k8s 清单里前后端 tag 仍是 `latest`（学习占位），发布时请用 kustomize / helm `--set` 钉死 digest 或 sha tag。

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测（helm lint/template + kustomize，无集群 e2e）
- [x] 已添加/更新必要的文档
- [ ] CI 检查通过（待本 PR checks）
- [x] 没有硬编码生产敏感信息（prod 不创建 Secret；example 仅为 `changeme` 的 base64）
- [x] 命名符合规范
- [x] 没有调试代码

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7018782c-90f4-5b98-b1ac-26fd46c89f81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7018782c-90f4-5b98-b1ac-26fd46c89f81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

