### PR TITLE
ops(deploy): 校园网复用本地 MinIO 并加入 starbyte 应急 CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ files/
 # Docker volumes
 docker-data/
 
+# 应急 CLI / 更新脚本在仓库内产生的备份（勿提交 dump）
+backups/
+
 # Coverage
 coverage/
 *.lcov

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ StarByte/
 │   │   └── styles/            # 全局样式
 │   └── Dockerfile
 ├── deploy/                     # 部署配置
-│   └── docker-compose.yml
+│   ├── docker-compose.yml
+│   ├── cli/starbyte           # SSH 应急 CLI（安装后 starbyte / sb）
+│   └── update-from-zip.sh     # zip 更新代码，保留 .env 与 volumes
 ├── docs/                       # 项目文档
 │   ├── specs/                 # 设计文档
 │   └── dev-guide/             # 开发规范
@@ -100,12 +102,18 @@ StarByte/
 git clone https://github.com/Yogdunana/StarByte.git
 cd StarByte
 
+# 复制环境变量（内网保持 SKIP_BUCKET_CREATE=true）
+cp deploy/.env.example deploy/.env
+
 # 启动所有服务
-docker-compose -f deploy/docker-compose.yml up -d
+docker compose -f deploy/docker-compose.yml up -d --build
 
 # 查看服务状态
