### PR TITLE
fix(rbac): 撤回 000054 多授的部长/副部长日程改删权

### DIFF
--- a/backend/migrations/000057_schedule_role_permissions_least_privilege.down.sql
+++ b/backend/migrations/000057_schedule_role_permissions_least_privilege.down.sql
@@ -1,0 +1,17 @@
+-- 回滚到 000054 对部长/副部长的授权（仅恢复本迁移删除的行）。
+
+INSERT INTO role_permissions (id, role_id, permission_id, data_scope)
+SELECT uuid_generate_v4(), r.id, p.id, 'department'
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.code = 'minister'
+  AND p.code = 'schedule:delete'
+ON CONFLICT (role_id, permission_id) DO NOTHING;
+
+INSERT INTO role_permissions (id, role_id, permission_id, data_scope)
+SELECT uuid_generate_v4(), r.id, p.id, 'department'
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.code = 'vice_minister'
+  AND p.code IN ('schedule:update', 'schedule:delete')
+ON CONFLICT (role_id, permission_id) DO NOTHING;

--- a/backend/migrations/000057_schedule_role_permissions_least_privilege.up.sql
+++ b/backend/migrations/000057_schedule_role_permissions_least_privilege.up.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- 000057_schedule_role_permissions_least_privilege.up.sql
+-- #165 的 000054 将 schedule 四权一并授给 minister / vice_minister（department）。
+-- 写入接口按权限码门禁，再按资源 schedule 取最宽 data_scope，
+-- 因而副部长可改删同部门他人部门日历，部长可删除该类日历。
+-- 与 seed_rbac.go 对齐：部长无 delete，副部长无 update/delete。
+-- ============================================================
+
+DELETE FROM role_permissions rp
+USING roles r, permissions p
+WHERE rp.role_id = r.id
+  AND rp.permission_id = p.id
+  AND r.code = 'minister'
+  AND p.code = 'schedule:delete';
+
+DELETE FROM role_permissions rp
+USING roles r, permissions p
+WHERE rp.role_id = r.id
+  AND rp.permission_id = p.id
+  AND r.code = 'vice_minister'
+  AND p.code IN ('schedule:update', 'schedule:delete');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

#165 已合入 `000054`，把 `schedule:*` 四权一并授给 `minister` / `vice_minister`（`data_scope=department`）。安全评审指出这超出 `seed_rbac.go`：

- 部长种子只有 read/create/update，**无 delete**
- 副部长种子只有 read/create，**无 update/delete**

写入接口按权限码门禁，再按资源 `schedule` 取最宽 `data_scope`，因此副部长可改删同部门他人部门日历，部长可删除该类日历。

本 PR **不改已合入的 000054**（避免改写已发布迁移）。`main` 上 #169 SMTP 占用 `000055`、#170 公告占用 `000056`，因此本迁移编号为 **000057**，只删除上述多授行。`officer` / `member` / 社长侧授权不变。

## 关联 Issue

Follow-up of #165 / 安全评审 MEDIUM。

## 测试方式

1. 在已应用 000054 的库上 `migrate up`：部长不再有 `schedule:delete`，副部长不再有 `schedule:update|delete`。
2. `down 1` 恢复这三行；再 `up` 再次撤回。
3. 会员/干事/社长/超管/副社长的 schedule 授权不受影响。
4. 与 `000055_smtp_settings`、`000056_announcement` 无编号冲突。

## 注意事项

- 已部署 000054 的环境需要再跑 000057，然后重启 backend 或清权限缓存 / 重新登录。
- 已 rebase 到最新 `main`。
- 未 force-merge。

## 检查清单

- [x] 与 seed_rbac 最小权限对齐
- [x] 已 rebase 到 latest main，编号为 000057
- [x] CI 检查通过（rebase 后 7/7 全绿）
- [x] 没有硬编码敏感信息

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92a30711-e68c-5685-9dd7-1ddb328ede37?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92a30711-e68c-5685-9dd7-1ddb328ede37&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

