### PR TITLE
ci: harden golang-migrate install (fix flaky main CI)

### DIFF
--- a/.github/scripts/install-migrate.sh
+++ b/.github/scripts/install-migrate.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Install pinned golang-migrate CLI for CI.
+# Prefer `go install` (module proxy). Fall back to a retried, verified
+# GitHub release tarball so one flaky assets.githubusercontent.com
+# download cannot fail the job.
+set -euo pipefail
+
+MIGRATE_VERSION="${MIGRATE_VERSION:-v4.17.0}"
+INSTALL_DIR="${MIGRATE_INSTALL_DIR:-/usr/local/bin}"
+ARCHIVE="migrate.linux-amd64.tar.gz"
+RELEASE_URL="https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/${ARCHIVE}"
+CHECKSUM_URL="https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/sha256sum.txt"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+place_binary() {
+  local src="$1"
+  [[ -f "${src}" ]] || return 1
+  if [[ -w "${INSTALL_DIR}" ]]; then
+    cp "${src}" "${INSTALL_DIR}/migrate"
+  else
+    sudo cp "${src}" "${INSTALL_DIR}/migrate"
+  fi
+  if [[ -w "${INSTALL_DIR}/migrate" ]]; then
+    chmod +x "${INSTALL_DIR}/migrate"
+  else
+    sudo chmod +x "${INSTALL_DIR}/migrate"
+  fi
+}
+
+install_via_go() {
+  command -v go >/dev/null 2>&1 || return 1
+  echo "Installing migrate ${MIGRATE_VERSION} via go install (postgres tag)..."
+  go install -tags 'postgres' "github.com/golang-migrate/migrate/v4/cmd/migrate@${MIGRATE_VERSION}" || return 1
+  local src
+  src="$(go env GOPATH)/bin/migrate"
+  place_binary "${src}" || return 1
+  echo "Installed migrate via go install -> ${INSTALL_DIR}/migrate"
+}
+
+download() {
+  local url="$1"
+  local dest="$2"
+  echo "Downloading ${url}"
+  curl --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 120 \
+    -fsSL --connect-timeout 15 --max-time 180 \
+    -o "${dest}" "${url}"
+}
+
+install_via_release() {
+  local tmp
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '${tmp}'" RETURN
+
+  download "${RELEASE_URL}" "${tmp}/${ARCHIVE}" || \
+    die "failed to download migrate ${MIGRATE_VERSION} from GitHub releases after retries: ${RELEASE_URL}"
+
+  # Reject HTML error pages / truncated payloads before tar.
+  if ! gzip -t "${tmp}/${ARCHIVE}" 2>/dev/null; then
+    echo "Downloaded file is not a valid gzip archive:" >&2
+    file "${tmp}/${ARCHIVE}" >&2 || true
+    head -c 300 "${tmp}/${ARCHIVE}" >&2 || true
+    echo >&2
+    die "migrate archive failed verification (not a valid .tar.gz)"
+  fi
+
+  if download "${CHECKSUM_URL}" "${tmp}/sha256sum.txt"; then
+    if grep -E "[[:space:]]${ARCHIVE}$" "${tmp}/sha256sum.txt" > "${tmp}/expected.sha"; then
+      (cd "${tmp}" && sha256sum -c expected.sha) || die "sha256 mismatch for ${ARCHIVE}"
+    else
+      echo "Warning: sha256sum.txt did not list ${ARCHIVE}; relying on gzip check"
+    fi
+  else
+    echo "Warning: could not fetch sha256sum.txt; relying on gzip integrity check"
+  fi
+
+  tar -xzf "${tmp}/${ARCHIVE}" -C "${tmp}"
+  [[ -f "${tmp}/migrate" ]] || die "archive did not contain migrate binary; contents: $(ls -la "${tmp}")"
+
+  place_binary "${tmp}/migrate" || die "failed to install migrate into ${INSTALL_DIR}"
+  echo "Installed migrate via release tarball -> ${INSTALL_DIR}/migrate"
+}
+
+if ! install_via_go; then
+  echo "go install unavailable or failed; falling back to GitHub release tarball"
+  install_via_release
+fi
+
+command -v migrate >/dev/null 2>&1 || die "migrate is not on PATH after install (${INSTALL_DIR})"
+echo -n "migrate version: "
+migrate -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,7 @@ jobs:
         run: go build -o starbyte-server ./cmd/server
 
       - name: Install migrate
-        run: |
-          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-amd64.tar.gz | tar xvz
-          sudo mv migrate /usr/local/bin/
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/install-migrate.sh"
 
       - name: Migrate test database
         run: migrate -path migrations -database "$TEST_DATABASE_URL" up
@@ -147,10 +145,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: false
+
       - name: Install migrate
-        run: |
-          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-amd64.tar.gz | tar xvz
-          sudo mv migrate /usr/local/bin/
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/install-migrate.sh"
 
       - name: Run migrations up
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

加固 CI 里 `Install migrate` 步骤，避免 main 在合并后因 GitHub Release 单次下载失败而红（例如 [run 34608782241](https://github.com/Yogdunana/StarByte/actions/runs/34608782241) 的 Database Migration Check / Backend Lint & Build）。

原先两处都是裸 `curl | tar`，没有 `-f`、没有重试、也不校验归档。现在改为共享脚本：

1. **优先** `go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.17.0`（走 Go module proxy，backend-lint 已有 setup-go；db-migration-check 补了同样的 Go 1.22）
2. **失败则回退** `curl --retry 5 --retry-all-errors -fsSL` 下载同一 pinned 版本，先 `gzip -t`，再尽量用官方 `sha256sum.txt` 校验，最后才 `tar`

未改应用代码。migrate 仍钉在 **v4.17.0**。

## 关联 Issue

修复 main 分支 CI 抖动（#160 合并后的失败 run），无单独 issue 号。

## 测试方式

1. 本地验证 `go install` 路径：脚本成功安装 migrate
2. 本地验证 curl 回退路径（伪造失败的 `go`）：重试下载 + sha256 通过，`migrate -version` 为 `4.17.0`
3. 等本 PR 的 **Install migrate** 在 Backend Lint & Build 与 Database Migration Check 上变绿

## 截图 / GIF

无前端变更。

## 注意事项

- 不自动合并；等本 PR CI 全绿后再人工合入
- `go install` 编出来的 CLI 版本字符串可能是 `dev`，功能与 v4.17.0 源码一致；回退的 release 二进制会显示 `4.17.0`
- 不影响其他模块

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测
- [x] 已添加/更新必要的文档
- [ ] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ebb3307-917e-5964-b5eb-5d7cb0a611d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ebb3307-917e-5964-b5eb-5d7cb0a611d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