-docker-compose -f deploy/docker-compose.yml ps
+docker compose -f deploy/docker-compose.yml ps
+# 或: sudo bash deploy/cli/starbyte install && starbyte status
 ```
+
+校园网裸机（无需 sed Dockerfile、镜像站 403 时复用本地 MinIO）见 [docs/deployment.md](docs/deployment.md)。
 
 服务启动后访问:
 - 前端: http://localhost/ （容器映射 80 端口）

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -51,3 +51,7 @@ CAS_SERVICE_URL=
 CAS_FRONTEND_URL=
 CAS_ALLOW_AUTO_PROVISION=true
 CAS_DEFAULT_ROLE=member
+# 容器 extra_hosts：把 authserver.smbu.edu.cn 指到校园网 IPv4。
+# 默认 10.100.14.250（深北莫信息化内网）。不设则 compose 也用该默认。
+# 缺此项时容器可能解析到公网 IPv6，CAS callback 卡住 / nginx 502。
+CAS_AUTHSERVER_IP=10.100.14.250

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -14,6 +14,10 @@ REDIS_PASSWORD=starbyte123
 # MinIO 配置
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
+# 镜像 tag。默认 latest + compose pull_policy: if_not_present，
+# 本机已有兼容镜像时不会去拉钉死的 RELEASE tag（校园镜像站常对 RELEASE.* 返回 403）。
+# 需要钉版本：MINIO_IMAGE=minio/minio:RELEASE.2024-08-17T01-16-21Z
+MINIO_IMAGE=minio/minio:latest
 
 # JWT 配置（生产环境务必修改为复杂随机字符串）
 JWT_SECRET=your-super-secret-key-change-in-production-please
@@ -34,9 +38,11 @@ SKIP_BUCKET_CREATE=true
 # ─────────────────────────────────────────────────────────
 # 后端 Dockerfile 已默认：ghfast.top 拉 golang-migrate v4.17.0、
 # GOPROXY=goproxy.cn、mc 占位（配合上面的 SKIP_BUCKET_CREATE=true）。
-# 前端仍用 docker.io 的 node:20-alpine / nginx:1.27-alpine。
-# 若 docker pull 失败：用已配置的 Docker Hub 国内镜像源拉取，或在可联网
-# 机器上 pull 后 docker tag / save 导入内网。不要在 Dockerfile 写死未验证的 registry。
+# postgres / redis / 前端仍用 docker.io 官方 tag：
+#   postgres:16-alpine、redis:7-alpine、node:20-alpine、nginx:1.27-alpine
+# 不要在 compose / Dockerfile 写死未验证的华为 SWR / 镜像站地址。
+# 拉基础镜像：在 daemon.json 配置 registry-mirrors（见 docs/deployment.md），
+# 或在可联网机器 pull 后 docker tag / save 导入。镜像站会 403，先自测再依赖。
 
 # 学校 CAS（漏测先用校园网 IP，回调按访问地址自动拼）
 CAS_ENABLED=true

--- a/deploy/cli/starbyte
+++ b/deploy/cli/starbyte
@@ -3,7 +3,7 @@
 # 依赖：bash + docker compose。不打印 .env 密钥值。
 set -euo pipefail
 
-VERSION="1.0.1"
+VERSION="1.0.2"
 CONF_FILE="/etc/starbyte.conf"
 
 usage() {
@@ -132,16 +132,24 @@ compose() {
   docker compose "${args[@]}" "$@"
 }
 
-# 从 .env 取键值到变量，不向终端打印
+# 从 .env 取键值到变量，不向终端打印。
+# 与 compose env-file 一致：后者覆盖前者；去掉行尾 CR 与成对包裹引号。
 env_get() {
   local key="$1"
   local file="$ROOT/deploy/.env"
-  local line=""
+  local line="" val=""
   [[ -f "$file" ]] || return 1
-  # 与 compose env-file 一致：后者覆盖前者
   line="$(grep -E "^${key}=" "$file" | tail -n1 || true)"
   [[ -n "$line" ]] || return 1
-  printf '%s' "${line#*=}"
+  val="${line#*=}"
+  val="${val%$'\r'}"
+  if [[ ${#val} -ge 2 ]]; then
+    case "$val" in
+      \"*\") val="${val:1:${#val}-2}" ;;
+      \'*\') val="${val:1:${#val}-2}" ;;
+    esac
+  fi
+  printf '%s' "$val"
 }
 
 env_has_key() {
@@ -328,17 +336,30 @@ cmd_env_check() {
 }
 
 pick_backup_dir() {
+  local dir
   if mkdir -p /var/backups/starbyte 2>/dev/null && [[ -w /var/backups/starbyte ]]; then
-    printf '%s' /var/backups/starbyte
-    return
+    dir=/var/backups/starbyte
+  else
+    dir="$ROOT/backups"
+    mkdir -p "$dir"
   fi
-  mkdir -p "$ROOT/backups"
-  printf '%s' "$ROOT/backups"
+  chmod 0700 "$dir" 2>/dev/null || true
+  printf '%s' "$dir"
+}
+
+# 先建 0600 空文件再重定向，避免默认 umask 写出 0644
+secure_create() {
+  local path="$1" mode="${2:-600}"
+  umask 077
+  : > "$path"
+  chmod "$mode" "$path"
 }
 
 cmd_backup() {
   need_docker
-  local dest stamp dump notes
+  local dest stamp dump notes old_umask
+  old_umask="$(umask)"
+  umask 077
   dest="$(pick_backup_dir)"
   stamp="$(date +%Y%m%d-%H%M%S)"
   dump="$dest/postgres-${stamp}.sql"
@@ -351,14 +372,18 @@ cmd_backup() {
   db="${db:-starbyte}"
 
   log "Postgres dump → $dump"
+  secure_create "$dump" 600
   if docker exec starbyte-postgres pg_dump -U "$user" "$db" > "$dump"; then
+    chmod 600 "$dump"
     ok "已写入 $dump"
   else
     err "pg_dump 失败（容器 starbyte-postgres 是否在运行？）"
     rm -f "$dump"
+    umask "$old_umask"
     exit 1
   fi
 
+  secure_create "$notes" 600
   {
     echo "StarByte 备份说明  $stamp"
     echo "Postgres dump: $dump"
@@ -377,6 +402,8 @@ cmd_backup() {
     echo ""
     echo "不要 docker compose down -v。"
   } > "$notes"
+  chmod 600 "$notes"
+  umask "$old_umask"
 
   log "说明: $notes"
   log "volume / MinIO 路径见该说明文件（未打包对象存储二进制，请另行复制卷）。"

--- a/deploy/cli/starbyte
+++ b/deploy/cli/starbyte
@@ -3,7 +3,7 @@
 # 依赖：bash + docker compose。不打印 .env 密钥值。
 set -euo pipefail
 
-VERSION="1.0.0"
+VERSION="1.0.1"
 CONF_FILE="/etc/starbyte.conf"
 
 usage() {
@@ -314,6 +314,12 @@ cmd_env_check() {
     info "未设置 MINIO_IMAGE（compose 默认 minio/minio:latest）"
   fi
 
+  if env_has_key CAS_AUTHSERVER_IP; then
+    ok "已设置: CAS_AUTHSERVER_IP"
+  else
+    info "未设置 CAS_AUTHSERVER_IP（compose extra_hosts 默认 10.100.14.250）"
+  fi
+
   if [[ "$missing" -gt 0 || "$empty" -gt 0 ]]; then
     err "env-check 未通过（缺少 ${missing}，空值 ${empty}）"
     exit 1
@@ -374,6 +380,26 @@ cmd_backup() {
 
   log "说明: $notes"
   log "volume / MinIO 路径见该说明文件（未打包对象存储二进制，请另行复制卷）。"
+}
+
+# RFC1918 IPv4。IPv6 / 公网地址视为非内网（校园 CAS 不可走 2001:250:…）
+is_private_ipv4() {
+  local ip="$1"
+  case "$ip" in
+    10.*|192.168.*) return 0 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[0-1].*) return 0 ;;
+  esac
+  return 1
+}
+
+# 尽力从运行中的 backend 取出 authserver 解析结果（不打印密钥）
+backend_authserver_addrs() {
+  local out=""
+  out="$(docker exec starbyte-backend grep -E 'authserver\.smbu\.edu\.cn' /etc/hosts 2>/dev/null | awk '{print $1}' || true)"
+  if [[ -z "$out" ]]; then
+    out="$(docker exec starbyte-backend getent hosts authserver.smbu.edu.cn 2>/dev/null | awk '{print $1}' || true)"
+  fi
+  printf '%s' "$out"
 }
 
 listening_on() {
@@ -460,6 +486,26 @@ cmd_doctor() {
       warn "CAS_ENABLED 不是 true，登录页可能没有「学校统一认证」"
     else
       ok "CAS_ENABLED=true"
+    fi
+  fi
+  if grep -q 'extra_hosts' "$ROOT/deploy/docker-compose.yml" \
+    && grep -q 'authserver.smbu.edu.cn' "$ROOT/deploy/docker-compose.yml"; then
+    ok "compose 已写入 authserver extra_hosts（CAS_AUTHSERVER_IP 默认 10.100.14.250）"
+  else
+    warn "compose 缺少 authserver extra_hosts：容器可能解析到 IPv6，CAS callback 超时/502"
+    issues=$((issues + 1))
+  fi
+  if command -v docker >/dev/null 2>&1 \
+    && docker inspect -f '{{.State.Status}}' starbyte-backend 2>/dev/null | grep -qx running; then
+    local addr
+    addr="$(backend_authserver_addrs | head -n1 || true)"
+    if [[ -z "$addr" ]]; then
+      info "backend 内未能解析 authserver.smbu.edu.cn（可选检查，可 recreate 后再看）"
+    elif is_private_ipv4 "$addr"; then
+      ok "backend 将 authserver 解析到内网 IPv4"
+    else
+      warn "backend 将 authserver 解析为非内网地址（常见为公网 IPv6）。CAS callback 会卡住/502；设 CAS_AUTHSERVER_IP 后 starbyte rebuild backend"
+      issues=$((issues + 1))
     fi
   fi
 

--- a/deploy/cli/starbyte
+++ b/deploy/cli/starbyte
@@ -1,0 +1,546 @@
+#!/usr/bin/env bash
+# StarByte 应急运维 CLI（类似宝塔 bt）
+# 依赖：bash + docker compose。不打印 .env 密钥值。
+set -euo pipefail
+
+VERSION="1.0.0"
+CONF_FILE="/etc/starbyte.conf"
+
+usage() {
+  cat <<'EOF'
+StarByte 应急运维 CLI（类似宝塔 bt）
+
+用法:
+  starbyte <命令> [参数]
+  sb <命令> [参数]          # 安装后的短命令
+
+命令:
+  status                         compose ps + :8080 / :80 短健康检查
+  logs [服务] [--tail N]         查看日志（默认 --tail 100）
+  restart [服务|all]             重启容器，不重建镜像
+  rebuild [backend|frontend|all] 构建并 --no-deps 重建应用（不强拉 MinIO/Postgres）
+  env-check                      检查 deploy/.env 关键键名（不打印值）
+  backup                         Postgres dump + volume/MinIO 路径说明
+  doctor                         校园网部署常见问题排查
+  install                        安装到 /usr/local/bin/starbyte，并创建 sb 软链
+  help                           显示本帮助
+  version                        显示版本
+
+环境:
+  STARBYTE_HOME    仓库根目录（含 deploy/docker-compose.yml）
+  /etc/starbyte.conf  可写 STARBYTE_HOME=/path
+
+示例:
+  starbyte status
+  starbyte logs backend --tail 200
+  starbyte rebuild all
+  starbyte doctor
+EOF
+}
+
+log() { printf '%s\n' "$*"; }
+err() { printf '错误: %s\n' "$*" >&2; }
+ok() { printf '  [OK] %s\n' "$*"; }
+warn() { printf '  [!!] %s\n' "$*"; }
+info() { printf '  [--] %s\n' "$*"; }
+
+# 只读 STARBYTE_HOME=...，忽略其它行，避免误 source 含命令的文件
+load_conf() {
+  if [[ ! -f "$CONF_FILE" ]]; then
+    return 0
+  fi
+  local line key val
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    key="${line%%=*}"
+    val="${line#*=}"
+    if [[ "$key" == "STARBYTE_HOME" && -n "$val" ]]; then
+      STARBYTE_HOME="$val"
+    fi
+  done < "$CONF_FILE"
+}
+
+resolve_script_path() {
+  local src="${BASH_SOURCE[0]}"
+  if command -v readlink >/dev/null 2>&1; then
+    src="$(readlink -f "$src" 2>/dev/null || printf '%s' "$src")"
+  fi
+  printf '%s' "$src"
+}
+
+find_root() {
+  local candidate
+  if [[ -n "${STARBYTE_HOME:-}" ]]; then
+    candidate="${STARBYTE_HOME}"
+    if [[ -f "$candidate/deploy/docker-compose.yml" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  fi
+
+  load_conf
+  if [[ -n "${STARBYTE_HOME:-}" && -f "${STARBYTE_HOME}/deploy/docker-compose.yml" ]]; then
+    printf '%s' "$STARBYTE_HOME"
+    return 0
+  fi
+
+  local here
+  here="$(cd "$(dirname "$(resolve_script_path)")" && pwd)"
+  if [[ -f "$here/../../deploy/docker-compose.yml" ]]; then
+    (cd "$here/../.." && pwd)
+    return 0
+  fi
+
+  local d="$PWD"
+  while [[ "$d" != "/" ]]; do
+    if [[ -f "$d/deploy/docker-compose.yml" ]]; then
+      printf '%s' "$d"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+
+  err "未找到 StarByte 仓库根（deploy/docker-compose.yml）。"
+  err "请在仓库目录执行，或设置 STARBYTE_HOME，或运行: sudo starbyte install"
+  exit 1
+}
+
+need_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    err "未找到 docker"
+    exit 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    err "未找到 docker compose 插件"
+    exit 1
+  fi
+}
+
+ROOT=""
+init_root() {
+  ROOT="$(find_root)"
+}
+
+compose() {
+  local args=(-f "$ROOT/deploy/docker-compose.yml")
+  if [[ -f "$ROOT/deploy/.env" ]]; then
+    args+=(--env-file "$ROOT/deploy/.env")
+  fi
+  docker compose "${args[@]}" "$@"
+}
+
+# 从 .env 取键值到变量，不向终端打印
+env_get() {
+  local key="$1"
+  local file="$ROOT/deploy/.env"
+  local line=""
+  [[ -f "$file" ]] || return 1
+  # 与 compose env-file 一致：后者覆盖前者
+  line="$(grep -E "^${key}=" "$file" | tail -n1 || true)"
+  [[ -n "$line" ]] || return 1
+  printf '%s' "${line#*=}"
+}
+
+env_has_key() {
+  local key="$1"
+  local file="$ROOT/deploy/.env"
+  [[ -f "$file" ]] && grep -Eq "^${key}=" "$file"
+}
+
+cmd_status() {
+  need_docker
+  log "仓库: $ROOT"
+  log ""
+  compose ps || true
+  log ""
+  log "健康检查:"
+  if curl -sf --max-time 3 http://127.0.0.1:8080/health >/dev/null 2>&1; then
+    ok "backend :8080/health"
+  else
+    warn "backend :8080/health 无响应"
+  fi
+  if curl -sf --max-time 3 http://127.0.0.1:80/ >/dev/null 2>&1 \
+    || wget -qO- --timeout=3 http://127.0.0.1:80/ >/dev/null 2>&1; then
+    ok "frontend :80"
+  else
+    warn "frontend :80 无响应"
+  fi
+}
+
+cmd_logs() {
+  local service="" tailn=100
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --tail)
+        tailn="${2:-}"
+        if [[ -z "$tailn" || ! "$tailn" =~ ^[0-9]+$ ]]; then
+          err "--tail 需要数字"
+          exit 2
+        fi
+        shift 2
+        ;;
+      --tail=*)
+        tailn="${1#--tail=}"
+        if [[ ! "$tailn" =~ ^[0-9]+$ ]]; then
+          err "--tail 需要数字"
+          exit 2
+        fi
+        shift
+        ;;
+      -h|--help)
+        log "用法: starbyte logs [服务] [--tail N]"
+        exit 0
+        ;;
+      -*)
+        err "未知参数: $1"
+        exit 2
+        ;;
+      *)
+        if [[ -n "$service" ]]; then
+          err "多余参数: $1"
+          exit 2
+        fi
+        service="$1"
+        shift
+        ;;
+    esac
+  done
+  need_docker
+  if [[ -n "$service" ]]; then
+    compose logs --tail "$tailn" "$service"
+  else
+    compose logs --tail "$tailn"
+  fi
+}
+
+cmd_restart() {
+  local target="${1:-all}"
+  case "$target" in
+    all|postgres|redis|minio|backend|frontend) ;;
+    *)
+      err "未知服务: $target（postgres|redis|minio|backend|frontend|all）"
+      exit 2
+      ;;
+  esac
+  need_docker
+  if [[ "$target" == "all" ]]; then
+    log "重启全部服务..."
+    compose restart
+  else
+    log "重启 $target ..."
+    compose restart "$target"
+  fi
+}
+
+cmd_rebuild() {
+  local target="${1:-}"
+  if [[ -z "$target" ]]; then
+    err "用法: starbyte rebuild [backend|frontend|all]"
+    exit 2
+  fi
+  local services=()
+  case "$target" in
+    backend|frontend) services=("$target") ;;
+    all) services=(backend frontend) ;;
+    *)
+      err "rebuild 仅支持 backend|frontend|all（不含 MinIO/Postgres，避免镜像站强拉）"
+      exit 2
+      ;;
+  esac
+  need_docker
+  log "构建: ${services[*]}"
+  compose build "${services[@]}"
+  log "重建（--no-deps --force-recreate）: ${services[*]}"
+  compose up -d --no-deps --force-recreate "${services[@]}"
+  log "完成。MinIO / Postgres / Redis 未被本命令拉取或重建。"
+}
+
+CRITICAL_KEYS=(
+  POSTGRES_USER
+  POSTGRES_PASSWORD
+  POSTGRES_DB
+  REDIS_PASSWORD
+  MINIO_ROOT_USER
+  MINIO_ROOT_PASSWORD
+  JWT_SECRET
+  SKIP_MIGRATION
+  MIGRATION_FAIL_FATAL
+  SKIP_BUCKET_CREATE
+  CAS_ENABLED
+  CAS_SERVER_URL
+)
+
+cmd_env_check() {
+  local file="$ROOT/deploy/.env"
+  local missing=0 empty=0
+  log "检查 $file （只报键名，不打印值）"
+  if [[ ! -f "$file" ]]; then
+    warn "文件不存在。请: cp deploy/.env.example deploy/.env"
+    exit 1
+  fi
+
+  local key val
+  for key in "${CRITICAL_KEYS[@]}"; do
+    if ! env_has_key "$key"; then
+      warn "缺少键: $key"
+      missing=$((missing + 1))
+      continue
+    fi
+    val="$(env_get "$key" || true)"
+    if [[ -z "$val" ]]; then
+      warn "键存在但值为空: $key"
+      empty=$((empty + 1))
+    else
+      ok "已设置: $key"
+    fi
+  done
+
+  # 占位 JWT：只对比已知示例，不回显实际内容
+  if env_has_key JWT_SECRET; then
+    val="$(env_get JWT_SECRET || true)"
+    case "$val" in
+      change-me-in-production|your-super-secret-key-change-in-production-please)
+        warn "JWT_SECRET 仍是示例占位，生产请改成随机串（值未打印）"
+        ;;
+    esac
+  fi
+
+  if env_has_key MINIO_IMAGE; then
+    ok "已设置: MINIO_IMAGE"
+  else
+    info "未设置 MINIO_IMAGE（compose 默认 minio/minio:latest）"
+  fi
+
+  if [[ "$missing" -gt 0 || "$empty" -gt 0 ]]; then
+    err "env-check 未通过（缺少 ${missing}，空值 ${empty}）"
+    exit 1
+  fi
+  log "env-check 通过"
+}
+
+pick_backup_dir() {
+  if mkdir -p /var/backups/starbyte 2>/dev/null && [[ -w /var/backups/starbyte ]]; then
+    printf '%s' /var/backups/starbyte
+    return
+  fi
+  mkdir -p "$ROOT/backups"
+  printf '%s' "$ROOT/backups"
+}
+
+cmd_backup() {
+  need_docker
+  local dest stamp dump notes
+  dest="$(pick_backup_dir)"
+  stamp="$(date +%Y%m%d-%H%M%S)"
+  dump="$dest/postgres-${stamp}.sql"
+  notes="$dest/README-${stamp}.txt"
+
+  local user db
+  user="$(env_get POSTGRES_USER 2>/dev/null || true)"
+  db="$(env_get POSTGRES_DB 2>/dev/null || true)"
+  user="${user:-starbyte}"
+  db="${db:-starbyte}"
+
+  log "Postgres dump → $dump"
+  if docker exec starbyte-postgres pg_dump -U "$user" "$db" > "$dump"; then
+    ok "已写入 $dump"
+  else
+    err "pg_dump 失败（容器 starbyte-postgres 是否在运行？）"
+    rm -f "$dump"
+    exit 1
+  fi
+
+  {
+    echo "StarByte 备份说明  $stamp"
+    echo "Postgres dump: $dump"
+    echo ""
+    echo "Named volumes（compose 项目目录一般为 deploy/，卷名带项目前缀）："
+    docker volume ls --format '{{.Name}}' 2>/dev/null | grep -E 'postgres-data|redis-data|minio-data' || echo "(当前未见匹配卷名，compose 尚未创建)"
+    echo ""
+    echo "查看挂载点:"
+    echo "  docker volume inspect <卷名>"
+    echo ""
+    echo "MinIO 数据在 minio-data 卷的 /data。桶名默认 starbyte。"
+    echo "SKIP_BUCKET_CREATE=true 时恢复后需保证桶已存在。"
+    echo ""
+    echo "恢复 Postgres:"
+    echo "  cat $dump | docker exec -i starbyte-postgres psql -U $user $db"
+    echo ""
+    echo "不要 docker compose down -v。"
+  } > "$notes"
+
+  log "说明: $notes"
+  log "volume / MinIO 路径见该说明文件（未打包对象存储二进制，请另行复制卷）。"
+}
+
+listening_on() {
+  local port="$1"
+  if command -v ss >/dev/null 2>&1; then
+    ss -lnt 2>/dev/null | grep -qE "[.:]${port}[[:space:]]"
+    return
+  fi
+  if command -v netstat >/dev/null 2>&1; then
+    netstat -lnt 2>/dev/null | grep -qE "[.:]${port}[[:space:]]"
+    return
+  fi
+  return 1
+}
+
+cmd_doctor() {
+  local issues=0
+  log "StarByte doctor  仓库=$ROOT"
+  log ""
+
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    ok "docker compose 可用"
+  else
+    warn "缺少 docker 或 compose 插件"
+    issues=$((issues + 1))
+  fi
+
+  if [[ -f "$ROOT/deploy/.env" ]]; then
+    ok "存在 deploy/.env"
+  else
+    warn "缺少 deploy/.env（cp deploy/.env.example deploy/.env）"
+    issues=$((issues + 1))
+  fi
+
+  log ""
+  log "镜像站 / MinIO:"
+  if [[ -f /etc/docker/daemon.json ]]; then
+    if grep -qi 'registry-mirrors' /etc/docker/daemon.json 2>/dev/null; then
+      info "daemon.json 含 registry-mirrors（请自测 pull；公开加速常 403）"
+    else
+      info "存在 /etc/docker/daemon.json，未见 registry-mirrors"
+    fi
+    if grep -qi 'xuanyuan' /etc/docker/daemon.json 2>/dev/null; then
+      warn "daemon.json 含 xuanyuan：生产上曾对 minio/minio:RELEASE.* 返回 403"
+      issues=$((issues + 1))
+    fi
+  else
+    info "无 /etc/docker/daemon.json。校园网请自配已验证的 mirrors，或 docker save/load"
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    if docker image inspect minio/minio:latest >/dev/null 2>&1; then
+      ok "本地已有 minio/minio:latest（compose 默认 + if_not_present 会复用）"
+    else
+      info "本地没有 minio/minio:latest；首次 up 需要能 pull 或先 load"
+    fi
+    if docker image inspect minio/minio:RELEASE.2024-08-17T01-16-21Z >/dev/null 2>&1; then
+      info "本地仍有旧 RELEASE tag；现 compose 默认不再使用它"
+    fi
+  fi
+
+  log ""
+  log "SKIP_BUCKET_CREATE / 桶:"
+  if [[ -f "$ROOT/deploy/.env" ]]; then
+    local skip
+    skip="$(env_get SKIP_BUCKET_CREATE 2>/dev/null || true)"
+    if [[ "${skip,,}" == "true" ]]; then
+      ok "SKIP_BUCKET_CREATE=true（镜像内 mc 为占位，不会自动建桶）"
+      info "首次部署请在 MinIO 控制台手动创建桶 starbyte"
+    else
+      warn "SKIP_BUCKET_CREATE 不是 true：内网 stub mc 无法真正建桶"
+      issues=$((issues + 1))
+    fi
+  fi
+
+  log ""
+  log "CAS 回调:"
+  info "漏测无域名：用校园网 IP 打开站点，备案 http://<服务器IP>/api/v1/auth/cas/callback"
+  info "CAS_SERVICE_URL / CAS_FRONTEND_URL 留空则按访问 Host 自动拼"
+  if [[ -f "$ROOT/deploy/.env" ]]; then
+    local cas_en
+    cas_en="$(env_get CAS_ENABLED 2>/dev/null || true)"
+    if [[ "${cas_en,,}" != "true" ]]; then
+      warn "CAS_ENABLED 不是 true，登录页可能没有「学校统一认证」"
+    else
+      ok "CAS_ENABLED=true"
+    fi
+  fi
+
+  log ""
+  log "端口 80:"
+  if listening_on 80; then
+    if command -v docker >/dev/null 2>&1 && docker inspect -f '{{.State.Status}}' starbyte-frontend 2>/dev/null | grep -qx running; then
+      ok "80 已被 starbyte-frontend 占用（预期）"
+    else
+      warn "主机 80 已被占用，且未见运行中的 starbyte-frontend。停掉宝塔/nginx 或改映射后再 up"
+      issues=$((issues + 1))
+    fi
+  else
+    info "当前未见 80 监听；compose up 后 frontend 会映射 80"
+  fi
+
+  if command -v docker >/dev/null 2>&1 && docker inspect starbyte-backend >/dev/null 2>&1; then
+    log ""
+    log "运行中容器短检:"
+    if curl -sf --max-time 3 http://127.0.0.1:8080/health >/dev/null 2>&1; then
+      ok "backend :8080/health"
+    else
+      warn "backend 容器在，但 :8080/health 失败"
+      issues=$((issues + 1))
+    fi
+  fi
+
+  log ""
+  if [[ "$issues" -gt 0 ]]; then
+    warn "doctor 发现 ${issues} 项需处理"
+    exit 1
+  fi
+  ok "doctor 未发现必须处理的问题"
+}
+
+cmd_install() {
+  local dest="/usr/local/bin/starbyte"
+  local src
+  src="$(resolve_script_path)"
+  init_root
+
+  if [[ "$(id -u)" -ne 0 ]]; then
+    err "install 需要 root：sudo bash deploy/cli/starbyte install"
+    exit 1
+  fi
+
+  install -m 0755 "$src" "$dest"
+  ln -sfn "$dest" /usr/local/bin/sb
+  printf 'STARBYTE_HOME=%s\n' "$ROOT" > "$CONF_FILE"
+  chmod 0644 "$CONF_FILE"
+  log "已安装: $dest"
+  log "软链:   /usr/local/bin/sb -> $dest"
+  log "配置:   $CONF_FILE  (STARBYTE_HOME=$ROOT)"
+  log "试运行: starbyte status"
+}
+
+main() {
+  local cmd="${1:-help}"
+  shift || true
+  case "$cmd" in
+    help|-h|--help) usage ;;
+    version|-v|--version) log "starbyte $VERSION" ;;
+    install) cmd_install "$@" ;;
+    status|logs|restart|rebuild|env-check|backup|doctor)
+      init_root
+      case "$cmd" in
+        status) cmd_status "$@" ;;
+        logs) cmd_logs "$@" ;;
+        restart) cmd_restart "$@" ;;
+        rebuild) cmd_rebuild "$@" ;;
+        env-check) cmd_env_check "$@" ;;
+        backup) cmd_backup "$@" ;;
+        doctor) cmd_doctor "$@" ;;
+      esac
+      ;;
+    *)
+      err "未知命令: $cmd"
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -10,6 +10,7 @@ services:
   # PostgreSQL 数据库
   postgres:
     image: postgres:16-alpine
+    pull_policy: if_not_present
     container_name: starbyte-postgres-dev
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-starbyte}
@@ -30,6 +31,7 @@ services:
   # Redis 缓存
   redis:
     image: redis:7-alpine
+    pull_policy: if_not_present
     container_name: starbyte-redis-dev
     command: redis-server --appendonly yes
     environment:
@@ -45,9 +47,10 @@ services:
       timeout: 5s
       retries: 5
 
-  # MinIO 对象存储
+  # MinIO：默认 latest，可用 MINIO_IMAGE 覆盖；本地已有镜像时不强制拉取
   minio:
-    image: minio/minio:RELEASE.2024-08-17T01-16-21Z
+    image: ${MINIO_IMAGE:-minio/minio:latest}
+    pull_policy: if_not_present
     container_name: starbyte-minio-dev
     command: server /data --console-address ":9001"
     environment:
@@ -61,7 +64,7 @@ services:
       - minio-dev-data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live >/dev/null || wget -qO- http://localhost:9000/minio/health/live >/dev/null || mc ready local"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -3,12 +3,16 @@ version: "3.8"
 # ─────────────────────────────────────────────────────────
 # StarByte 生产环境 Docker Compose
 # 用法：docker compose -f deploy/docker-compose.yml up -d
+# 校园网：基础镜像走 docker.io 官方 tag + daemon.json mirrors（勿写死未验证源）；
+# MinIO 默认 latest + pull_policy: if_not_present，避免 RELEASE 钉死 tag 被镜像站 403。
 # ─────────────────────────────────────────────────────────
 
 services:
   # PostgreSQL 数据库（仅容器网络访问，不对外暴露端口）
+  # 镜像名保持 docker.io 官方 tag；校园网请在 daemon.json 配 registry-mirrors，勿改 FROM/image 为未验证源。
   postgres:
     image: postgres:16-alpine
+    pull_policy: if_not_present
     container_name: starbyte-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-starbyte}
@@ -27,6 +31,7 @@ services:
   # Redis 缓存（仅容器网络访问，不对外暴露端口）
   redis:
     image: redis:7-alpine
+    pull_policy: if_not_present
     container_name: starbyte-redis
     command: redis-server --requirepass ${REDIS_PASSWORD:-starbyte123} --appendonly yes
     environment:
@@ -40,9 +45,12 @@ services:
       timeout: 5s
       retries: 5
 
-  # MinIO 对象存储
+  # MinIO：默认 latest，可用 MINIO_IMAGE 覆盖。
+  # pull_policy: if_not_present — 本地已有兼容镜像时不强制拉 RELEASE 钉死 tag
+  #（校园镜像站对 minio/minio:RELEASE.* 常 403，而本机已有 minio/minio:latest）。
   minio:
-    image: minio/minio:RELEASE.2024-08-17T01-16-21Z
+    image: ${MINIO_IMAGE:-minio/minio:latest}
+    pull_policy: if_not_present
     container_name: starbyte-minio
     command: server /data --console-address ":9001"
     environment:
@@ -56,7 +64,8 @@ services:
       - minio-data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      # latest 与旧 RELEASE 镜像工具集不同：curl / wget / mc 任一成功即可
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live >/dev/null || wget -qO- http://localhost:9000/minio/health/live >/dev/null || mc ready local"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -114,6 +114,11 @@ services:
       # 内网镜像内 mc 为占位脚本；默认跳过自动建桶，请手动创建一次
       SKIP_BUCKET_CREATE: ${SKIP_BUCKET_CREATE:-true}
       TZ: Asia/Shanghai
+    # 校园 DNS 常把 authserver 解析到不可达 IPv6（如 2001:250:…），
+    # 导致容器内 wget CAS 超时、/api/v1/auth/cas/callback 卡住约 20s（nginx 502）。
+    # zip 更新会覆盖本文件，故把 extra_hosts 写进仓库，勿再靠机器上手改。
+    extra_hosts:
+      - "authserver.smbu.edu.cn:${CAS_AUTHSERVER_IP:-10.100.14.250}"
     ports:
       - "8080:8080"
     depends_on:

--- a/deploy/update-from-zip.sh
+++ b/deploy/update-from-zip.sh
@@ -12,6 +12,7 @@ usage() {
   • 保留已有 deploy/.env
   • 不触碰 Docker named volumes（postgres/redis/minio 数据）
   • 不删除 .git
+  • deploy/docker-compose.yml 会被 zip 覆盖（CAS extra_hosts 已在仓库 compose 内）
 
 zip 可以是 GitHub 的 Source code（顶层带 StarByte-main/ 目录），
 也可以是仓库根文件直接打包。
@@ -97,9 +98,16 @@ else
   echo "目录中原先没有 deploy/.env（未新建密钥文件）"
 fi
 
+if ! grep -q 'extra_hosts' "$COMPOSE_FILE" \
+  || ! grep -q 'authserver.smbu.edu.cn' "$COMPOSE_FILE"; then
+  echo "警告: 更新后的 deploy/docker-compose.yml 没有 authserver extra_hosts。" >&2
+  echo "  CAS callback 可能再解析到 IPv6 并 502。请换含本仓库 compose 的 zip，或手工加回 extra_hosts。" >&2
+fi
+
 cat <<EOF
 
 代码已更新。Docker named volumes 未被本脚本触碰。
+deploy/docker-compose.yml 已按 zip 覆盖（CAS extra_hosts 应已在文件内）。
 下一步（按需）：
   starbyte rebuild all
   # 或 docker compose -f deploy/docker-compose.yml up -d --build --no-deps --force-recreate backend frontend

--- a/deploy/update-from-zip.sh
+++ b/deploy/update-from-zip.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# 用 zip 覆盖更新 StarByte 代码。
+# - 始终保留现有 deploy/.env（不覆盖密钥）
+# - 绝不执行 docker volume / compose down -v
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+用法: bash deploy/update-from-zip.sh <StarByte.zip>
+
+将 zip 解压并覆盖到本仓库根目录：
+  • 保留已有 deploy/.env
+  • 不触碰 Docker named volumes（postgres/redis/minio 数据）
+  • 不删除 .git
+
+zip 可以是 GitHub 的 Source code（顶层带 StarByte-main/ 目录），
+也可以是仓库根文件直接打包。
+
+更新后请重建应用（不会强拉 MinIO）：
+  starbyte rebuild all
+  # 或
+  docker compose -f deploy/docker-compose.yml up -d --build --no-deps --force-recreate backend frontend
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+ZIP="${1:-}"
+if [[ -z "$ZIP" ]]; then
+  usage >&2
+  exit 2
+fi
+if [[ ! -f "$ZIP" ]]; then
+  echo "找不到 zip: $ZIP" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/deploy/docker-compose.yml"
+ENV_FILE="$REPO_ROOT/deploy/.env"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "未找到 $COMPOSE_FILE，请在 StarByte 仓库内执行本脚本。" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+if [[ -f "$ENV_FILE" ]]; then
+  cp -a "$ENV_FILE" "$WORKDIR/preserved.env"
+  echo "已暂存 deploy/.env"
+fi
+
+EXTRACT="$WORKDIR/extract"
+mkdir -p "$EXTRACT"
+
+if command -v unzip >/dev/null 2>&1; then
+  unzip -q "$ZIP" -d "$EXTRACT"
+elif command -v python3 >/dev/null 2>&1; then
+  python3 -m zipfile -e "$ZIP" "$EXTRACT"
+else
+  echo "需要 unzip 或 python3 才能解压。" >&2
+  exit 1
+fi
+
+# 顶层若只有一个目录，视为 GitHub 源码包
+shopt -s nullglob
+entries=("$EXTRACT"/*)
+shopt -u nullglob
+SRC="$EXTRACT"
+if [[ ${#entries[@]} -eq 1 && -d "${entries[0]}" ]]; then
+  SRC="${entries[0]}"
+fi
+
+if [[ ! -f "$SRC/deploy/docker-compose.yml" && ! -f "$SRC/README.md" ]]; then
+  echo "zip 内容不像 StarByte 仓库根（缺少 deploy/docker-compose.yml 或 README.md）。" >&2
+  exit 1
+fi
+
+# 用 tar 覆盖文件；排除 .git 与现有 .env（稍后再还原）
+# 不使用 rsync，减少校园机依赖
+echo "正在覆盖: $REPO_ROOT  （来源: $SRC）"
+tar -C "$SRC" --exclude='.git' --exclude='deploy/.env' -cf - . \
+  | tar -C "$REPO_ROOT" -xf -
+
+if [[ -f "$WORKDIR/preserved.env" ]]; then
+  mkdir -p "$(dirname "$ENV_FILE")"
+  cp -a "$WORKDIR/preserved.env" "$ENV_FILE"
+  echo "已还原 deploy/.env"
+else
+  echo "目录中原先没有 deploy/.env（未新建密钥文件）"
+fi
+
+cat <<EOF
+
+代码已更新。Docker named volumes 未被本脚本触碰。
+下一步（按需）：
+  starbyte rebuild all
+  # 或 docker compose -f deploy/docker-compose.yml up -d --build --no-deps --force-recreate backend frontend
+
+切勿: docker compose down -v   （会删 postgres/redis/minio 数据）
+EOF

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,7 @@
 1. **安装 Docker Engine + Compose 插件**（发行版官方源或学校镜像）。确认 `docker compose version` 可用。
 2. **（可选）配置 registry-mirrors**，见下方「daemon.json」。先 `docker pull hello-world` 自测，**不要**把未验证的镜像站写进 compose。
 3. **取得代码**：`git clone`，或把发布 zip 解到目标目录。若用 zip 覆盖已有目录：`bash deploy/update-from-zip.sh /path/to/StarByte.zip`（会保留 `deploy/.env`，且**绝不**触碰 named volumes）。
-4. **复制环境变量**：`cp deploy/.env.example deploy/.env`，改密码与 `JWT_SECRET`。内网保持 `SKIP_BUCKET_CREATE=true`。
+4. **复制环境变量**：`cp deploy/.env.example deploy/.env`，改密码与 `JWT_SECRET`。内网保持 `SKIP_BUCKET_CREATE=true`。`CAS_AUTHSERVER_IP` 默认 `10.100.14.250`（写入 backend `extra_hosts`）。
 5. **恢复数据（若有导出）**：先 `up` 出 postgres/minio，再导入 SQL / 拷回 MinIO 数据，见「数据库备份与恢复」。
 6. **构建并启动**：`docker compose -f deploy/docker-compose.yml up -d --build`
 7. **首次建桶**：`SKIP_BUCKET_CREATE=true` 时后端不会自动建桶。在 MinIO 控制台（或 `mc`）**手动创建一次** `starbyte` 桶。
@@ -143,7 +143,7 @@ echo "STARBYTE_HOME=$(pwd)" | sudo tee /etc/starbyte.conf
 | `starbyte rebuild [backend\|frontend\|all]` | `build` + `up --no-deps --force-recreate`，避免顺带强拉 MinIO/Postgres |
 | `starbyte env-check` | 只检查 `deploy/.env` **键名**是否存在且非空，不打印值 |
 | `starbyte backup` | Postgres dump 到 `/var/backups/starbyte/`（不可写则 `./backups/`），并提示 volume / MinIO 路径 |
-| `starbyte doctor` | 校园部署常见问题：镜像站 403、`SKIP_BUCKET_CREATE`、CAS 回调、80 端口 |
+| `starbyte doctor` | 校园部署常见问题：镜像站 403、`SKIP_BUCKET_CREATE`、CAS 回调 / authserver 内网解析、80 端口 |
 
 `rebuild` 对应生产上已验证的绕过方式：镜像站 403 时不要对 MinIO 做 `compose up` 全量拉取。
 
@@ -154,7 +154,7 @@ bash deploy/update-from-zip.sh /path/to/StarByte-main.zip
 starbyte rebuild all
 ```
 
