### PR TITLE
feat(member): 入会申请接入流程引擎一期

### DIFF
--- a/backend/internal/member/dto/application.go
+++ b/backend/internal/member/dto/application.go
@@ -77,6 +77,7 @@ type ApplicationResponse struct {
 	Status                   int16         `json:"status"`
 	CurrentStage             string        `json:"current_stage,omitempty"`
 	FlowInstanceID           string        `json:"flow_instance_id,omitempty"`
+	WorkflowKey              string        `json:"workflow_key,omitempty"`
 	Reviewer                 *ReviewerInfo `json:"reviewer,omitempty"`
 	ReviewComment            string        `json:"review_comment,omitempty"`
 	RequiredFields           []string      `json:"required_fields,omitempty"`

--- a/backend/internal/member/model/admission.go
+++ b/backend/internal/member/model/admission.go
@@ -16,6 +16,7 @@ const (
 	AdmissionRejected   = "rejected"
 	AdmissionSupplement = "supplement"
 	AdmissionLegacy     = "legacy_review"
+	AdmissionEngine     = "engine"
 )
 
 type AdmissionSignature struct {

--- a/backend/internal/member/model/application.go
+++ b/backend/internal/member/model/application.go
@@ -79,4 +79,5 @@ type ApplicationWithNames struct {
 	Username       string `gorm:"column:username"`
 	DepartmentName string `gorm:"column:department_name"`
 	ReviewerName   string `gorm:"column:reviewer_name"`
+	WorkflowKey    string `gorm:"column:workflow_key"`
 }

--- a/backend/internal/member/repo/admission_repo.go
+++ b/backend/internal/member/repo/admission_repo.go
@@ -21,6 +21,7 @@ type AdmissionRepo interface {
 	AddSignature(context.Context, *model.AdmissionSignature) error
 	InterviewCompleted(context.Context, uuid.UUID, int16, time.Time) (bool, error)
 	SaveApplication(context.Context, *model.MemberApplication) error
+	WorkflowDefinitionKey(context.Context, uuid.UUID) (string, error)
 }
 type admissionRepo struct{ db *gorm.DB }
 
@@ -66,6 +67,14 @@ func (r *admissionRepo) InterviewCompleted(ctx context.Context, id uuid.UUID, ro
 }
 func (r *admissionRepo) SaveApplication(ctx context.Context, app *model.MemberApplication) error {
 	return r.db.WithContext(ctx).Save(app).Error
+}
+func (r *admissionRepo) WorkflowDefinitionKey(ctx context.Context, instanceID uuid.UUID) (string, error) {
+	var key string
+	err := r.db.WithContext(ctx).Raw(
+		`SELECT d.key FROM flow_instances i JOIN flow_definitions d ON d.id = i.definition_id WHERE i.id = ?`,
+		instanceID,
+	).Scan(&key).Error
+	return key, err
 }
 
 func (r *admissionRepo) Objections(ctx context.Context, id uuid.UUID) ([]model.AdmissionObjection, error) {

--- a/backend/internal/member/repo/application_repo.go
+++ b/backend/internal/member/repo/application_repo.go
@@ -57,10 +57,12 @@ func (r *applicationRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Mem
 
 func (r *applicationRepo) namedQuery(ctx context.Context) *gorm.DB {
 	return r.db.WithContext(ctx).Table("member_applications AS a").
-		Select("a.*, u.username, COALESCE(d.name, '') AS department_name, COALESCE(r.real_name, '') AS reviewer_name").
+		Select("a.*, u.username, COALESCE(d.name, '') AS department_name, COALESCE(r.real_name, '') AS reviewer_name, COALESCE(fd.key, '') AS workflow_key").
 		Joins("LEFT JOIN users u ON u.id = a.user_id").
 		Joins("LEFT JOIN departments d ON d.id = a.department_id").
-		Joins("LEFT JOIN users r ON r.id = a.reviewer_id")
+		Joins("LEFT JOIN users r ON r.id = a.reviewer_id").
+		Joins("LEFT JOIN flow_instances fi ON fi.id = a.flow_instance_id").
+		Joins("LEFT JOIN flow_definitions fd ON fd.id = fi.definition_id")
 }
 
 func applyAppScope(q *gorm.DB, scope *rbacModel.DataScopeCondition) *gorm.DB {

--- a/backend/internal/member/service/admission_service.go
+++ b/backend/internal/member/service/admission_service.go
@@ -291,6 +291,10 @@ func (s *admissionService) Sign(ctx context.Context, viewer, id uuid.UUID, req *
 	return out, err
 }
 func (s *admissionService) ReviewMaterials(ctx context.Context, viewer, id uuid.UUID, action, comment string) error {
+	handled, err := s.tryEngineReview(ctx, viewer, id, action, comment, nil)
+	if handled || err != nil {
+		return err
+	}
 	snapshot, err := s.Snapshot(ctx, viewer, id)
 	if err != nil {
 		return err
@@ -303,6 +307,10 @@ func (s *admissionService) ReviewMaterials(ctx context.Context, viewer, id uuid.
 }
 
 func (s *admissionService) RequestSupplement(ctx context.Context, viewer, id uuid.UUID, req *dto.SupplementRequest) error {
+	handled, err := s.tryEngineReview(ctx, viewer, id, actionSupplement, req.Comment, req.RequiredFields)
+	if handled || err != nil {
+		return err
+	}
 	snapshot, err := s.Snapshot(ctx, viewer, id)
 	if err != nil {
 		return err

--- a/backend/internal/member/service/admission_service.go
+++ b/backend/internal/member/service/admission_service.go
@@ -177,6 +177,13 @@ func (s *admissionService) Sign(ctx context.Context, viewer, id uuid.UUID, req *
 		if app.HistoricalReviewRequired || app.AdmissionVersion < 2 {
 			return response.NewError(response.CodeMemberAppInvalid, "历史申请须先核验，不能自动补签")
 		}
+		engineChain, err := s.isEngineChain(ctx, store, app)
+		if err != nil {
+			return err
+		}
+		if engineChain {
+			return response.NewError(response.CodeMemberAppInvalid, "该申请已接入流程引擎，请使用入会审批，不能走章程签字")
+		}
 		if req.Stage != app.AdmissionStage || req.Revision != app.AdmissionRevision {
 			return response.NewError(response.CodeConflict, "申请进度已变化，请刷新后操作")
 		}

--- a/backend/internal/member/service/admission_transition.go
+++ b/backend/internal/member/service/admission_transition.go
@@ -28,6 +28,6 @@ func advanceAdmission(app *model.MemberApplication, now time.Time) {
 	}
 }
 func admissionStageLabel(stage string) string {
-	labels := map[string]string{model.AdmissionMaterials: "资料审核", model.AdmissionRound1: "一面与会签", model.AdmissionRound2: "二面与中心审批", model.AdmissionPresident: "会长最终确认", model.AdmissionProbation: "候补期", model.AdmissionApproved: "正式成员", model.AdmissionRejected: "未通过", model.AdmissionSupplement: "待补充材料", model.AdmissionLegacy: "历史待核验"}
+	labels := map[string]string{model.AdmissionMaterials: "资料审核", model.AdmissionRound1: "一面与会签", model.AdmissionRound2: "二面与中心审批", model.AdmissionPresident: "会长最终确认", model.AdmissionProbation: "候补期", model.AdmissionApproved: "正式成员", model.AdmissionRejected: "未通过", model.AdmissionSupplement: "待补充材料", model.AdmissionLegacy: "历史待核验", model.AdmissionEngine: "流程审批"}
 	return labels[stage]
 }

--- a/backend/internal/member/service/admission_workflow.go
+++ b/backend/internal/member/service/admission_workflow.go
@@ -34,19 +34,13 @@ func (s *admissionService) startAdmissionWorkflow(ctx context.Context, tx *gorm.
 	if err != nil {
 		return nil, err
 	}
-	key := "member_admission"
-	if app.Type == model.ApplicantOfficer {
-		key = officerInterviewKey
-	}
-	vars := map[string]interface{}{"application_id": app.ID.String(), "applicant_type": app.Type, "revision": app.AdmissionRevision}
-	if app.DepartmentID != nil {
-		vars["department_id"] = app.DepartmentID.String()
-	}
-	inst, err := flow.Start(ctx, key, app.ID.String(), "member_application", app.UserID, vars)
+	inst, err := flow.Start(ctx, engine.MemberApplicationDefinitionKey, app.ID.String(), "member_application", app.UserID, applicationVariables(app))
 	if err != nil {
 		return nil, err
 	}
 	app.FlowInstanceID = &inst.ID
+	app.Status = model.AppPending
+	app.CurrentStage = engineStageMinister
 	if err := store.SaveApplication(ctx, app); err != nil {
 		return nil, err
 	}

--- a/backend/internal/member/service/admission_workflow.go
+++ b/backend/internal/member/service/admission_workflow.go
@@ -39,8 +39,18 @@ func (s *admissionService) startAdmissionWorkflow(ctx context.Context, tx *gorm.
 		return nil, err
 	}
 	app.FlowInstanceID = &inst.ID
+	app.AdmissionStage = model.AdmissionEngine
+	app.StageEnteredAt = s.now()
 	app.Status = model.AppPending
 	app.CurrentStage = engineStageMinister
+	// 无意向部门的会员申请没有对口部长，跳过部长节点直达社长。干事申请提交时已强制部门。
+	if skipMinisterNode(app) {
+		if err := flow.SkipApplicationApproval(ctx, inst.ID, "minister", app.UserID, "会员申请无意向部门，跳过部长审批"); err != nil {
+			return nil, err
+		}
+		app.Status = model.AppReviewing
+		app.CurrentStage = engineStagePresident
+	}
 	if err := store.SaveApplication(ctx, app); err != nil {
 		return nil, err
 	}

--- a/backend/internal/member/service/admission_workflow.go
+++ b/backend/internal/member/service/admission_workflow.go
@@ -41,15 +41,13 @@ func (s *admissionService) startAdmissionWorkflow(ctx context.Context, tx *gorm.
 	app.FlowInstanceID = &inst.ID
 	app.AdmissionStage = model.AdmissionEngine
 	app.StageEnteredAt = s.now()
-	app.Status = model.AppPending
-	app.CurrentStage = engineStageMinister
-	// 无意向部门的会员申请没有对口部长，跳过部长节点直达社长。干事申请提交时已强制部门。
+	// skip_minister 在 Start 时已让引擎穿过部长节点，不会创建全员部长待办。
 	if skipMinisterNode(app) {
-		if err := flow.SkipApplicationApproval(ctx, inst.ID, "minister", app.UserID, "会员申请无意向部门，跳过部长审批"); err != nil {
-			return nil, err
-		}
 		app.Status = model.AppReviewing
 		app.CurrentStage = engineStagePresident
+	} else {
+		app.Status = model.AppPending
+		app.CurrentStage = engineStageMinister
 	}
 	if err := store.SaveApplication(ctx, app); err != nil {
 		return nil, err

--- a/backend/internal/member/service/application_engine.go
+++ b/backend/internal/member/service/application_engine.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/Yogdunana/StarByte/backend/internal/member/model"
+	"github.com/Yogdunana/StarByte/backend/internal/member/repo"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+)
+
+const (
+	engineStageMinister  = "部长审批"
+	engineStagePresident = "社长审批"
+)
+
+func applicationVariables(app *model.MemberApplication) map[string]interface{} {
+	vars := map[string]interface{}{
+		"application_id": app.ID.String(),
+		"applicant":      app.UserID.String(),
+		"applicant_type": app.Type,
+		"apply_type":     app.Type,
+		"real_name":      app.RealName,
+		"student_no":     app.StudentNo,
+		"revision":       app.AdmissionRevision,
+	}
+	if app.DepartmentID != nil {
+		vars["department_id"] = app.DepartmentID.String()
+		vars["department"] = app.DepartmentID.String()
+	}
+	return vars
+}
+
+func applyEngineOutcome(app *model.MemberApplication, action, nodeID string, completed bool, now time.Time) {
+	app.UpdatedAt = now
+	app.ReviewedAt = &now
+	if action == actionReject {
+		app.Status = model.AppRejected
+		app.AdmissionStage = model.AdmissionRejected
+		app.CurrentStage = stageLabel(model.AppRejected)
+		return
+	}
+	if action == actionSupplement {
+		app.Status = model.AppSupplement
+		app.AdmissionStage = model.AdmissionSupplement
+		app.CurrentStage = stageLabel(model.AppSupplement)
+		return
+	}
+	if completed {
+		app.Status = model.AppApproved
+		app.AdmissionStage = model.AdmissionApproved
+		app.CurrentStage = stageLabel(model.AppApproved)
+		return
+	}
+	if nodeID == "president" {
+		app.Status = model.AppReviewing
+		app.CurrentStage = engineStagePresident
+		return
+	}
+	app.Status = model.AppPending
+	app.CurrentStage = engineStageMinister
+}
+
+func engineNodeRole(nodeID string) string {
+	switch nodeID {
+	case "minister":
+		return "minister"
+	case "president":
+		return "president"
+	default:
+		return ""
+	}
+}
+
+func (s *admissionService) tryEngineReview(ctx context.Context, viewer, id uuid.UUID, action, comment string, required []string) (bool, error) {
+	if s.flow == nil {
+		return false, nil
+	}
+	var handled bool
+	var deliver func(context.Context)
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		store := repo.NewAdmissionRepo(tx)
+		app, actor, parent, err := loadAdmission(ctx, store, viewer, id)
+		if err != nil {
+			return err
+		}
+		ok, err := s.isEngineChain(ctx, store, app)
+		if err != nil || !ok {
+			return err
+		}
+		handled = true
+		deliver, err = s.runEngineReview(ctx, tx, store, app, actor, parent, viewer, action, comment, required)
+		return err
+	})
+	if err == nil && deliver != nil {
+		deliver(ctx)
+		_ = s.refreshPermissions(ctx)
+	}
+	return handled, err
+}
+
+func (s *admissionService) isEngineChain(ctx context.Context, store repo.AdmissionRepo, app *model.MemberApplication) (bool, error) {
+	if app.FlowInstanceID == nil {
+		return false, nil
+	}
+	key, err := store.WorkflowDefinitionKey(ctx, *app.FlowInstanceID)
+	if err != nil {
+		return false, err
+	}
+	return key == engine.MemberApplicationDefinitionKey, nil
+}
+
+func (s *admissionService) runEngineReview(
+	ctx context.Context, tx *gorm.DB, store repo.AdmissionRepo,
+	app *model.MemberApplication, actor *model.AdmissionActor, parent *uuid.UUID,
+	viewer uuid.UUID, action, comment string, required []string,
+) (func(context.Context), error) {
+	if app.HistoricalReviewRequired {
+		return nil, response.NewError(response.CodeMemberAppInvalid, "历史申请须先核验，不能自动补签")
+	}
+	if action != actionApprove && action != actionReject && action != actionSupplement {
+		return nil, response.NewError(response.CodeBadRequest, "无效的审批决定")
+	}
+	if action != actionApprove && comment == "" {
+		return nil, response.NewError(response.CodeBadRequest, "拒绝或补充材料须填写原因")
+	}
+	flow, deliver, err := s.flow.BindTransaction(tx)
+	if err != nil {
+		return nil, err
+	}
+	nodeID, completed, err := flow.RunningApprovalNode(ctx, *app.FlowInstanceID)
+	if err != nil {
+		return nil, err
+	}
+	if completed {
+		return nil, response.NewError(response.CodeConflict, "入会流程已结束")
+	}
+	role := engineNodeRole(nodeID)
+	allowed, _ := admissionAuthority(actor, app, parent, role)
+	if !allowed {
+		return nil, admissionDenied("无权审批该入会申请")
+	}
+	from := app.Status
+	now := s.now()
+	if action == actionSupplement {
+		if err := flow.Terminate(ctx, *app.FlowInstanceID, viewer, "正式审批：supplement"); err != nil {
+			return nil, err
+		}
+		app.RequiredFields = nonemptyStrings(required)
+		applyEngineOutcome(app, action, nodeID, false, now)
+	} else {
+		if err := flow.CompleteApplicationApproval(ctx, *app.FlowInstanceID, viewer, engine.TaskAction(action), comment); err != nil {
+			return nil, err
+		}
+		nodeID, completed, err = flow.RunningApprovalNode(ctx, *app.FlowInstanceID)
+		if err != nil && action != actionReject {
+			return nil, err
+		}
+		if action == actionReject {
+			completed = false
+			nodeID = ""
+		}
+		applyEngineOutcome(app, action, nodeID, completed, now)
+	}
+	app.ReviewerID = &viewer
+	app.ReviewComment = comment
+	if err := store.SaveApplication(ctx, app); err != nil {
+		return nil, err
+	}
+	if app.Status == model.AppApproved {
+		if err := s.admitFromEngine(ctx, tx, app); err != nil {
+			return nil, err
+		}
+	}
+	members := &memberService{apps: repo.NewApplicationRepo(tx), profs: repo.NewProfileRepo(tx)}
+	if err := members.recordAppHistory(ctx, app.ID, from, app.Status, &viewer, comment, map[string]interface{}{"action": action, "engine": true, "node": nodeID}); err != nil {
+		return nil, err
+	}
+	return deliver, nil
+}
+
+func membershipRole(app *model.MemberApplication) string {
+	if app.Type == model.ApplicantOfficer {
+		return "officer"
+	}
+	return "member"
+}
+
+func (s *admissionService) admitFromEngine(ctx context.Context, tx *gorm.DB, app *model.MemberApplication) error {
+	members := &memberService{apps: repo.NewApplicationRepo(tx), profs: repo.NewProfileRepo(tx)}
+	if err := members.ensureProfile(ctx, app); err != nil {
+		return err
+	}
+	if err := repo.NewAdmissionMaintenanceRepo(tx).GrantRole(ctx, app.UserID, membershipRole(app), app.DepartmentID); err != nil {
+		return err
+	}
+	return repo.NewAdmissionJobsRepo(tx).QueuePermissionRefresh(ctx, app.UserID)
+}

--- a/backend/internal/member/service/application_engine.go
+++ b/backend/internal/member/service/application_engine.go
@@ -32,6 +32,8 @@ func applicationVariables(app *model.MemberApplication) map[string]interface{} {
 	if app.DepartmentID != nil {
 		vars["department_id"] = app.DepartmentID.String()
 		vars["department"] = app.DepartmentID.String()
+	} else {
+		vars[engine.SkipMinisterVariable] = true
 	}
 	return vars
 }

--- a/backend/internal/member/service/application_engine.go
+++ b/backend/internal/member/service/application_engine.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -56,6 +57,7 @@ func applyEngineOutcome(app *model.MemberApplication, action, nodeID string, com
 		app.CurrentStage = stageLabel(model.AppApproved)
 		return
 	}
+	app.AdmissionStage = model.AdmissionEngine
 	if nodeID == "president" {
 		app.Status = model.AppReviewing
 		app.CurrentStage = engineStagePresident
@@ -63,6 +65,26 @@ func applyEngineOutcome(app *model.MemberApplication, action, nodeID string, com
 	}
 	app.Status = model.AppPending
 	app.CurrentStage = engineStageMinister
+}
+
+func skipMinisterNode(app *model.MemberApplication) bool {
+	return app != nil && app.DepartmentID == nil
+}
+
+func engineReviewPermission(actor *model.AdmissionActor, app *model.MemberApplication, parent *uuid.UUID, nodeID, comment string, now time.Time) error {
+	role := engineNodeRole(nodeID)
+	if role == "" {
+		return admissionDenied("当前环节不可审批")
+	}
+	allowed, delegated := admissionAuthority(actor, app, parent, role)
+	if !allowed {
+		return admissionDenied("无权审批该入会申请")
+	}
+	// 部长节点只允许意向部门部长立即处理；社长/中心主任须走既有 24h 代签规则。
+	if delegated && (strings.TrimSpace(comment) == "" || now.Before(app.StageEnteredAt.Add(24*time.Hour))) {
+		return admissionDenied("超时24小时后上级才可代签，并须填写原因")
+	}
+	return nil
 }
 
 func engineNodeRole(nodeID string) string {
@@ -139,10 +161,8 @@ func (s *admissionService) runEngineReview(
 	if completed {
 		return nil, response.NewError(response.CodeConflict, "入会流程已结束")
 	}
-	role := engineNodeRole(nodeID)
-	allowed, _ := admissionAuthority(actor, app, parent, role)
-	if !allowed {
-		return nil, admissionDenied("无权审批该入会申请")
+	if err := engineReviewPermission(actor, app, parent, nodeID, comment, s.now()); err != nil {
+		return nil, err
 	}
 	from := app.Status
 	now := s.now()

--- a/backend/internal/member/service/application_engine_test.go
+++ b/backend/internal/member/service/application_engine_test.go
@@ -28,10 +28,11 @@ func TestApplicationVariables(t *testing.T) {
 func TestApplyEngineOutcome(t *testing.T) {
 	now := time.Now()
 	t.Run("minister approve waits for president", func(t *testing.T) {
-		app := &model.MemberApplication{Status: model.AppPending}
+		app := &model.MemberApplication{Status: model.AppPending, AdmissionStage: model.AdmissionMaterials}
 		applyEngineOutcome(app, actionApprove, "president", false, now)
 		require.Equal(t, model.AppReviewing, app.Status)
 		require.Equal(t, engineStagePresident, app.CurrentStage)
+		require.Equal(t, model.AdmissionEngine, app.AdmissionStage)
 	})
 	t.Run("president approve admits", func(t *testing.T) {
 		app := &model.MemberApplication{Status: model.AppReviewing}
@@ -62,6 +63,30 @@ func TestEngineNodeRole(t *testing.T) {
 func TestMembershipRole(t *testing.T) {
 	require.Equal(t, "member", membershipRole(&model.MemberApplication{Type: model.ApplicantMember}))
 	require.Equal(t, "officer", membershipRole(&model.MemberApplication{Type: model.ApplicantOfficer}))
+}
+
+func TestSkipMinisterNode(t *testing.T) {
+	require.True(t, skipMinisterNode(&model.MemberApplication{Type: model.ApplicantMember}))
+	dept := uuid.New()
+	require.False(t, skipMinisterNode(&model.MemberApplication{Type: model.ApplicantOfficer, DepartmentID: &dept}))
+}
+
+func TestEngineReviewPermissionKeepsDelegation(t *testing.T) {
+	dept, center := uuid.New(), uuid.New()
+	now := time.Now()
+	app := &model.MemberApplication{UserID: uuid.New(), DepartmentID: &dept, StageEnteredAt: now}
+	minister := &model.AdmissionActor{ID: uuid.New(), DepartmentID: &dept, Roles: []string{"minister"}}
+	president := &model.AdmissionActor{ID: uuid.New(), Roles: []string{"president"}}
+	other := &model.AdmissionActor{ID: uuid.New(), DepartmentID: &center, Roles: []string{"minister"}}
+
+	require.NoError(t, engineReviewPermission(minister, app, &center, "minister", "", now))
+	require.Error(t, engineReviewPermission(president, app, &center, "minister", "代签", now))
+	require.Error(t, engineReviewPermission(other, app, &center, "minister", "", now))
+	require.NoError(t, engineReviewPermission(president, app, &center, "president", "", now))
+
+	later := now.Add(25 * time.Hour)
+	require.NoError(t, engineReviewPermission(president, app, &center, "minister", "超时代签", later))
+	require.Error(t, engineReviewPermission(president, app, &center, "minister", "", later))
 }
 
 func TestEngineChainUsesDefaultDefinition(t *testing.T) {

--- a/backend/internal/member/service/application_engine_test.go
+++ b/backend/internal/member/service/application_engine_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Yogdunana/StarByte/backend/internal/member/model"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
+)
+
+func TestApplicationVariables(t *testing.T) {
+	dept := uuid.New()
+	app := &model.MemberApplication{
+		ID: uuid.New(), UserID: uuid.New(), Type: model.ApplicantOfficer,
+		RealName: "王五", StudentNo: "2024001", DepartmentID: &dept, AdmissionRevision: 2,
+	}
+	vars := applicationVariables(app)
+	require.Equal(t, app.ID.String(), vars["application_id"])
+	require.Equal(t, app.UserID.String(), vars["applicant"])
+	require.Equal(t, app.Type, vars["apply_type"])
+	require.Equal(t, dept.String(), vars["department_id"])
+	require.Equal(t, dept.String(), vars["department"])
+}
+
+func TestApplyEngineOutcome(t *testing.T) {
+	now := time.Now()
+	t.Run("minister approve waits for president", func(t *testing.T) {
+		app := &model.MemberApplication{Status: model.AppPending}
+		applyEngineOutcome(app, actionApprove, "president", false, now)
+		require.Equal(t, model.AppReviewing, app.Status)
+		require.Equal(t, engineStagePresident, app.CurrentStage)
+	})
+	t.Run("president approve admits", func(t *testing.T) {
+		app := &model.MemberApplication{Status: model.AppReviewing}
+		applyEngineOutcome(app, actionApprove, "", true, now)
+		require.Equal(t, model.AppApproved, app.Status)
+		require.Equal(t, model.AdmissionApproved, app.AdmissionStage)
+		require.Equal(t, stageLabel(model.AppApproved), app.CurrentStage)
+	})
+	t.Run("reject any node", func(t *testing.T) {
+		app := &model.MemberApplication{Status: model.AppReviewing}
+		applyEngineOutcome(app, actionReject, "president", false, now)
+		require.Equal(t, model.AppRejected, app.Status)
+		require.Equal(t, model.AdmissionRejected, app.AdmissionStage)
+	})
+	t.Run("supplement terminates chain", func(t *testing.T) {
+		app := &model.MemberApplication{Status: model.AppPending}
+		applyEngineOutcome(app, actionSupplement, "minister", false, now)
+		require.Equal(t, model.AppSupplement, app.Status)
+	})
+}
+
+func TestEngineNodeRole(t *testing.T) {
+	require.Equal(t, "minister", engineNodeRole("minister"))
+	require.Equal(t, "president", engineNodeRole("president"))
+	require.Empty(t, engineNodeRole("start"))
+}
+
+func TestMembershipRole(t *testing.T) {
+	require.Equal(t, "member", membershipRole(&model.MemberApplication{Type: model.ApplicantMember}))
+	require.Equal(t, "officer", membershipRole(&model.MemberApplication{Type: model.ApplicantOfficer}))
+}
+
+func TestEngineChainUsesDefaultDefinition(t *testing.T) {
+	require.Equal(t, "member_application", engine.MemberApplicationDefinitionKey)
+	graph, err := engine.ParseGraph(engine.MemberApplicationBPMN())
+	require.NoError(t, err)
+	require.NoError(t, engine.ValidateBusinessDefinition(engine.MemberApplicationDefinitionKey, graph))
+}

--- a/backend/internal/member/service/application_engine_test.go
+++ b/backend/internal/member/service/application_engine_test.go
@@ -23,6 +23,14 @@ func TestApplicationVariables(t *testing.T) {
 	require.Equal(t, app.Type, vars["apply_type"])
 	require.Equal(t, dept.String(), vars["department_id"])
 	require.Equal(t, dept.String(), vars["department"])
+	require.Nil(t, vars[engine.SkipMinisterVariable])
+
+	member := applicationVariables(&model.MemberApplication{
+		ID: uuid.New(), UserID: uuid.New(), Type: model.ApplicantMember, RealName: "会员", StudentNo: "2024002",
+	})
+	require.Equal(t, true, member[engine.SkipMinisterVariable])
+	_, hasDept := member["department_id"]
+	require.False(t, hasDept)
 }
 
 func TestApplyEngineOutcome(t *testing.T) {

--- a/backend/internal/member/service/mapper.go
+++ b/backend/internal/member/service/mapper.go
@@ -29,6 +29,7 @@ func mapApplication(row *model.ApplicationWithNames) *dto.ApplicationResponse {
 		ContactEmail:   row.ContactEmail,
 		Status:         row.Status,
 		CurrentStage:   row.CurrentStage,
+		WorkflowKey:    row.WorkflowKey,
 		ReviewComment:  row.ReviewComment,
 		RequiredFields: []string(row.RequiredFields),
 		ReviewedAt:     row.ReviewedAt,

--- a/backend/internal/workflow/engine/admission_graph.go
+++ b/backend/internal/workflow/engine/admission_graph.go
@@ -15,6 +15,9 @@ func ValidateBusinessDefinition(key string, g *FlowGraph) error {
 	if key == TaskDefinitionKey {
 		return ValidateTaskDefinition(g)
 	}
+	if key == MemberApplicationDefinitionKey {
+		return validateMemberApplicationGraph(g)
+	}
 	if key != "officer_interview" && key != "member_admission" {
 		return nil
 	}

--- a/backend/internal/workflow/engine/application_approval.go
+++ b/backend/internal/workflow/engine/application_approval.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+)
+
+// CompleteApplicationApproval completes the current role-based membership task
+// inside an already-authorized business transaction.
+func (e *FlowEngine) CompleteApplicationApproval(ctx context.Context, instanceID, reviewer uuid.UUID, action TaskAction, comment string) error {
+	if !e.businessTransaction {
+		return response.NewError(response.CodeForbidden, "入会审批需要业务事务")
+	}
+	if action != ActionApprove && action != ActionReject {
+		return response.NewError(response.CodeBadRequest, "入会审批只支持同意或拒绝")
+	}
+	if e.db != nil {
+		if err := repo.NewRuntimeRepo(e.db).LockInstance(ctx, instanceID); err != nil {
+			return err
+		}
+	}
+	inst, err := e.instRepo.GetByID(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	if inst == nil || inst.BusinessType != "member_application" || inst.Status != 0 {
+		return response.NewError(response.CodeConflict, "关联入会流程不可审批")
+	}
+	nodeID, err := e.currentApprovalNodeID(ctx, inst)
+	if err != nil {
+		return err
+	}
+	selected, err := e.selectApprovalTask(ctx, instanceID, nodeID, reviewer)
+	if err != nil {
+		return err
+	}
+	return e.CompleteTask(ctx, selected.ID, reviewer, action, comment, nil)
+}
+
+// RunningApprovalNode returns the active approval node, or completed=true when the instance ended.
+func (e *FlowEngine) RunningApprovalNode(ctx context.Context, id uuid.UUID) (string, bool, error) {
+	inst, err := e.instRepo.GetByID(ctx, id)
+	if err != nil {
+		return "", false, err
+	}
+	if inst == nil {
+		return "", false, response.NewError(response.CodeWorkflowInstNotFound, "流程实例不存在")
+	}
+	if inst.Status == 1 {
+		return "", true, nil
+	}
+	if inst.Status != 0 {
+		return "", false, response.NewError(response.CodeConflict, "关联流程已中止")
+	}
+	nodeID, err := e.currentApprovalNodeID(ctx, inst)
+	return nodeID, false, err
+}
+
+func (e *FlowEngine) currentApprovalNodeID(ctx context.Context, inst *model.FlowInstance) (string, error) {
+	version, err := e.defRepo.GetVersionByID(ctx, inst.DefinitionVersionID)
+	if err != nil {
+		return "", err
+	}
+	if version == nil {
+		return "", response.NewError(response.CodeWorkflowVerNotFound, "审批流程版本不存在")
+	}
+	graph, err := ParseGraph(version.BpmnData)
+	if err != nil {
+		return "", err
+	}
+	for _, id := range GetCurrentNodeIDs(inst.CurrentNodeIDs) {
+		node := graph.GetNode(id)
+		if node != nil && node.Type == "approval" {
+			return id, nil
+		}
+	}
+	return "", response.NewError(response.CodeConflict, "当前没有可处理的入会审批环节")
+}
+
+func (e *FlowEngine) selectApprovalTask(ctx context.Context, instanceID uuid.UUID, nodeID string, reviewer uuid.UUID) (*model.FlowTask, error) {
+	tasks, err := e.taskRepo.ListTasksByInstance(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	var selected, reference *model.FlowTask
+	for i := range tasks {
+		task := &tasks[i]
+		if task.NodeID != nodeID || task.Status != 0 {
+			continue
+		}
+		reference = task
+		if task.AssigneeID != nil && *task.AssigneeID == reviewer {
+			selected = task
+		}
+	}
+	if reference == nil {
+		return nil, response.NewError(response.CodeConflict, "当前审批环节没有待办")
+	}
+	if selected != nil {
+		return selected, nil
+	}
+	now := time.Now()
+	selected = &model.FlowTask{
+		ID: uuid.New(), InstanceID: instanceID, NodeID: nodeID, NodeName: reference.NodeName,
+		TaskType: "approval", ActivationID: reference.ActivationID, AssigneeID: &reviewer,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := e.taskRepo.CreateTask(ctx, nil, selected); err != nil {
+		return nil, err
+	}
+	return selected, nil
+}

--- a/backend/internal/workflow/engine/application_approval.go
+++ b/backend/internal/workflow/engine/application_approval.go
@@ -40,7 +40,127 @@ func (e *FlowEngine) CompleteApplicationApproval(ctx context.Context, instanceID
 	if err != nil {
 		return err
 	}
-	return e.CompleteTask(ctx, selected.ID, reviewer, action, comment, nil)
+	if err := e.CompleteTask(ctx, selected.ID, reviewer, action, comment, nil); err != nil {
+		return err
+	}
+	if action != ActionReject {
+		return nil
+	}
+	// approvalType=any 在仍有 pending 时不会因单票拒绝结束实例；业务拒绝必须强制终止。
+	fresh, err := e.instRepo.GetByID(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	if fresh != nil && fresh.Status == 0 {
+		return e.Terminate(ctx, instanceID, reviewer, "入会审批拒绝："+comment)
+	}
+	return nil
+}
+
+// SkipApplicationApproval 跳过当前审批节点并进入下一环节。
+// 会员申请无意向部门时没有对口部长，部长节点不能指派，因此直达社长。
+func (e *FlowEngine) SkipApplicationApproval(ctx context.Context, instanceID uuid.UUID, nodeID string, operator uuid.UUID, reason string) error {
+	if !e.businessTransaction {
+		return response.NewError(response.CodeForbidden, "入会审批需要业务事务")
+	}
+	if e.db != nil {
+		if err := repo.NewRuntimeRepo(e.db).LockInstance(ctx, instanceID); err != nil {
+			return err
+		}
+	}
+	inst, err := e.instRepo.GetByID(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	if inst == nil || inst.BusinessType != "member_application" || inst.Status != 0 {
+		return response.NewError(response.CodeConflict, "关联入会流程不可跳过")
+	}
+	current, err := e.currentApprovalNodeID(ctx, inst)
+	if err != nil {
+		return err
+	}
+	if current != nodeID {
+		return response.NewError(response.CodeConflict, "当前环节不是可跳过的审批节点")
+	}
+	if err := e.cancelNodePendingTasks(ctx, inst.ID, nodeID, operator, reason); err != nil {
+		return err
+	}
+	now := time.Now()
+	hist := &model.FlowHistory{
+		ID: uuid.New(), InstanceID: inst.ID, NodeID: nodeID, NodeName: nodeID,
+		NodeType: "approval", Action: "skip", Comment: reason, CreatedAt: now,
+	}
+	if operator != uuid.Nil {
+		hist.OperatorID = &operator
+	}
+	if err := e.taskRepo.CreateHistory(ctx, nil, hist); err != nil {
+		return err
+	}
+	version, err := e.defRepo.GetVersionByID(ctx, inst.DefinitionVersionID)
+	if err != nil {
+		return err
+	}
+	if version == nil {
+		return response.NewError(response.CodeWorkflowVerNotFound, "审批流程版本不存在")
+	}
+	graph, err := ParseGraph(version.BpmnData)
+	if err != nil {
+		return err
+	}
+	node := graph.GetNode(nodeID)
+	if node == nil {
+		return response.NewError(response.CodeWorkflowNodeNotFound, "流程节点不存在: "+nodeID)
+	}
+	vars, err := e.varRepo.GetMap(ctx, inst.ID)
+	if err != nil {
+		return err
+	}
+	next, err := e.executeNode(ctx, inst, graph, node, vars)
+	if err != nil {
+		return err
+	}
+	currentIDs := []string{}
+	for _, id := range GetCurrentNodeIDs(inst.CurrentNodeIDs) {
+		if id != nodeID {
+			currentIDs = append(currentIDs, id)
+		}
+	}
+	if err := e.updateCurrentNodes(ctx, inst, currentIDs); err != nil {
+		return err
+	}
+	if len(next) == 0 {
+		return nil
+	}
+	return e.executeFromNodes(ctx, inst, graph, next, vars, node.ID)
+}
+
+func (e *FlowEngine) cancelNodePendingTasks(ctx context.Context, instanceID uuid.UUID, nodeID string, operator uuid.UUID, reason string) error {
+	tasks, err := e.taskRepo.ListTasksByInstance(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	for _, task := range tasks {
+		if task.Status != 0 || task.NodeID != nodeID {
+			continue
+		}
+		task.Status = 5
+		task.Action = "cancel"
+		task.Comment = reason
+		task.CompletedAt = &now
+		task.UpdatedAt = now
+		if err := e.taskRepo.UpdateTask(ctx, nil, &task); err != nil {
+			return err
+		}
+		hist := &model.FlowHistory{ID: uuid.New(), InstanceID: instanceID, TaskID: &task.ID, NodeID: task.NodeID, NodeName: task.NodeName, NodeType: task.TaskType, Action: "cancel", Comment: reason, CreatedAt: now}
+		if operator != uuid.Nil {
+			hist.OperatorID = &operator
+		}
+		if err := e.taskRepo.CreateHistory(ctx, nil, hist); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RunningApprovalNode returns the active approval node, or completed=true when the instance ended.

--- a/backend/internal/workflow/engine/application_approval_test.go
+++ b/backend/internal/workflow/engine/application_approval_test.go
@@ -34,13 +34,27 @@ func (m *storingInstRepo) List(context.Context, int, int, *int, *uuid.UUID, *uui
 	return nil, 0, nil
 }
 
+type recordingApproval struct {
+	waitingTestNode
+	enteredIDs []string
+}
+
+func (n *recordingApproval) OnEnter(ctx context.Context, inst *model.FlowInstance, node *FlowNode, vars map[string]interface{}) error {
+	n.enteredIDs = append(n.enteredIDs, node.ID)
+	return n.waitingTestNode.OnEnter(ctx, inst, node, vars)
+}
+
 func memberApplicationEngine(t *testing.T, tasks *mockTaskRepo) (*FlowEngine, *storingInstRepo) {
+	t.Helper()
+	return memberApplicationEngineWith(t, tasks, &waitingTestNode{})
+}
+
+func memberApplicationEngineWith(t *testing.T, tasks *mockTaskRepo, approval NodeHandler) (*FlowEngine, *storingInstRepo) {
 	t.Helper()
 	defID, verID := uuid.New(), uuid.New()
 	def := &model.FlowDefinition{ID: defID, Key: MemberApplicationDefinitionKey, Status: 1}
 	ver := &model.FlowDefinitionVersion{ID: verID, DefinitionID: defID, BpmnData: MemberApplicationBPMN(), Status: 1}
 	insts := &storingInstRepo{insts: map[uuid.UUID]*model.FlowInstance{}}
-	approval := &waitingTestNode{}
 	e := NewFlowEngine(&mockDefRepo{def: def, version: ver}, insts, tasks, newMockVarRepo(), nil, &mockRegistryForTest{handlers: map[string]NodeHandler{
 		"start": stubStartHandler{}, "end": stubEndHandler{}, "approval": approval,
 	}}, NewExpressionEngine(), events.NewEventBus(), nil)
@@ -131,24 +145,28 @@ func TestMemberApplicationRejectTerminatesOtherPendingTasks(t *testing.T) {
 	require.Error(t, e.CompleteApplicationApproval(context.Background(), inst.ID, second, ActionApprove, "不能救活"))
 }
 
-func TestSkipMinisterAdvancesToPresident(t *testing.T) {
+func TestStartSkipMinisterDoesNotEnterMinister(t *testing.T) {
 	applicant := uuid.New()
 	tasks := newMockTaskRepo()
-	e, _ := memberApplicationEngine(t, tasks)
+	approval := &recordingApproval{}
+	e, _ := memberApplicationEngineWith(t, tasks, approval)
 
 	inst, err := e.Start(context.Background(), MemberApplicationDefinitionKey, uuid.New().String(), "member_application", applicant, map[string]interface{}{
-		"applicant": applicant.String(), "apply_type": int16(1),
+		"applicant": applicant.String(), "apply_type": int16(1), SkipMinisterVariable: true,
 	})
 	require.NoError(t, err)
-	addApprovalTask(tasks, inst.ID, "minister", uuid.New())
-	require.NoError(t, e.SkipApplicationApproval(context.Background(), inst.ID, "minister", applicant, "会员申请无意向部门，跳过部长审批"))
+	require.NotContains(t, approval.enteredIDs, "minister")
+	require.Equal(t, []string{"president"}, approval.enteredIDs)
 	nodeID, done, err := e.RunningApprovalNode(context.Background(), inst.ID)
 	require.NoError(t, err)
 	require.False(t, done)
 	require.Equal(t, "president", nodeID)
-	for _, task := range tasks.tasks {
-		if task.InstanceID == inst.ID && task.NodeID == "minister" {
-			require.NotEqual(t, 0, task.Status)
-		}
-	}
+	require.Empty(t, tasks.tasks)
+}
+
+func TestSkipMinisterApprovalFlag(t *testing.T) {
+	require.False(t, skipMinisterApproval(&FlowNode{ID: "minister"}, nil))
+	require.False(t, skipMinisterApproval(&FlowNode{ID: "president"}, map[string]interface{}{SkipMinisterVariable: true}))
+	require.True(t, skipMinisterApproval(&FlowNode{ID: "minister"}, map[string]interface{}{SkipMinisterVariable: true}))
+	require.False(t, skipMinisterApproval(&FlowNode{ID: "minister"}, map[string]interface{}{}))
 }

--- a/backend/internal/workflow/engine/application_approval_test.go
+++ b/backend/internal/workflow/engine/application_approval_test.go
@@ -98,3 +98,57 @@ func TestMemberApplicationRejectStopsChain(t *testing.T) {
 	require.NoError(t, e.CompleteApplicationApproval(context.Background(), inst.ID, minister, ActionReject, "材料不符"))
 	require.Equal(t, 2, insts.insts[inst.ID].Status)
 }
+
+func TestMemberApplicationRejectTerminatesOtherPendingTasks(t *testing.T) {
+	first, second, applicant := uuid.New(), uuid.New(), uuid.New()
+	tasks := newMockTaskRepo()
+	e, insts := memberApplicationEngine(t, tasks)
+
+	inst, err := e.Start(context.Background(), MemberApplicationDefinitionKey, uuid.New().String(), "member_application", applicant, nil)
+	require.NoError(t, err)
+	addApprovalTask(tasks, inst.ID, "minister", first)
+	addApprovalTask(tasks, inst.ID, "minister", second)
+	require.NoError(t, e.CompleteApplicationApproval(context.Background(), inst.ID, first, ActionReject, "材料不符"))
+	require.Equal(t, 2, insts.insts[inst.ID].Status)
+
+	var canceled, rejected int
+	for _, task := range tasks.tasks {
+		if task.InstanceID != inst.ID {
+			continue
+		}
+		if task.AssigneeID != nil && *task.AssigneeID == first {
+			require.Equal(t, 2, task.Status)
+			rejected++
+		}
+		if task.AssigneeID != nil && *task.AssigneeID == second {
+			require.Equal(t, 5, task.Status)
+			require.Equal(t, "cancel", task.Action)
+			canceled++
+		}
+	}
+	require.Equal(t, 1, rejected)
+	require.Equal(t, 1, canceled)
+	require.Error(t, e.CompleteApplicationApproval(context.Background(), inst.ID, second, ActionApprove, "不能救活"))
+}
+
+func TestSkipMinisterAdvancesToPresident(t *testing.T) {
+	applicant := uuid.New()
+	tasks := newMockTaskRepo()
+	e, _ := memberApplicationEngine(t, tasks)
+
+	inst, err := e.Start(context.Background(), MemberApplicationDefinitionKey, uuid.New().String(), "member_application", applicant, map[string]interface{}{
+		"applicant": applicant.String(), "apply_type": int16(1),
+	})
+	require.NoError(t, err)
+	addApprovalTask(tasks, inst.ID, "minister", uuid.New())
+	require.NoError(t, e.SkipApplicationApproval(context.Background(), inst.ID, "minister", applicant, "会员申请无意向部门，跳过部长审批"))
+	nodeID, done, err := e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, "president", nodeID)
+	for _, task := range tasks.tasks {
+		if task.InstanceID == inst.ID && task.NodeID == "minister" {
+			require.NotEqual(t, 0, task.Status)
+		}
+	}
+}

--- a/backend/internal/workflow/engine/application_approval_test.go
+++ b/backend/internal/workflow/engine/application_approval_test.go
@@ -1,0 +1,100 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/events"
+)
+
+type storingInstRepo struct {
+	insts map[uuid.UUID]*model.FlowInstance
+}
+
+func (m *storingInstRepo) Create(_ context.Context, _ *gorm.DB, inst *model.FlowInstance) error {
+	if m.insts == nil {
+		m.insts = map[uuid.UUID]*model.FlowInstance{}
+	}
+	m.insts[inst.ID] = inst
+	return nil
+}
+func (m *storingInstRepo) GetByID(_ context.Context, id uuid.UUID) (*model.FlowInstance, error) {
+	return m.insts[id], nil
+}
+func (m *storingInstRepo) Update(_ context.Context, _ *gorm.DB, inst *model.FlowInstance) error {
+	m.insts[inst.ID] = inst
+	return nil
+}
+func (m *storingInstRepo) List(context.Context, int, int, *int, *uuid.UUID, *uuid.UUID) ([]model.FlowInstance, int64, error) {
+	return nil, 0, nil
+}
+
+func memberApplicationEngine(t *testing.T, tasks *mockTaskRepo) (*FlowEngine, *storingInstRepo) {
+	t.Helper()
+	defID, verID := uuid.New(), uuid.New()
+	def := &model.FlowDefinition{ID: defID, Key: MemberApplicationDefinitionKey, Status: 1}
+	ver := &model.FlowDefinitionVersion{ID: verID, DefinitionID: defID, BpmnData: MemberApplicationBPMN(), Status: 1}
+	insts := &storingInstRepo{insts: map[uuid.UUID]*model.FlowInstance{}}
+	approval := &waitingTestNode{}
+	e := NewFlowEngine(&mockDefRepo{def: def, version: ver}, insts, tasks, newMockVarRepo(), nil, &mockRegistryForTest{handlers: map[string]NodeHandler{
+		"start": stubStartHandler{}, "end": stubEndHandler{}, "approval": approval,
+	}}, NewExpressionEngine(), events.NewEventBus(), nil)
+	e.businessTransaction = true
+	return e, insts
+}
+
+func addApprovalTask(tasks *mockTaskRepo, instanceID uuid.UUID, nodeID string, assignee uuid.UUID) {
+	id := uuid.New()
+	activation := uuid.New()
+	tasks.tasks[id] = &model.FlowTask{
+		ID: id, InstanceID: instanceID, NodeID: nodeID, NodeName: nodeID, TaskType: "approval",
+		ActivationID: &activation, AssigneeID: &assignee, Status: 0,
+	}
+}
+
+func TestMemberApplicationStartMinisterPresidentComplete(t *testing.T) {
+	minister, president, applicant := uuid.New(), uuid.New(), uuid.New()
+	tasks := newMockTaskRepo()
+	e, insts := memberApplicationEngine(t, tasks)
+
+	inst, err := e.Start(context.Background(), MemberApplicationDefinitionKey, uuid.New().String(), "member_application", applicant, map[string]interface{}{
+		"applicant": applicant.String(), "apply_type": int16(2),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, inst.Status)
+	nodeID, done, err := e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, "minister", nodeID)
+
+	addApprovalTask(tasks, inst.ID, "minister", minister)
+	require.NoError(t, e.CompleteApplicationApproval(context.Background(), inst.ID, minister, ActionApprove, "部长同意"))
+	nodeID, done, err = e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, "president", nodeID)
+
+	addApprovalTask(tasks, inst.ID, "president", president)
+	require.NoError(t, e.CompleteApplicationApproval(context.Background(), inst.ID, president, ActionApprove, "社长同意"))
+	_, done, err = e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, 1, insts.insts[inst.ID].Status)
+}
+
+func TestMemberApplicationRejectStopsChain(t *testing.T) {
+	minister, applicant := uuid.New(), uuid.New()
+	tasks := newMockTaskRepo()
+	e, insts := memberApplicationEngine(t, tasks)
+
+	inst, err := e.Start(context.Background(), MemberApplicationDefinitionKey, uuid.New().String(), "member_application", applicant, nil)
+	require.NoError(t, err)
+	addApprovalTask(tasks, inst.ID, "minister", minister)
+	require.NoError(t, e.CompleteApplicationApproval(context.Background(), inst.ID, minister, ActionReject, "材料不符"))
+	require.Equal(t, 2, insts.insts[inst.ID].Status)
+}

--- a/backend/internal/workflow/engine/application_graph.go
+++ b/backend/internal/workflow/engine/application_graph.go
@@ -1,0 +1,91 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// MemberApplicationDefinitionKey is the default membership approval template (#64).
+const MemberApplicationDefinitionKey = "member_application"
+
+// MemberApplicationBPMN is the React Flow graph seeded by 000061.
+func MemberApplicationBPMN() []byte {
+	raw, err := json.Marshal(map[string]interface{}{
+		"nodes": []map[string]interface{}{
+			node("start", "start", "干事申请", 20, nil),
+			node("minister", "approval", "部长审批", 160, map[string]interface{}{
+				"assigneeStrategy": "role", "roleCode": "minister", "approvalType": "any",
+				"departmentScope": true, "allowReject": true, "allowTransfer": false, "allowRollback": false,
+			}),
+			node("president", "approval", "社长审批", 300, map[string]interface{}{
+				"assigneeStrategy": "role", "roleCode": "president", "approvalType": "any",
+				"allowReject": true, "allowTransfer": false, "allowRollback": false,
+			}),
+			node("end", "end", "结束", 440, nil),
+		},
+		"edges": []map[string]string{
+			{"id": "start-minister", "source": "start", "target": "minister"},
+			{"id": "minister-president", "source": "minister", "target": "president"},
+			{"id": "president-end", "source": "president", "target": "end"},
+		},
+		"viewport": map[string]interface{}{"x": 0, "y": 0, "zoom": 1},
+	})
+	if err != nil {
+		return []byte(`{"nodes":[],"edges":[]}`)
+	}
+	return raw
+}
+
+func node(id, kind, label string, y int, config map[string]interface{}) map[string]interface{} {
+	if config == nil {
+		config = map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"id": id, "type": kind, "position": map[string]int{"x": 280, "y": y},
+		"data": map[string]interface{}{"label": label, "config": config},
+	}
+}
+
+func validateMemberApplicationGraph(g *FlowGraph) error {
+	semantic := map[string]string{}
+	seen := map[string]bool{}
+	for id, item := range g.Nodes {
+		name := item.Type
+		switch item.Type {
+		case "start", "end":
+		case "approval":
+			code, _ := item.Config["roleCode"].(string)
+			if item.Config["assigneeStrategy"] != "role" || (code != "minister" && code != "president") || item.Config["approvalType"] != "any" {
+				return fmt.Errorf("入会申请节点须按角色指派部长或社长")
+			}
+			name = code
+		default:
+			return fmt.Errorf("默认入会链不支持额外节点类型")
+		}
+		if seen[name] {
+			return fmt.Errorf("入会申请环节重复：%s", name)
+		}
+		seen[name] = true
+		semantic[id] = name
+	}
+	actual := map[string]bool{}
+	for _, edge := range g.Edges {
+		actual[semantic[edge.Source]+">"+semantic[edge.Target]] = true
+	}
+	pattern := []string{"start>minister", "minister>president", "president>end"}
+	if len(actual) != len(pattern) || len(g.Edges) != len(pattern) || len(g.Nodes) != 4 {
+		return fmt.Errorf("默认入会链必须为：干事申请 → 部长审批 → 社长审批 → 结束")
+	}
+	for _, edge := range pattern {
+		if !actual[edge] {
+			return fmt.Errorf("默认入会链必须为：干事申请 → 部长审批 → 社长审批 → 结束")
+		}
+		for _, part := range strings.Split(edge, ">") {
+			if !seen[part] {
+				return fmt.Errorf("默认入会链缺少环节：%s", part)
+			}
+		}
+	}
+	return nil
+}

--- a/backend/internal/workflow/engine/application_graph.go
+++ b/backend/internal/workflow/engine/application_graph.go
@@ -9,6 +9,24 @@ import (
 // MemberApplicationDefinitionKey is the default membership approval template (#64).
 const MemberApplicationDefinitionKey = "member_application"
 
+// SkipMinisterVariable tells Start to pass through the minister node
+// without creating assignees when a member application has no department.
+const SkipMinisterVariable = "skip_minister"
+
+func skipMinisterApproval(node *FlowNode, vars map[string]interface{}) bool {
+	if node == nil || node.ID != "minister" || vars == nil {
+		return false
+	}
+	switch v := vars[SkipMinisterVariable].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "1"
+	default:
+		return false
+	}
+}
+
 // MemberApplicationBPMN is the React Flow graph seeded by 000061.
 func MemberApplicationBPMN() []byte {
 	raw, err := json.Marshal(map[string]interface{}{

--- a/backend/internal/workflow/engine/application_graph_test.go
+++ b/backend/internal/workflow/engine/application_graph_test.go
@@ -1,0 +1,29 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemberApplicationGraph(t *testing.T) {
+	graph, err := ParseGraph(MemberApplicationBPMN())
+	require.NoError(t, err)
+	require.NoError(t, ValidateBusinessDefinition(MemberApplicationDefinitionKey, graph))
+	require.Equal(t, "start", graph.FindStartNode().ID)
+}
+
+func TestMemberApplicationGraphRejectsBypass(t *testing.T) {
+	graph, err := ParseGraph(MemberApplicationBPMN())
+	require.NoError(t, err)
+	delete(graph.Nodes, "minister")
+	graph.Edges = []*FlowEdge{{Source: "start", Target: "president"}, {Source: "president", Target: "end"}}
+	require.Error(t, ValidateBusinessDefinition(MemberApplicationDefinitionKey, graph))
+}
+
+func TestMemberApplicationGraphRequiresRoleAssignees(t *testing.T) {
+	graph, err := ParseGraph(MemberApplicationBPMN())
+	require.NoError(t, err)
+	graph.Nodes["minister"].Config["assigneeStrategy"] = "business_role"
+	require.Error(t, ValidateBusinessDefinition(MemberApplicationDefinitionKey, graph))
+}

--- a/backend/internal/workflow/engine/engine.go
+++ b/backend/internal/workflow/engine/engine.go
@@ -61,7 +61,7 @@ func NewFlowEngine(
 
 // Start initiates a new flow instance and begins execution from the start node.
 func (e *FlowEngine) start(ctx context.Context, definitionKey string, businessKey string, businessType string, initiatorID uuid.UUID, variables map[string]interface{}) (*model.FlowInstance, error) {
-	if (IsProtectedBusiness(businessType) || definitionKey == TaskDefinitionKey || IsTaskTransferDefinition(definitionKey) || definitionKey == "officer_interview" || definitionKey == "member_admission") && !e.businessTransaction {
+	if (IsProtectedBusiness(businessType) || definitionKey == TaskDefinitionKey || IsTaskTransferDefinition(definitionKey) || definitionKey == "officer_interview" || definitionKey == "member_admission" || definitionKey == MemberApplicationDefinitionKey) && !e.businessTransaction {
 		return nil, response.NewAppError(response.CodeForbidden, "业务流程须从对应业务页面发起")
 	}
 	if err := validateInputVariables(variables); err != nil {
@@ -164,5 +164,8 @@ func (e *FlowEngine) start(ctx context.Context, definitionKey string, businessKe
 
 // withTransaction runs a function within a database transaction.
 func (e *FlowEngine) withTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if e.db == nil {
+		return fn(nil)
+	}
 	return e.db.WithContext(ctx).Transaction(fn)
 }

--- a/backend/internal/workflow/engine/execution.go
+++ b/backend/internal/workflow/engine/execution.go
@@ -58,6 +58,20 @@ func (e *FlowEngine) executeFromNodes(ctx context.Context, inst *model.FlowInsta
 			return err
 		}
 		e.eventBus.Publish(ctx, events.NodeEnteredEvent{InstanceID: inst.ID, NodeID: node.ID, NodeType: node.Type})
+		if skipMinisterApproval(node, vars) {
+			next, err := handler.Execute(ctx, inst, node, graph, vars)
+			if err != nil {
+				return err
+			}
+			if err = handler.OnLeave(ctx, inst, node, vars); err != nil {
+				return err
+			}
+			e.eventBus.Publish(ctx, events.NodeLeftEvent{InstanceID: inst.ID, NodeID: node.ID, NodeType: node.Type})
+			for _, nextID := range next {
+				queue = append(queue, arrival{nextID, id})
+			}
+			continue
+		}
 		if err = handler.OnEnter(ctx, inst, node, vars); err != nil {
 			return err
 		}

--- a/backend/internal/workflow/engine/nodes/approval.go
+++ b/backend/internal/workflow/engine/nodes/approval.go
@@ -50,7 +50,7 @@ func (n *ApprovalNode) OnEnter(ctx context.Context, inst *model.FlowInstance, no
 		}
 	} else if n.Approvers != nil {
 		var err error
-		assignees, err = n.resolveRuntime(ctx, config, inst.InitiatorID, assignees)
+		assignees, err = n.resolveRuntime(ctx, config, inst.InitiatorID, vars, assignees)
 		if err != nil {
 			return err
 		}
@@ -155,9 +155,11 @@ func (n *ApprovalNode) Validate(node *engine.FlowNode) error {
 				"静态处理人策略需要非空的 assignees 列表")
 		}
 	case "role":
-		if _, ok := config["roleId"].(string); !ok {
+		roleID, _ := config["roleId"].(string)
+		roleCode, _ := config["roleCode"].(string)
+		if roleID == "" && roleCode == "" {
 			return response.NewAppError(response.CodeWorkflowInvalidNode,
-				"角色处理人策略需要 roleId 配置")
+				"角色处理人策略需要 roleId 或 roleCode 配置")
 		}
 	case "dept_leader", "initiator":
 		// No additional fields required.

--- a/backend/internal/workflow/engine/nodes/approver.go
+++ b/backend/internal/workflow/engine/nodes/approver.go
@@ -8,15 +8,10 @@ import (
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
 )
 
-func (n *ApprovalNode) resolveRuntime(ctx context.Context, config map[string]interface{}, initiator uuid.UUID, fallback []uuid.UUID) ([]uuid.UUID, error) {
+func (n *ApprovalNode) resolveRuntime(ctx context.Context, config map[string]interface{}, initiator uuid.UUID, vars map[string]interface{}, fallback []uuid.UUID) ([]uuid.UUID, error) {
 	switch config["assigneeStrategy"] {
 	case "role":
-		role, _ := config["roleId"].(string)
-		id, err := uuid.Parse(role)
-		if err != nil {
-			return nil, response.NewAppError(response.CodeWorkflowInvalidNode, "角色 ID 无效")
-		}
-		return n.Approvers.ByRole(ctx, id)
+		return n.resolveRoleAssignees(ctx, config, vars)
 	case "dept_leader":
 		return n.Approvers.DepartmentLeaders(ctx, initiator)
 	default:
@@ -33,4 +28,32 @@ func (n *ApprovalNode) resolveRuntime(ctx context.Context, config map[string]int
 		}
 		return users, nil
 	}
+}
+
+func (n *ApprovalNode) resolveRoleAssignees(ctx context.Context, config map[string]interface{}, vars map[string]interface{}) ([]uuid.UUID, error) {
+	if n.Approvers == nil {
+		return nil, response.NewAppError(response.CodeWorkflowInvalidNode, "角色审批人解析器未配置")
+	}
+	if code, _ := config["roleCode"].(string); code != "" {
+		return n.Approvers.ByRoleCode(ctx, code, scopedDepartment(config, vars))
+	}
+	role, _ := config["roleId"].(string)
+	id, err := uuid.Parse(role)
+	if err != nil {
+		return nil, response.NewAppError(response.CodeWorkflowInvalidNode, "角色 ID 无效")
+	}
+	return n.Approvers.ByRole(ctx, id)
+}
+
+func scopedDepartment(config, vars map[string]interface{}) *uuid.UUID {
+	scoped, _ := config["departmentScope"].(bool)
+	if !scoped || vars == nil {
+		return nil
+	}
+	raw, _ := vars["department_id"].(string)
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return nil
+	}
+	return &id
 }

--- a/backend/internal/workflow/engine/nodes/approver_test.go
+++ b/backend/internal/workflow/engine/nodes/approver_test.go
@@ -1,0 +1,63 @@
+package nodes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+)
+
+type roleApprovers struct {
+	code string
+	dept *uuid.UUID
+	ids  []uuid.UUID
+}
+
+func (r *roleApprovers) Search(context.Context, string, uuid.UUID) ([]model.ApproverOption, error) {
+	return nil, nil
+}
+func (r *roleApprovers) ActiveUsers(context.Context, []uuid.UUID) ([]uuid.UUID, error) {
+	return nil, nil
+}
+func (r *roleApprovers) ByRole(context.Context, uuid.UUID) ([]uuid.UUID, error) { return nil, nil }
+func (r *roleApprovers) ByRoleCode(_ context.Context, code string, dept *uuid.UUID) ([]uuid.UUID, error) {
+	r.code, r.dept = code, dept
+	return r.ids, nil
+}
+func (r *roleApprovers) DepartmentLeaders(context.Context, uuid.UUID) ([]uuid.UUID, error) {
+	return nil, nil
+}
+
+func TestResolveRoleAssigneesUsesCodeAndDepartment(t *testing.T) {
+	dept := uuid.New()
+	holder := uuid.New()
+	store := &roleApprovers{ids: []uuid.UUID{holder}}
+	node := &ApprovalNode{Approvers: store}
+	ids, err := node.resolveRuntime(context.Background(), map[string]interface{}{
+		"assigneeStrategy": "role", "roleCode": "minister", "departmentScope": true,
+	}, uuid.New(), map[string]interface{}{"department_id": dept.String()}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{holder}, ids)
+	require.Equal(t, "minister", store.code)
+	require.NotNil(t, store.dept)
+	require.Equal(t, dept, *store.dept)
+}
+
+func TestValidateRoleAcceptsRoleCode(t *testing.T) {
+	node := &ApprovalNode{}
+	err := node.Validate(&engine.FlowNode{ID: "minister", Type: "approval", Config: map[string]interface{}{
+		"assigneeStrategy": "role", "roleCode": "minister", "approvalType": "any",
+	}})
+	require.NoError(t, err)
+	err = node.Validate(&engine.FlowNode{ID: "minister", Type: "approval", Config: map[string]interface{}{
+		"assigneeStrategy": "role", "approvalType": "any",
+	}})
+	require.Error(t, err)
+	_, ok := err.(*response.AppError)
+	require.True(t, ok)
+}

--- a/backend/internal/workflow/engine/nodes/approver_test.go
+++ b/backend/internal/workflow/engine/nodes/approver_test.go
@@ -48,6 +48,11 @@ func TestResolveRoleAssigneesUsesCodeAndDepartment(t *testing.T) {
 	require.Equal(t, dept, *store.dept)
 }
 
+func TestScopedDepartmentNilWithoutDepartment(t *testing.T) {
+	require.Nil(t, scopedDepartment(map[string]interface{}{"departmentScope": true}, map[string]interface{}{}))
+	require.Nil(t, scopedDepartment(map[string]interface{}{"departmentScope": true}, map[string]interface{}{"department_id": ""}))
+}
+
 func TestValidateRoleAcceptsRoleCode(t *testing.T) {
 	node := &ApprovalNode{}
 	err := node.Validate(&engine.FlowNode{ID: "minister", Type: "approval", Config: map[string]interface{}{

--- a/backend/internal/workflow/repo/approver_repo.go
+++ b/backend/internal/workflow/repo/approver_repo.go
@@ -13,6 +13,7 @@ type ApproverRepo interface {
 	Search(context.Context, string, uuid.UUID) ([]model.ApproverOption, error)
 	ActiveUsers(context.Context, []uuid.UUID) ([]uuid.UUID, error)
 	ByRole(context.Context, uuid.UUID) ([]uuid.UUID, error)
+	ByRoleCode(context.Context, string, *uuid.UUID) ([]uuid.UUID, error)
 	DepartmentLeaders(context.Context, uuid.UUID) ([]uuid.UUID, error)
 }
 type approverRepo struct{ db *gorm.DB }
@@ -29,6 +30,15 @@ func (r *approverRepo) roleUsers(ctx context.Context) *gorm.DB {
 func (r *approverRepo) ByRole(ctx context.Context, role uuid.UUID) ([]uuid.UUID, error) {
 	var result []uuid.UUID
 	err := r.roleUsers(ctx).Where("r.id=?", role).Distinct().Order("u.id").Pluck("u.id", &result).Error
+	return result, err
+}
+func (r *approverRepo) ByRoleCode(ctx context.Context, code string, departmentID *uuid.UUID) ([]uuid.UUID, error) {
+	query := r.roleUsers(ctx).Where("r.code=?", code)
+	if departmentID != nil {
+		query = query.Where("u.department_id=?", *departmentID)
+	}
+	var result []uuid.UUID
+	err := query.Distinct().Order("u.id").Pluck("u.id", &result).Error
 	return result, err
 }
 func (r *approverRepo) DepartmentLeaders(ctx context.Context, initiator uuid.UUID) ([]uuid.UUID, error) {

--- a/backend/migrations/000061_member_application_workflow.down.sql
+++ b/backend/migrations/000061_member_application_workflow.down.sql
@@ -1,0 +1,12 @@
+-- Drop the default membership approval template only when no instances remain.
+
+DELETE FROM flow_definition_versions
+WHERE definition_id IN (
+  SELECT d.id FROM flow_definitions d
+  WHERE d.key = 'member_application'
+    AND NOT EXISTS (SELECT 1 FROM flow_instances i WHERE i.definition_id = d.id)
+);
+
+DELETE FROM flow_definitions d
+WHERE d.key = 'member_application'
+  AND NOT EXISTS (SELECT 1 FROM flow_instances i WHERE i.definition_id = d.id);

--- a/backend/migrations/000061_member_application_workflow.up.sql
+++ b/backend/migrations/000061_member_application_workflow.up.sql
@@ -1,0 +1,50 @@
+-- Default membership approval template (#64 phase-1):
+-- 干事申请 → 部长审批 → 社长审批 → 结束
+-- Role assignees use roleCode (minister / president). Department scope is
+-- applied at runtime from instance variable department_id.
+-- Idempotent: publish only when no current version exists, so later designer
+-- edits are not overwritten. Charter graphs (member_admission / officer_interview)
+-- stay available for later editing.
+
+DO $migration$
+DECLARE
+  target_definition_id uuid;
+  graph jsonb := $json${
+    "nodes": [
+      {"id": "start", "type": "start", "position": {"x": 280, "y": 20}, "data": {"label": "干事申请", "config": {}}},
+      {"id": "minister", "type": "approval", "position": {"x": 280, "y": 160}, "data": {"label": "部长审批", "config": {"assigneeStrategy": "role", "roleCode": "minister", "approvalType": "any", "departmentScope": true, "allowReject": true, "allowTransfer": false, "allowRollback": false}}},
+      {"id": "president", "type": "approval", "position": {"x": 280, "y": 300}, "data": {"label": "社长审批", "config": {"assigneeStrategy": "role", "roleCode": "president", "approvalType": "any", "allowReject": true, "allowTransfer": false, "allowRollback": false}}},
+      {"id": "end", "type": "end", "position": {"x": 280, "y": 440}, "data": {"label": "结束", "config": {}}}
+    ],
+    "edges": [
+      {"id": "start-minister", "source": "start", "target": "minister"},
+      {"id": "minister-president", "source": "minister", "target": "president"},
+      {"id": "president-end", "source": "president", "target": "end"}
+    ],
+    "viewport": {"x": 0, "y": 0, "zoom": 1}
+  }$json$::jsonb;
+BEGIN
+  INSERT INTO flow_definitions(id, key, name, description, category, status, created_at, updated_at)
+  VALUES (
+    uuid_generate_v4(),
+    'member_application',
+    '入会申请审批',
+    '默认干事申请链：部长审批 → 社长审批。可在流程设计器调整标签与布局；增删分支属后续迭代。',
+    'member',
+    0,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (key) DO NOTHING;
+
+  SELECT id INTO target_definition_id FROM flow_definitions WHERE key = 'member_application' FOR UPDATE;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM flow_definition_versions
+    WHERE definition_id = target_definition_id AND status = 1
+  ) THEN
+    INSERT INTO flow_definition_versions(id, definition_id, version, bpmn_data, status, published_at, created_at)
+    VALUES (uuid_generate_v4(), target_definition_id, 1, graph, 1, NOW(), NOW());
+    UPDATE flow_definitions SET status = 1, updated_at = NOW() WHERE id = target_definition_id;
+  END IF;
+END $migration$;

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,7 +132,7 @@ POST /api/v1/contracts
 
 ### 会员 / 面试 / 会议 / 任务 / 实习
 
-- 入会：`/member/applications`、审核 approve/reject/supplement、`/member/profiles`
+- 入会：`/member/applications`、审核 approve/reject/supplement（新申请走 `member_application` 流程实例）、`/member/profiles`
 - 面试：`/interviews`、sessions、evaluations、stats
 - 会议：`/meetings`、attendees、agendas、votes
 - 任务：`/tasks`、指派/转交/评论/附件、`/tasks/my/*`

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -463,6 +463,7 @@
       "approved": "Approved; the workflow advanced",
       "rejected": "Application rejected",
       "hint": "New applications use the default minister → president chain. Edit the member_application definition in the designer to publish a new version later.",
+      "supplementHint": "More materials were requested. Wait for the applicant to resubmit.",
       "viewFlow": "Open workflow instance"
     }
   }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -446,5 +446,24 @@
       "manual": "Manual",
       "scheduled": "Scheduled"
     }
+  },
+  "member": {
+    "engine": {
+      "title": "Membership approval",
+      "steps": {
+        "apply": "Application submitted",
+        "minister": "Minister review",
+        "president": "President review",
+        "end": "Completed"
+      },
+      "approve": "Approve",
+      "reject": "Reject",
+      "comment": "Comment",
+      "commentRequired": "A reason is required to reject",
+      "approved": "Approved; the workflow advanced",
+      "rejected": "Application rejected",
+      "hint": "New applications use the default minister → president chain. Edit the member_application definition in the designer to publish a new version later.",
+      "viewFlow": "Open workflow instance"
+    }
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -463,6 +463,7 @@
       "approved": "已同意并推进流程",
       "rejected": "已拒绝该申请",
       "hint": "新申请走默认部长 → 社长链。更复杂的分支可在流程设计器编辑 member_application 定义后发布新版本。",
+      "supplementHint": "已要求补充材料，请等待申请人重新提交。",
       "viewFlow": "查看流程实例"
     }
   }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -446,5 +446,24 @@
       "manual": "手动",
       "scheduled": "定时"
     }
+  },
+  "member": {
+    "engine": {
+      "title": "入会审批进度",
+      "steps": {
+        "apply": "干事申请",
+        "minister": "部长审批",
+        "president": "社长审批",
+        "end": "结束"
+      },
+      "approve": "同意",
+      "reject": "拒绝",
+      "comment": "审批意见",
+      "commentRequired": "拒绝须填写原因",
+      "approved": "已同意并推进流程",
+      "rejected": "已拒绝该申请",
+      "hint": "新申请走默认部长 → 社长链。更复杂的分支可在流程设计器编辑 member_application 定义后发布新版本。",
+      "viewFlow": "查看流程实例"
+    }
   }
 }

--- a/frontend/src/pages/member/application/EngineChainPanel.tsx
+++ b/frontend/src/pages/member/application/EngineChainPanel.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Button, Form, Input, Space, Steps, message } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { approveApplication, rejectApplication } from '@/api/member';
+import type { MemberApplication } from '@/types/api';
+import styles from './AdmissionPanel.module.css';
+
+interface Props {
+  record: MemberApplication;
+  editable: boolean;
+  onChanged: () => void;
+}
+
+function currentStep(record: MemberApplication): number {
+  if (record.status === 3) return 3;
+  if (record.status === 1) return 2;
+  return 1;
+}
+
+export default function EngineChainPanel({ record, editable, onChanged }: Props) {
+  const { t } = useTranslation();
+  const [form] = Form.useForm<{ comment?: string }>();
+  const [busy, setBusy] = useState(false);
+  const closed = record.status === 3 || record.status === 4;
+  const run = async (fn: () => Promise<unknown>, ok: string) => {
+    setBusy(true);
+    try {
+      await fn();
+      message.success(ok);
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className={styles.panel} aria-label={t('member.engine.title')}>
+      <div className={styles.heading}>
+        <h3>{t('member.engine.title')}</h3>
+      </div>
+      <Steps
+        direction="vertical"
+        size="small"
+        current={currentStep(record)}
+        status={record.status === 4 ? 'error' : record.status === 3 ? 'finish' : 'process'}
+        items={[
+          { title: t('member.engine.steps.apply') },
+          { title: t('member.engine.steps.minister') },
+          { title: t('member.engine.steps.president') },
+          { title: t('member.engine.steps.end') },
+        ]}
+      />
+      {record.flow_instance_id && (
+        <p>
+          <Link to={`/workflow/instances?instance_id=${encodeURIComponent(record.flow_instance_id)}`}>
+            {t('member.engine.viewFlow')}
+          </Link>
+        </p>
+      )}
+      <p className={styles.hint}>{t('member.engine.hint')}</p>
+      {editable && !closed && (
+        <Form form={form} layout="vertical" className={styles.form}>
+          <Form.Item name="comment" label={t('member.engine.comment')} rules={[{ max: 1000 }]}>
+            <Input.TextArea rows={3} maxLength={1000} />
+          </Form.Item>
+          <Space wrap>
+            <Button
+              type="primary"
+              loading={busy}
+              onClick={() => {
+                void run(async () => {
+                  const values = await form.validateFields();
+                  await approveApplication(record.id, values.comment || '');
+                }, t('member.engine.approved'));
+              }}
+            >
+              {t('member.engine.approve')}
+            </Button>
+            <Button
+              danger
+              loading={busy}
+              onClick={() => {
+                void (async () => {
+                  const values = await form.validateFields();
+                  const comment = (values.comment || '').trim();
+                  if (!comment) {
+                    form.setFields([{ name: 'comment', errors: [t('member.engine.commentRequired')] }]);
+                    return;
+                  }
+                  await run(() => rejectApplication(record.id, comment), t('member.engine.rejected'));
+                })();
+              }}
+            >
+              {t('member.engine.reject')}
+            </Button>
+          </Space>
+        </Form>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/member/application/EngineChainPanel.tsx
+++ b/frontend/src/pages/member/application/EngineChainPanel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { approveApplication, rejectApplication } from '@/api/member';
 import type { MemberApplication } from '@/types/api';
+import { engineReviewClosed } from './engineChain';
 import styles from './AdmissionPanel.module.css';
 
 interface Props {
@@ -22,7 +23,7 @@ export default function EngineChainPanel({ record, editable, onChanged }: Props)
   const { t } = useTranslation();
   const [form] = Form.useForm<{ comment?: string }>();
   const [busy, setBusy] = useState(false);
-  const closed = record.status === 3 || record.status === 4;
+  const closed = engineReviewClosed(record.status);
   const run = async (fn: () => Promise<unknown>, ok: string) => {
     setBusy(true);
     try {
@@ -59,6 +60,7 @@ export default function EngineChainPanel({ record, editable, onChanged }: Props)
         </p>
       )}
       <p className={styles.hint}>{t('member.engine.hint')}</p>
+      {record.status === 5 && <p className={styles.hint}>{t('member.engine.supplementHint')}</p>}
       {editable && !closed && (
         <Form form={form} layout="vertical" className={styles.form}>
           <Form.Item name="comment" label={t('member.engine.comment')} rules={[{ max: 1000 }]}>

--- a/frontend/src/pages/member/application/ReviewDrawer.tsx
+++ b/frontend/src/pages/member/application/ReviewDrawer.tsx
@@ -7,6 +7,7 @@ import {
 import type { MemberApplication, MemberApplicationHistory } from '@/types/api';
 import StatusTag from '@/components/StatusTag/StatusTag';
 import AdmissionPanel from './AdmissionPanel';
+import EngineChainPanel from './EngineChainPanel';
 import dayjs from 'dayjs';
 import { Link } from 'react-router-dom';
 import { ApplicationStatusMap } from '../meta';
@@ -80,9 +81,14 @@ const ReviewDrawer: React.FC<ReviewDrawerProps> = ({ open, record, mode, onClose
               <Descriptions.Item label="审核意见">{record.review_comment}</Descriptions.Item>
             )}
           </Descriptions>
-          {record.flow_instance_id && <p><Link to={`/workflow/instances?instance_id=${encodeURIComponent(record.flow_instance_id)}`}>查看关联审批流程</Link></p>}
-
-          <AdmissionPanel key={record.id} id={record.id} officer={record.applicant_type === 2} editable={mode === 'review'} onChanged={onDone} />
+          {record.workflow_key === 'member_application' ? (
+            <EngineChainPanel record={record} editable={mode === 'review'} onChanged={onDone} />
+          ) : (
+            <>
+              {record.flow_instance_id && <p><Link to={`/workflow/instances?instance_id=${encodeURIComponent(record.flow_instance_id)}`}>查看关联审批流程</Link></p>}
+              <AdmissionPanel key={record.id} id={record.id} officer={record.applicant_type === 2} editable={mode === 'review'} onChanged={onDone} />
+            </>
+          )}
 
           {mode === 'resubmit' && (
             <Form form={form} layout="vertical" style={{ marginTop: 16 }} initialValues={record}>

--- a/frontend/src/pages/member/application/engineChain.test.ts
+++ b/frontend/src/pages/member/application/engineChain.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { engineReviewClosed } from './engineChain';
+
+describe('engineReviewClosed', () => {
+  it('hides actions for approved, rejected, and supplement', () => {
+    expect(engineReviewClosed(0)).toBe(false);
+    expect(engineReviewClosed(1)).toBe(false);
+    expect(engineReviewClosed(3)).toBe(true);
+    expect(engineReviewClosed(4)).toBe(true);
+    expect(engineReviewClosed(5)).toBe(true);
+  });
+});

--- a/frontend/src/pages/member/application/engineChain.ts
+++ b/frontend/src/pages/member/application/engineChain.ts
@@ -1,0 +1,3 @@
+export function engineReviewClosed(status: number): boolean {
+  return status === 3 || status === 4 || status === 5;
+}

--- a/frontend/src/pages/member/application/engineI18n.test.ts
+++ b/frontend/src/pages/member/application/engineI18n.test.ts
@@ -3,7 +3,7 @@ import en from '../../../locales/en-US.json';
 import zh from '../../../locales/zh-CN.json';
 
 const keys = [
-  'title', 'approve', 'reject', 'comment', 'commentRequired', 'approved', 'rejected', 'hint', 'viewFlow',
+  'title', 'approve', 'reject', 'comment', 'commentRequired', 'approved', 'rejected', 'hint', 'supplementHint', 'viewFlow',
   'steps.apply', 'steps.minister', 'steps.president', 'steps.end',
 ] as const;
 

--- a/frontend/src/pages/member/application/engineI18n.test.ts
+++ b/frontend/src/pages/member/application/engineI18n.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import en from '../../../locales/en-US.json';
+import zh from '../../../locales/zh-CN.json';
+
+const keys = [
+  'title', 'approve', 'reject', 'comment', 'commentRequired', 'approved', 'rejected', 'hint', 'viewFlow',
+  'steps.apply', 'steps.minister', 'steps.president', 'steps.end',
+] as const;
+
+function pick(obj: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object') {
+      return (acc as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
+}
+
+describe('member engine i18n', () => {
+  it('has matching zh-CN and en-US keys', () => {
+    keys.forEach((key) => {
+      expect(pick(zh.member.engine, key), `zh missing member.engine.${key}`).toBeTruthy();
+      expect(pick(en.member.engine, key), `en missing member.engine.${key}`).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/pages/workflow/runtime/AdmissionTask.tsx
+++ b/frontend/src/pages/workflow/runtime/AdmissionTask.tsx
@@ -4,6 +4,7 @@ import { getApplicationDetail } from '@/api/member';
 import type { MemberApplication } from '@/types/api';
 import { usePermission } from '@/hooks/usePermission';
 import AdmissionPanel from '@/pages/member/application/AdmissionPanel';
+import EngineChainPanel from '@/pages/member/application/EngineChainPanel';
 
 interface Props { applicationId: string; instanceId: string; onChanged: () => void }
 export default function AdmissionTask({ applicationId, instanceId, onChanged }: Props) {
@@ -32,6 +33,8 @@ export default function AdmissionTask({ applicationId, instanceId, onChanged }: 
       { key: 'skills', label: '技能', children: application.skills.join('、') || '—' },
       { key: 'experience', label: '经历', children: application.experience || '—' },
     ]} />
-    <AdmissionPanel id={applicationId} officer={application.applicant_type === 2} editable={canApprove && application.flow_instance_id === instanceId} onChanged={onChanged} />
+    {application.workflow_key === 'member_application'
+      ? <EngineChainPanel record={application} editable={canApprove && application.flow_instance_id === instanceId} onChanged={onChanged} />
+      : <AdmissionPanel id={applicationId} officer={application.applicant_type === 2} editable={canApprove && application.flow_instance_id === instanceId} onChanged={onChanged} />}
   </>;
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -319,6 +319,7 @@ export interface MemberApplication {
   status: MemberApplicationStatus;
   current_stage?: string;
   flow_instance_id?: string;
+  workflow_key?: string;
   reviewer?: MemberReviewer;
   review_comment?: string;
   required_fields?: string[];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

将入会申请的默认审批链接到现有流程引擎（`backend/internal/workflow/`），不重写引擎。

新申请提交后启动已发布定义 **`member_application`**：

干事申请 → 部长审批（`assigneeStrategy=role` / `roleCode=minister`，按意向部门划范围）→ 社长审批（`roleCode=president`）→ 结束。

- 同意/拒绝走 `Engine.CompleteApplicationApproval`（业务事务内 CompleteTask），不再把硬编码 `transit` 当作唯一路径。
- 任一节点拒绝：**强制终止**整个实例（cancel 所有 pending tasks + terminate），申请状态与实例终态一致，其他人不能再 approve 救活。
- 社长终审通过：复用原 `ensureProfile` + `GrantRole` + 权限刷新（录用副作用）。
- 补充材料：终止当前实例，状态回到补充材料；重新提交会再启一个实例。
- 章程签字链（`officer_interview` / `member_admission`）**仍保留**，只服务已在途/历史实例；新申请不再自动启动它们。引擎链申请禁止走 `/admission/sign`。

### Bugbot 修复（同一分支，未另开 PR）

1. **拒绝后实例仍在跑**：`CompleteApplicationApproval` 在 reject 后若实例仍 running（`approvalType=any` 且还有 pending），立即 `Terminate`。两部长待办时一方拒绝 → 实例终止、另一方不能再同意。
2. **Materials 阶段仍开着**：引擎启动后 `AdmissionStage` 迁到 `engine`；`Sign` 对 `member_application` 实例直接返回明确错误。前端引擎申请只显示 `EngineChainPanel`。
3. **上级跳过部长等待**：部长节点只允许意向部门部长立即处理；社长/中心主任走既有 24h 代签（须超时且填写原因），不能立刻连过部长+社长。
4. **无部门会员审不了 / Start 后 skip 太晚**：产品选择——**无意向部门的会员申请跳过部长节点直达社长**。提交变量带 `skip_minister`，`Start` 在部长 `OnEnter` 之前穿过该节点，不会因「没有处理人」回滚，也不会先创建全员部长待办再取消。干事申请提交时仍强制部门。
5. **补材料仍显示审批按钮**：`status=5` 视为结束，隐藏同意/拒绝，并提示等待申请人重提。

侧分支 Autofix（含 `cursor/application-engine-bugs-4626`）忽略，以本分支为准。

### 如何以后改流程

在「流程设计器」打开 key=`member_application` 的定义，改标签/布局后发布新版本即可。phase-1 校验仍要求保留 **部长 → 社长** 脊骨（`roleCode` + `approvalType=any`）。多分支/会签模板明确不做。

## 关联 Issue

Refs #64

（本切片未覆盖可视化设计器重做、任意多分支模板，故不 Closes。）

## 测试方式

1. 基于最新 `main`（含 #173 / `000060`）迁移到 `000061`。
2. `cd backend && go test ./internal/workflow/engine/ ./internal/workflow/engine/nodes/ ./internal/member/service/ ./internal/member/handler/`
3. `cd frontend && npx vitest --run src/pages/member/application/engineI18n.test.ts src/pages/member/application/engineChain.test.ts`
4. 启动后端/前端后，用普通账号提交干事申请（须选意向部门）。
5. 该部门部长在入会申请列表或流程待办打开申请：应看到「入会审批进度」而不是正式签字面板；同意后进入社长环节。
6. 社长同意后：申请状态=通过，生成人员档案并授予 `officer`/`member` 角色。
7. 任一节点拒绝：申请=拒绝，流程终止；另一待办人不能再同意。
8. 无意向部门的会员申请：提交后直接进入社长审批；系统中即使没有部长也能提交。
9. 已在途的章程签字申请仍走 AdmissionPanel 签字，不受影响。

### 自测记录

- `go test`：engine 启动→部长同意→社长同意→实例完成；两部长一方拒绝→实例终止且另一方无法同意；`skip_minister` 的 Start 不进入部长 OnEnter；24h 代签；`applyEngineOutcome` / 角色指派 / 图校验。
- `vitest`：zh-CN / en-US 键对齐；status 5 隐藏审批按钮。
- `go build ./cmd/server` 通过。
- 本环境无完整登录联调，未做浏览器走查。

## 截图 / GIF

前端新增引擎进度面板（Steps + 同意/拒绝），样式复用现有 AdmissionPanel。完整登录联调截图待漏测机补。

| 页面/功能 | 截图 |
|----------|------|
| 入会审批进度 | 待有库环境补 |

## 注意事项

- 迁移 `000061` 仅在 **没有已发布版本** 时写入默认图，不会覆盖之后在设计器里发布的版本。
- 通用流程待办接口仍禁止直接 CompleteTask（`member_application` 受保护）；必须从入会申请页/待办里的业务面板操作。
- 部长待办按申请 `department_id` 过滤；无部门会员在 Start 时跳过部长。社长为全量 `president` 角色。
- 不影响 backup #173、请假、公告。

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测（单测 + build）
- [x] 已添加/更新必要的文档（`docs/api.md` 一行）
- [ ] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e46b910b-e939-59d1-b08c-e4792fe270f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e46b910b-e939-59d1-b08c-e4792fe270f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