-脚本会把 zip 解到仓库上，**始终保留现有 `deploy/.env`**，且不执行任何 `docker volume` / `down -v`。
+脚本会把 zip 解到仓库上，**始终保留现有 `deploy/.env`**，且不执行任何 `docker volume` / `down -v`。`deploy/docker-compose.yml` **会被 zip 覆盖**（不要靠机器上手改 compose）。CAS 所需的 `extra_hosts` 已写进仓库 compose，zip 更新后 `rebuild` 即可保持 `authserver.smbu.edu.cn` → `CAS_AUTHSERVER_IP`。
 
 ## 手动部署
 
@@ -170,7 +170,8 @@ starbyte rebuild all
 - **漏测没有域名**：用校园网 IP 打开系统（`http://<服务器IP>/`）。`service` / 回跳按访问 Host 自动拼，信息化备案：
   `http://<服务器IP>/api/v1/auth/cas/callback`
 - 有 `starbyte.smbu.edu.cn` 后再改备案，或设 `CAS_SERVICE_URL` / `CAS_FRONTEND_URL`
-- 环境变量见 `backend/.env.example` 的 `CAS_*`
+- **容器解析**：backend 带 `extra_hosts`，`authserver.smbu.edu.cn` → `${CAS_AUTHSERVER_IP:-10.100.14.250}`。校园 DNS 常返回不可达 IPv6，callback 会 wget 超时约 20s（nginx 502）。改 IP 后必须 `starbyte rebuild backend`（或 `--force-recreate`）才会写入容器 `/etc/hosts`
+- 环境变量见 `deploy/.env.example` / `backend/.env.example` 的 `CAS_*`
 - 外网 `starbyte.com` 检测校内 IP 后 301 属二期
 
 ## Nginx 反向代理（示例）

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,24 @@
 
 生产环境以 `deploy/docker-compose.yml` 为准。开发环境用 `deploy/docker-compose.dev.yml`（会把 Postgres/Redis/MinIO 端口打到主机）。
 
+应急运维：`deploy/cli/starbyte`（安装后可用 `starbyte` / `sb`，类似宝塔 `bt`）。
+
+## 新服务器清单（校园网 / 内网裸机）
+
+目标：格式化新机 → 只走国内可达源拉依赖 → 恢复导出数据 → `up`。**不必再对 Dockerfile 做 ad-hoc sed。**
+
+1. **安装 Docker Engine + Compose 插件**（发行版官方源或学校镜像）。确认 `docker compose version` 可用。
+2. **（可选）配置 registry-mirrors**，见下方「daemon.json」。先 `docker pull hello-world` 自测，**不要**把未验证的镜像站写进 compose。
+3. **取得代码**：`git clone`，或把发布 zip 解到目标目录。若用 zip 覆盖已有目录：`bash deploy/update-from-zip.sh /path/to/StarByte.zip`（会保留 `deploy/.env`，且**绝不**触碰 named volumes）。
+4. **复制环境变量**：`cp deploy/.env.example deploy/.env`，改密码与 `JWT_SECRET`。内网保持 `SKIP_BUCKET_CREATE=true`。
+5. **恢复数据（若有导出）**：先 `up` 出 postgres/minio，再导入 SQL / 拷回 MinIO 数据，见「数据库备份与恢复」。
+6. **构建并启动**：`docker compose -f deploy/docker-compose.yml up -d --build`
+7. **首次建桶**：`SKIP_BUCKET_CREATE=true` 时后端不会自动建桶。在 MinIO 控制台（或 `mc`）**手动创建一次** `starbyte` 桶。
+8. **健康检查**：`curl -sf http://127.0.0.1:8080/health`；浏览器打开 `http://<服务器IP>/`。或 `starbyte status` / `starbyte doctor`。
+9. **更新应用时保留 volumes**：只重建前后端，例如 `starbyte rebuild all`（内部 `up --no-deps --force-recreate`），或  
+   `docker compose -f deploy/docker-compose.yml up -d --no-deps --force-recreate backend frontend`。  
+   **不要** `down -v`，不要删除 `postgres-data` / `redis-data` / `minio-data`。
+
 ## Docker Compose（推荐）
 
 ```bash
@@ -20,7 +38,65 @@ docker compose -f deploy/docker-compose.yml ps
 - **Go modules**：`go env -w GOPROXY=https://goproxy.cn,direct` 后再 `go mod download`
 - **MinIO mc**：镜像内是 `exit 0` 占位脚本，不从 `dl.min.io` 拉客户端。生产请设 `SKIP_BUCKET_CREATE=true`（`deploy/.env.example` 默认已是），在 MinIO 控制台手动创建一次 `starbyte` 桶
 
-前端基础镜像仍是 docker.io 的 `node:20-alpine` / `nginx:1.27-alpine`。仓库不写死未验证的国内 registry。若 `docker pull` 失败，用已配置的 Docker Hub 镜像源拉取，或在可联网机器上 `docker pull` 后 `tag` / `save` 导入内网。
+前端与基础设施仍用 docker.io 官方 tag，仓库**不写死**未验证的国内 registry / 华为 SWR：
+
+| 用途 | 镜像 |
+|------|------|
+| 前端构建 | `node:20-alpine` |
+| 前端生产 | `nginx:1.27-alpine` |
+| 数据库 | `postgres:16-alpine` |
+| 缓存 | `redis:7-alpine` |
+| 对象存储 | `${MINIO_IMAGE:-minio/minio:latest}` |
+
+若 `docker pull` 失败：用已配置的 Docker Hub 镜像源拉取，或在可联网机器上 `docker pull` 后 `tag` / `save` 导入内网。
+
+### MinIO 镜像与本地复用
+
+生产机上曾出现：compose 钉死 `minio/minio:RELEASE.2024-08-17T01-16-21Z`，经校园镜像站拉取得到 **403**，而本机已有健康的 `minio/minio:latest` 却用不上。
+
+当前 compose：
+
+- 默认 `minio/minio:latest`，可用环境变量 `MINIO_IMAGE=...` 覆盖（写入 `deploy/.env`）
+- `pull_policy: if_not_present`：本地已有该 tag 时**不强制拉取**
+- postgres / redis 同样 `if_not_present`，避免镜像站抖动时把 `up` 卡死
+
+CI 只 `docker build` 前后端生产 target，不 `compose pull` MinIO，不受此默认 tag 影响。
+
+若必须钉 RELEASE：在 `.env` 设 `MINIO_IMAGE=minio/minio:RELEASE.2024-08-17T01-16-21Z`，并保证该 tag 已在本机或可拉取。
+
+### daemon.json 镜像源（可选，先自测）
+
+**不要**把某一个未验证的镜像站写进 `docker-compose.yml` 的 `image:`。校园常见镜像站会对部分仓库返回 403（例如某机上的 `docker.xuanyuan.me` 拉 `minio/minio:RELEASE.*`）。
+
+若学校或机房提供可用加速，在宿主机配置 Docker，而不是改仓库：
+
+```bash
+sudo mkdir -p /etc/docker
+sudo tee /etc/docker/daemon.json >/dev/null <<'EOF'
+{
+  "registry-mirrors": [
+    "https://example-campus-mirror.invalid"
+  ]
+}
+EOF
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+```
+
+把 `example-campus-mirror.invalid` 换成**本机已验证**的地址。可选来源（均须自行 `docker pull` 验证，失效很常见）：
+
+- 学校 / 机房自建 registry-mirrors
+- 云厂商容器镜像加速（须登录控制台获取专属地址）
+- 社区公开加速（地址经常更换或 403，**禁止**当仓库默认）
+
+验证：
+
+```bash
+docker info | grep -A20 'Registry Mirrors'
+docker pull hello-world
+```
+
+拉失败时改用离线导入：在可访问 Docker Hub 的机器 `docker pull` + `docker save`，拷到内网 `docker load`。postgres / redis / node / nginx / minio 均可如此导入后再 `compose up --build`（`if_not_present` 会复用本地镜像）。
 
 启动后：
 
@@ -42,6 +118,43 @@ APP_ENV=prod make seed
 ```
 
 默认账号：`admin/admin123`（社长，学号 `20210001`）、`test/test123`（会员，学号 `20210002`）。
+
+## 应急 CLI（`starbyte` / `sb`）
+
+SSH 登录后的轻量运维入口，依赖 **bash + docker compose**，不读、不打印密钥值。
+
+```bash
+# 在仓库根执行（一次性安装到 PATH，并写入 /etc/starbyte.conf）
+sudo bash deploy/cli/starbyte install
+
+# 或手动：
+sudo install -m 0755 deploy/cli/starbyte /usr/local/bin/starbyte
+sudo ln -sfn /usr/local/bin/starbyte /usr/local/bin/sb
+echo "STARBYTE_HOME=$(pwd)" | sudo tee /etc/starbyte.conf
+```
+
+之后任意目录：
+
+| 命令 | 作用 |
+|------|------|
+| `starbyte status` / `sb status` | `compose ps` + `:8080/health`、`:80` 短检查 |
+| `starbyte logs [服务] [--tail N]` | 看日志 |
+| `starbyte restart [服务\|all]` | 重启容器（不重建镜像） |
+| `starbyte rebuild [backend\|frontend\|all]` | `build` + `up --no-deps --force-recreate`，避免顺带强拉 MinIO/Postgres |
+| `starbyte env-check` | 只检查 `deploy/.env` **键名**是否存在且非空，不打印值 |
+| `starbyte backup` | Postgres dump 到 `/var/backups/starbyte/`（不可写则 `./backups/`），并提示 volume / MinIO 路径 |
+| `starbyte doctor` | 校园部署常见问题：镜像站 403、`SKIP_BUCKET_CREATE`、CAS 回调、80 端口 |
+
+`rebuild` 对应生产上已验证的绕过方式：镜像站 403 时不要对 MinIO 做 `compose up` 全量拉取。
+
+## 用 zip 更新代码（保留 .env 与 volumes）
+
+```bash
+bash deploy/update-from-zip.sh /path/to/StarByte-main.zip
+starbyte rebuild all
+```
+
+脚本会把 zip 解到仓库上，**始终保留现有 `deploy/.env`**，且不执行任何 `docker volume` / `down -v`。
 
 ## 手动部署
 
@@ -96,11 +209,14 @@ server {
 ## 数据库备份与恢复
 
 ```bash
-# 备份
+# 推荐：应急 CLI（自动选目录并写说明）
+starbyte backup
+
+# 或手动
 docker exec starbyte-postgres pg_dump -U starbyte starbyte > starbyte-$(date +%F).sql
 
 # 恢复
 cat starbyte-2026-09-07.sql | docker exec -i starbyte-postgres psql -U starbyte starbyte
 ```
 
-MinIO 桶与 Postgres 一起备份。恢复后执行 `make migrate-up` 确认 schema 版本。
+MinIO 桶与 Postgres 一起备份。Named volumes 典型路径可用 `docker volume inspect` 查看（compose 项目名多为 `deploy`，卷名类似 `deploy_postgres-data`）。恢复后确认迁移版本；`SKIP_BUCKET_CREATE=true` 时桶需已存在。

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────
 # Stage 1: 构建前端静态资源
-# node:20-alpine 来自 docker.io。校园网拉失败时请用已配置的国内镜像源
-# 拉取后 retag 为 node:20-alpine，勿在本文件写死未验证的 registry。
+# node:20-alpine 来自 docker.io。校园网拉失败时请用 daemon.json 的
+# registry-mirrors 拉取后 retag，勿在本文件写死未验证的 registry。
 # ─────────────────────────────────────────────────────────
 FROM node:20-alpine AS builder
 
@@ -33,6 +33,8 @@ CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 
 # ─────────────────────────────────────────────────────────
 # Stage 3: 生产镜像（Nginx 托管静态文件 + API 代理）
+# nginx:1.27-alpine 同样来自 docker.io；拉失败时用 daemon.json 镜像源
+# 或 retag，勿写死未验证的 registry。
 # ─────────────────────────────────────────────────────────
 FROM nginx:1.27-alpine AS production
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

接 #164（ghfast / stub mc / goproxy / `SKIP_BUCKET_CREATE=true`）。生产机 `10.100.13.17` 上 `compose build` 已通，但裸 `compose up` 仍会去拉钉死的 `minio/minio:RELEASE.2024-08-17T01-16-21Z`，经校园镜像站（如 `docker.xuanyuan.me`）得到 **403**；本机已有健康的 `minio/minio:latest` 却用不上。当时靠 `up --no-deps --force-recreate backend frontend` 绕过。

本 PR 让新机可以：格式化 → 国内可达源拉依赖 → 恢复数据 → `up`，**不必再 sed Dockerfile**，并提供类似宝塔 `bt` 的 SSH 应急 CLI。

1. **MinIO**：compose 默认 `${MINIO_IMAGE:-minio/minio:latest}`，`pull_policy: if_not_present`。本地已有兼容镜像时不强制拉取。postgres / redis 同样 `if_not_present`。不把未验证镜像站写进 `image:`。
2. **文档**：`docs/deployment.md` + `deploy/.env.example` 补充新机清单、`daemon.json` registry-mirrors **选项**（先自测，禁止写死会 403 的源）、建桶一次、更新时保留 volumes。postgres / redis / node / nginx 仍用 docker.io 官方 tag，与 #164 一致。
3. **`deploy/update-from-zip.sh`**：zip 覆盖代码，始终保留 `deploy/.env`，绝不碰 named volumes。`docker-compose.yml` 会被 zip 覆盖（勿靠机器上手改）。
4. **`deploy/cli/starbyte`**（`install` 后 `/usr/local/bin/starbyte` + 软链 `sb`）：`status` / `logs` / `restart` / `rebuild` / `env-check` / `backup` / `doctor`。`rebuild` 只 build + `--no-deps --force-recreate` 应用服务。`env-check` 只报键名，不打印密钥。未改 CAS AppSecret 处理。

### 跟进：CAS extra_hosts（`8c1693b`）

仓库 compose 的 `backend` 写入 `authserver.smbu.edu.cn:${CAS_AUTHSERVER_IP:-10.100.14.250}`，避免 zip 覆盖后解析到公网 IPv6 导致 callback 502。

### 跟进：审查修复 + rebase `#165`（`dad3225`）

已 rebase 最新 `main`（含 schedule 角色迁移 #165）。

- **备份权限**：目录 `0700`；dump / notes 先 `umask 077` + `chmod 600` 再建再写。
- **env_get**：去掉行尾 `\\r` 与成对单/双引号，对齐 compose env-file（`SKIP_BUCKET_CREATE="true"`、`POSTGRES_USER="..."`）。

## 关联 Issue

无对应 Issue（校园网裸机部署与应急运维，接 #164）。

## 测试方式

1. `bash -n deploy/cli/starbyte`
2. `env_get`：带引号 + CRLF 的 `.env` 得到无引号值；doctor 将 `SKIP_BUCKET_CREATE="true"` 视为 true。
3. 备份目录 `0700`、dump/notes `600`，other 无读写执行。
4. PyYAML：MinIO `latest` + `if_not_present`；backend `extra_hosts` 含 `CAS_AUTHSERVER_IP`。
5. 请在 `10.100.13.17` 上 `rebuild backend` 后确认 CAS 与 `starbyte backup` 文件权限。

## 注意事项

- **请勿自动 merge**，人工 Review 后再合。
- 不要把某一个公开镜像站写进 compose。
- `CAS_AUTHSERVER_IP` 仅影响容器 hosts，不改 CAS AppSecret。

## 检查清单

- [x] 代码遵循项目开发规范
- [x] 已进行自测
- [x] 已添加/更新必要的文档
- [ ] CI 检查通过（rebase 后重跑）
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f895e0e1-7141-5388-a07d-103df91c3556?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f895e0e1-7141-5388-a07d-103df91c3556&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

