### PR TITLE
feat(task): 任务流转接入流程引擎一期

### DIFF
--- a/backend/internal/task/dto/workflow.go
+++ b/backend/internal/task/dto/workflow.go
@@ -14,7 +14,7 @@ type WorkflowConfig struct {
 }
 type WorkflowActionRequest struct {
 	Revision int64  `json:"revision" binding:"required,min=1"`
-	Action   string `json:"action" binding:"required,oneof=start pause resume submit approve return"`
+	Action   string `json:"action" binding:"required,oneof=start pause resume submit approve return reject claim"`
 	Comment  string `json:"comment" binding:"required,max=5000"`
 }
 type WorkflowResponse struct {
@@ -35,6 +35,8 @@ type WorkflowResponse struct {
 	CanSubmit      bool          `json:"can_submit"`
 	CanApprove     bool          `json:"can_approve"`
 	CanReturn      bool          `json:"can_return"`
+	CanReject      bool          `json:"can_reject"`
+	CanClaim       bool          `json:"can_claim"`
 	UpdatedAt      time.Time     `json:"updated_at"`
 	History        []LogResponse `json:"history"`
 }

--- a/backend/internal/task/handler/routes.go
+++ b/backend/internal/task/handler/routes.go
@@ -54,7 +54,7 @@ func RegisterRoutes(
 	g := r.Group("/tasks")
 	read := withReadScope(g, cacheService, db, deptRepo)
 	personal := g.Group("", personalTaskViewer(cacheService))
-	for _, p := range []string{"task:update", "task:delete", "task:assign", "task:transfer", "task:comment", "task:create"} {
+	for _, p := range []string{"task:read", "task:update", "task:delete", "task:assign", "task:transfer", "task:comment", "task:create"} {
 		personal.Use(middleware.RequireDataScope(p), middleware.DataScopeMiddleware(db, deptRepo, cacheService), taskCapability(p))
 	}
 	personal.GET("/:id/workflow", h.GetWorkflow)

--- a/backend/internal/task/handler/workflow.go
+++ b/backend/internal/task/handler/workflow.go
@@ -33,7 +33,7 @@ func (h *TaskHandler) GetWorkflow(c *gin.Context) {
 }
 
 // ActWorkflow godoc
-// @Summary 提交交付、签字审核或退回返工
+// @Summary 提交交付、签字审核、拒绝或认领
 // @Tags tasks
 // @Accept json
 // @Produce json

--- a/backend/internal/task/service/workflow.go
+++ b/backend/internal/task/service/workflow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	rbac "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/task/model"
 	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
@@ -106,16 +107,21 @@ func (s *taskService) workflowTask(ctx context.Context, id, actor uuid.UUID) (*m
 	if workflowParticipant(t, actor) {
 		return t, nil
 	}
-	// Unassigned assignment-stage tasks can be claimed by anyone who can already view them.
+	// Personal workflow routes pin viewer.Scope to IsSelf. Claimers who can already
+	// list the task must be judged by task:read, not that personal default.
 	if t.WorkflowStage == "assignment" && t.AssigneeID == nil {
-		if viewer, ok := model.ViewerFromContext(ctx); ok && canViewTask(t, actor, viewer.Scope) {
-			return t, nil
-		}
-		if canViewTask(t, actor, nil) {
+		if viewer, ok := model.ViewerFromContext(ctx); ok && canViewTask(t, actor, workflowReadScope(viewer)) {
 			return t, nil
 		}
 	}
 	return nil, response.NewError(response.CodeForbidden, "仅任务参与人可查看或处理审批")
+}
+
+func workflowReadScope(viewer model.Viewer) *rbac.DataScopeCondition {
+	if scope, ok := viewer.Scopes["task:read"]; ok {
+		return scope
+	}
+	return viewer.Scope
 }
 func (s *taskService) ActWorkflow(ctx context.Context, id, actor uuid.UUID, req *dto.WorkflowActionRequest) (*dto.WorkflowResponse, error) {
 	if req == nil || strings.TrimSpace(req.Comment) == "" || utf8.RuneCountInString(req.Comment) > 5000 {

--- a/backend/internal/task/service/workflow.go
+++ b/backend/internal/task/service/workflow.go
@@ -62,6 +62,17 @@ func (s *taskService) projectWorkflow(ctx context.Context, t *model.Task) error 
 	if s.flow == nil || t.WorkflowInstanceID == nil {
 		return response.NewError(response.CodeConflict, "任务缺少关联流程")
 	}
+	if terminated, err := s.flow.InstanceTerminated(ctx, *t.WorkflowInstanceID); err != nil {
+		return err
+	} else if terminated {
+		if t.WorkflowStage != "cancelled" {
+			t.WorkflowStage = "rejected"
+		}
+		t.Status = model.StatusCancelled
+		t.WorkflowRevision++
+		t.UpdatedAt = time.Now()
+		return s.tasks.Update(ctx, t)
+	}
 	stage, done, err := s.flow.BusinessStage(ctx, *t.WorkflowInstanceID)
 	if err != nil {
 		return err
@@ -92,12 +103,19 @@ func (s *taskService) workflowTask(ctx context.Context, id, actor uuid.UUID) (*m
 	if t.WorkflowInstanceID == nil {
 		return nil, response.NewError(response.CodeConflict, "该任务未启用审核验收流程")
 	}
-	// This panel is for explicitly designated participants; broad task management
-	// permission alone must never grant a signature on their behalf.
-	if !workflowParticipant(t, actor) {
-		return nil, response.NewError(response.CodeForbidden, "仅任务参与人可查看或处理审批")
+	if workflowParticipant(t, actor) {
+		return t, nil
 	}
-	return t, nil
+	// Unassigned assignment-stage tasks can be claimed by anyone who can already view them.
+	if t.WorkflowStage == "assignment" && t.AssigneeID == nil {
+		if viewer, ok := model.ViewerFromContext(ctx); ok && canViewTask(t, actor, viewer.Scope) {
+			return t, nil
+		}
+		if canViewTask(t, actor, nil) {
+			return t, nil
+		}
+	}
+	return nil, response.NewError(response.CodeForbidden, "仅任务参与人可查看或处理审批")
 }
 func (s *taskService) ActWorkflow(ctx context.Context, id, actor uuid.UUID, req *dto.WorkflowActionRequest) (*dto.WorkflowResponse, error) {
 	if req == nil || strings.TrimSpace(req.Comment) == "" || utf8.RuneCountInString(req.Comment) > 5000 {
@@ -154,6 +172,34 @@ func (s *taskService) ActWorkflow(ctx context.Context, id, actor uuid.UUID, req 
 			if err := b.tasks.Update(ctx, t); err != nil {
 				return err
 			}
+		case "claim":
+			if stage != "assignment" || t.AssigneeID != nil {
+				return response.NewError(response.CodeConflict, "只有待认领的任务可以认领")
+			}
+			if err := validateWorkflowAssignee(t, &actor); err != nil {
+				return err
+			}
+			t.AssigneeID = &actor
+			if err := b.tasks.Update(ctx, t); err != nil {
+				return err
+			}
+			if err := b.flow.ClaimTaskAssignment(ctx, *t.WorkflowInstanceID, actor, req.Comment); err != nil {
+				return err
+			}
+			action = ""
+		case "reject":
+			if stage != "review" && stage != "acceptance" {
+				return response.NewError(response.CodeConflict, "当前不是审核或验收环节")
+			}
+			if (stage == "review" && (t.ReviewerID == nil || *t.ReviewerID != actor)) || (stage == "acceptance" && (t.AcceptorID == nil || *t.AcceptorID != actor)) {
+				return response.NewError(response.CodeForbidden, "只有该环节的指定处理人可以拒绝")
+			}
+			if err := b.flow.CompleteTaskApproval(ctx, *t.WorkflowInstanceID, actor, engine.ActionReject, req.Comment); err != nil {
+				return err
+			}
+			t.Status = model.StatusCancelled
+			t.WorkflowStage = "rejected"
+			action = ""
 		case "approve", "return":
 			if stage != "review" && stage != "acceptance" {
 				return response.NewError(response.CodeConflict, "当前不是审核或验收环节")
@@ -172,7 +218,13 @@ func (s *taskService) ActWorkflow(ctx context.Context, id, actor uuid.UUID, req 
 		if stage == "review" && req.Action == "approve" {
 			t.Progress = 90
 		}
-		if err := b.projectWorkflow(ctx, t); err != nil {
+		if req.Action == "reject" {
+			t.WorkflowRevision++
+			t.UpdatedAt = time.Now()
+			if err := b.tasks.Update(ctx, t); err != nil {
+				return err
+			}
+		} else if err := b.projectWorkflow(ctx, t); err != nil {
 			return err
 		}
 		if err := b.addLog(ctx, id, actor, "workflow_"+req.Action, stage, t.WorkflowStage, req.Comment); err != nil {

--- a/backend/internal/task/service/workflow_policy_test.go
+++ b/backend/internal/task/service/workflow_policy_test.go
@@ -290,6 +290,48 @@ func TestWorkflowClaimAdvancesAssignment(t *testing.T) {
 	}
 }
 
+func TestWorkflowClaimHonorsTaskReadScopeOnPersonalViewer(t *testing.T) {
+	svc, tasks, stub, ids := workflowFixture(t)
+	dept, other, peer, stranger := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	tasks.users[peer] = &model.NamedUser{ID: peer, Username: "peer"}
+	tasks.users[stranger] = &model.NamedUser{ID: stranger, Username: "stranger"}
+	ctx := context.Background()
+	row, err := svc.Create(ctx, ids[0], &dto.CreateTaskRequest{Title: "Dept task", DepartmentID: dept.String(), Workflow: &dto.WorkflowConfig{ReviewerID: ids[2].String(), AcceptorID: ids[3].String()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(row.ID)
+	personal := func(id uuid.UUID, read *rbac.DataScopeCondition) context.Context {
+		return model.WithViewer(ctx, model.Viewer{
+			ID:     id,
+			Scope:  &rbac.DataScopeCondition{Query: "1 = 0", IsSelf: true},
+			Scopes: map[string]*rbac.DataScopeCondition{"task:read": read},
+		})
+	}
+	deptRead := &rbac.DataScopeCondition{Query: "department_id = ?", Args: []interface{}{dept}}
+	selfRead := &rbac.DataScopeCondition{Query: "1 = 0", IsSelf: true}
+	otherRead := &rbac.DataScopeCondition{Query: "department_id = ?", Args: []interface{}{other}}
+	if _, err := svc.GetWorkflow(personal(stranger, selfRead), id, stranger); err == nil {
+		t.Fatal("self-scope outsider opened workflow")
+	}
+	if _, err := svc.ActWorkflow(personal(stranger, selfRead), id, stranger, &dto.WorkflowActionRequest{Action: "claim", Comment: "我来认领", Revision: 1}); err == nil {
+		t.Fatal("self-scope outsider claimed")
+	}
+	if _, err := svc.GetWorkflow(personal(stranger, otherRead), id, stranger); err == nil {
+		t.Fatal("other-department viewer opened workflow")
+	}
+	if _, err := svc.GetWorkflow(personal(peer, deptRead), id, peer); err != nil {
+		t.Fatal(err)
+	}
+	state, err := svc.ActWorkflow(personal(peer, deptRead), id, peer, &dto.WorkflowActionRequest{Action: "claim", Comment: "我来认领", Revision: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Stage != "execution" || tasks.items[id].AssigneeID == nil || *tasks.items[id].AssigneeID != peer || len(stub.calls) == 0 {
+		t.Fatalf("department peer could not claim: %+v assignee=%v calls=%v", state, tasks.items[id].AssigneeID, stub.calls)
+	}
+}
+
 func (w *workflowStub) CompleteTaskTransferApproval(context.Context, uuid.UUID, string, uuid.UUID, uuid.UUID, bool) error {
 	return w.fail
 }

--- a/backend/internal/task/service/workflow_policy_test.go
+++ b/backend/internal/task/service/workflow_policy_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/google/uuid"
 
+	rbac "github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/Yogdunana/StarByte/backend/internal/task/dto"
 	"github.com/Yogdunana/StarByte/backend/internal/task/model"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
 	wfmodel "github.com/Yogdunana/StarByte/backend/internal/workflow/model"
 )
 
@@ -41,10 +43,37 @@ func (w *workflowStub) TaskCheckpoint(_ context.Context, _ uuid.UUID, stage stri
 	w.calls = append(w.calls, checkpointCall{stage, action, actor})
 	if action == "return" {
 		w.stage = "execution"
+	} else if action == "reject" {
+		w.terminated = true
+		w.stage = "rejected"
 	} else {
 		w.stage = map[string]string{"assignment": "execution", "execution": "review", "review": "acceptance", "acceptance": "completed"}[stage]
 	}
 	return nil
+}
+func (w *workflowStub) CompleteTaskApproval(_ context.Context, _ uuid.UUID, actor uuid.UUID, action engine.TaskAction, comment string) error {
+	if w.fail != nil {
+		return w.fail
+	}
+	w.calls = append(w.calls, checkpointCall{w.stage, string(action), actor})
+	if action == engine.ActionReject {
+		w.terminated = true
+		w.stage = "rejected"
+	} else {
+		w.stage = map[string]string{"assignment": "execution", "execution": "review", "review": "acceptance", "acceptance": "completed"}[w.stage]
+	}
+	return nil
+}
+func (w *workflowStub) ClaimTaskAssignment(_ context.Context, _ uuid.UUID, actor uuid.UUID, _ string) error {
+	if w.fail != nil {
+		return w.fail
+	}
+	w.calls = append(w.calls, checkpointCall{"assignment", "claim", actor})
+	w.stage = "execution"
+	return nil
+}
+func (w *workflowStub) InstanceTerminated(context.Context, uuid.UUID) (bool, error) {
+	return w.terminated, w.fail
 }
 func (w *workflowStub) Terminate(context.Context, uuid.UUID, uuid.UUID, string) error {
 	if w.fail != nil {
@@ -199,6 +228,65 @@ func TestWorkflowAssignmentCancellationAndConfigurationGuards(t *testing.T) {
 	svc.flow = nil
 	if _, err := svc.Create(ctx, ids[0], &dto.CreateTaskRequest{Title: "No engine", Workflow: config}); err == nil {
 		t.Fatal("missing workflow engine reported success")
+	}
+}
+
+func TestWorkflowRejectTerminatesTaskAndInstance(t *testing.T) {
+	svc, tasks, stub, ids := workflowFixture(t)
+	ctx := context.Background()
+	row, err := svc.Create(ctx, ids[0], &dto.CreateTaskRequest{Title: "Deliverable", AssigneeID: ids[1].String(), Workflow: &dto.WorkflowConfig{ReviewerID: ids[2].String(), AcceptorID: ids[3].String()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(row.ID)
+	act := func(actor uuid.UUID, action string) *dto.WorkflowResponse {
+		state, err := svc.GetWorkflow(ctx, id, actor)
+		if err != nil {
+			t.Fatal(err)
+		}
+		next, err := svc.ActWorkflow(ctx, id, actor, &dto.WorkflowActionRequest{Action: action, Comment: "拒绝原因", Revision: state.Revision})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return next
+	}
+	if _, err := svc.ActWorkflow(ctx, id, ids[1], &dto.WorkflowActionRequest{Action: "start", Comment: "开始执行", Revision: 1}); err != nil {
+		t.Fatal(err)
+	}
+	act(ids[1], "submit")
+	if _, err := svc.ActWorkflow(ctx, id, ids[1], &dto.WorkflowActionRequest{Action: "reject", Comment: "执行人不能拒绝", Revision: 2}); err == nil {
+		t.Fatal("executor rejected review")
+	}
+	state := act(ids[2], "reject")
+	if state.Stage != "rejected" || !stub.terminated || tasks.items[id].Status != model.StatusCancelled {
+		t.Fatalf("reject did not terminate: %+v status=%d terminated=%v", state, tasks.items[id].Status, stub.terminated)
+	}
+	if _, err := svc.ActWorkflow(ctx, id, ids[3], &dto.WorkflowActionRequest{Action: "approve", Comment: "不能救活", Revision: state.Revision}); err == nil {
+		t.Fatal("acceptor revived rejected task")
+	}
+}
+
+func TestWorkflowClaimAdvancesAssignment(t *testing.T) {
+	svc, tasks, stub, ids := workflowFixture(t)
+	ctx := context.Background()
+	row, err := svc.Create(ctx, ids[0], &dto.CreateTaskRequest{Title: "Open task", Workflow: &dto.WorkflowConfig{ReviewerID: ids[2].String(), AcceptorID: ids[3].String()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(row.ID)
+	if row.WorkflowStage != "assignment" {
+		t.Fatal("expected assignment stage")
+	}
+	claimer := model.WithViewer(ctx, model.Viewer{ID: ids[1], Scope: &rbac.DataScopeCondition{}})
+	if _, err := svc.ActWorkflow(claimer, id, ids[2], &dto.WorkflowActionRequest{Action: "claim", Comment: "审核人不能认领自己的交付", Revision: 1}); err == nil {
+		t.Fatal("reviewer claimed own review")
+	}
+	state, err := svc.ActWorkflow(claimer, id, ids[1], &dto.WorkflowActionRequest{Action: "claim", Comment: "我来认领", Revision: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Stage != "execution" || tasks.items[id].AssigneeID == nil || *tasks.items[id].AssigneeID != ids[1] || len(stub.calls) == 0 {
+		t.Fatalf("claim did not advance: %+v assignee=%v calls=%v", state, tasks.items[id].AssigneeID, stub.calls)
 	}
 }
 

--- a/backend/internal/task/service/workflow_port.go
+++ b/backend/internal/task/service/workflow_port.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/engine"
 	wfmodel "github.com/Yogdunana/StarByte/backend/internal/workflow/model"
 )
 
@@ -16,6 +17,9 @@ type TaskWorkflowRuntime interface {
 
 	Start(context.Context, string, string, string, uuid.UUID, map[string]interface{}) (*wfmodel.FlowInstance, error)
 	TaskCheckpoint(context.Context, uuid.UUID, string, uuid.UUID, string, string) error
+	CompleteTaskApproval(context.Context, uuid.UUID, uuid.UUID, engine.TaskAction, string) error
+	ClaimTaskAssignment(context.Context, uuid.UUID, uuid.UUID, string) error
+	InstanceTerminated(context.Context, uuid.UUID) (bool, error)
 	BusinessStage(context.Context, uuid.UUID) (string, bool, error)
 	Terminate(context.Context, uuid.UUID, uuid.UUID, string) error
 }

--- a/backend/internal/task/service/workflow_view.go
+++ b/backend/internal/task/service/workflow_view.go
@@ -55,6 +55,8 @@ func (s *taskService) GetWorkflow(ctx context.Context, id, actor uuid.UUID) (*dt
 	out.CanSubmit = t.WorkflowStage == "execution" && t.Status == model.StatusDoing && t.AssigneeID != nil && *t.AssigneeID == actor
 	out.CanApprove = !model.IsClosed(t.Status) && ((t.WorkflowStage == "review" && t.ReviewerID != nil && *t.ReviewerID == actor) || (t.WorkflowStage == "acceptance" && t.AcceptorID != nil && *t.AcceptorID == actor))
 	out.CanReturn = out.CanApprove
+	out.CanReject = out.CanApprove
+	out.CanClaim = t.WorkflowStage == "assignment" && t.AssigneeID == nil && !model.IsClosed(t.Status) && validateWorkflowAssignee(t, &actor) == nil
 	logs, err := s.logs.ListByTask(ctx, id)
 	if err != nil {
 		return nil, err

--- a/backend/internal/workflow/engine/application_approval.go
+++ b/backend/internal/workflow/engine/application_approval.go
@@ -200,7 +200,7 @@ func (e *FlowEngine) currentApprovalNodeID(ctx context.Context, inst *model.Flow
 			return id, nil
 		}
 	}
-	return "", response.NewError(response.CodeConflict, "当前没有可处理的入会审批环节")
+	return "", response.NewError(response.CodeConflict, "当前没有可处理的审批环节")
 }
 
 func (e *FlowEngine) selectApprovalTask(ctx context.Context, instanceID uuid.UUID, nodeID string, reviewer uuid.UUID) (*model.FlowTask, error) {

--- a/backend/internal/workflow/engine/task_approval.go
+++ b/backend/internal/workflow/engine/task_approval.go
@@ -1,0 +1,184 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/repo"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+)
+
+// CompleteTaskApproval completes the current collaboration-task node inside an
+// already-authorized business transaction (same pattern as CompleteApplicationApproval).
+// Reject / fail always terminates the instance so leftover pending todos cannot revive it.
+func (e *FlowEngine) CompleteTaskApproval(ctx context.Context, instanceID, actor uuid.UUID, action TaskAction, comment string) error {
+	if !e.businessTransaction {
+		return response.NewError(response.CodeForbidden, "任务审批需要业务事务")
+	}
+	if action != ActionApprove && action != ActionReject {
+		return response.NewError(response.CodeBadRequest, "任务审批只支持同意或拒绝")
+	}
+	if action == ActionReject && strings.TrimSpace(comment) == "" {
+		return response.NewError(response.CodeBadRequest, "拒绝须填写原因")
+	}
+	if e.db != nil {
+		if err := repo.NewRuntimeRepo(e.db).LockInstance(ctx, instanceID); err != nil {
+			return err
+		}
+	}
+	inst, err := e.instRepo.GetByID(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	if inst == nil || inst.BusinessType != TaskBusinessType || inst.Status != 0 {
+		return response.NewError(response.CodeConflict, "任务流程当前不可审批")
+	}
+	nodeID, err := e.currentApprovalNodeID(ctx, inst)
+	if err != nil {
+		return err
+	}
+	selected, err := e.selectApprovalTask(ctx, instanceID, nodeID, actor)
+	if err != nil {
+		return err
+	}
+	if err := e.CompleteTask(ctx, selected.ID, actor, action, comment, nil); err != nil {
+		return err
+	}
+	if action != ActionReject {
+		return nil
+	}
+	fresh, err := e.instRepo.GetByID(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	if fresh != nil && fresh.Status == 0 {
+		return e.Terminate(ctx, instanceID, actor, "任务审批拒绝："+comment)
+	}
+	return nil
+}
+
+// ClaimTaskAssignment advances past the assignment node after the business task
+// already has an assignee. The publisher's assignment todo is cancelled so it
+// cannot later complete or revive the stage.
+func (e *FlowEngine) ClaimTaskAssignment(ctx context.Context, instanceID, actor uuid.UUID, comment string) error {
+	if !e.businessTransaction {
+		return response.NewError(response.CodeForbidden, "任务认领需要业务事务")
+	}
+	if e.db != nil {
+		if err := repo.NewRuntimeRepo(e.db).LockInstance(ctx, instanceID); err != nil {
+			return err
+		}
+	}
+	inst, err := e.instRepo.GetByID(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+	if inst == nil || inst.BusinessType != TaskBusinessType || inst.Status != 0 {
+		return response.NewError(response.CodeConflict, "任务流程当前不可认领")
+	}
+	nodeID, err := e.currentApprovalNodeID(ctx, inst)
+	if err != nil {
+		return err
+	}
+	stage, err := e.nodeTaskStage(ctx, inst, nodeID)
+	if err != nil {
+		return err
+	}
+	if stage != "assignment" {
+		return response.NewError(response.CodeConflict, "当前不是认领或分配环节")
+	}
+	reason := strings.TrimSpace(comment)
+	if reason == "" {
+		reason = "任务已被认领"
+	}
+	if err := e.cancelNodePendingTasks(ctx, inst.ID, nodeID, actor, reason); err != nil {
+		return err
+	}
+	now := time.Now()
+	hist := &model.FlowHistory{
+		ID: uuid.New(), InstanceID: inst.ID, NodeID: nodeID, NodeName: nodeID,
+		NodeType: "approval", Action: "claim", Comment: reason, CreatedAt: now,
+	}
+	if actor != uuid.Nil {
+		hist.OperatorID = &actor
+	}
+	if err := e.taskRepo.CreateHistory(ctx, nil, hist); err != nil {
+		return err
+	}
+	return e.advancePastApprovalNode(ctx, inst, nodeID, actor)
+}
+
+func (e *FlowEngine) nodeTaskStage(ctx context.Context, inst *model.FlowInstance, nodeID string) (string, error) {
+	version, err := e.defRepo.GetVersionByID(ctx, inst.DefinitionVersionID)
+	if err != nil {
+		return "", err
+	}
+	if version == nil {
+		return "", response.NewError(response.CodeWorkflowVerNotFound, "任务流程版本不存在")
+	}
+	graph, err := ParseGraph(version.BpmnData)
+	if err != nil {
+		return "", err
+	}
+	node := graph.GetNode(nodeID)
+	if node == nil {
+		return "", response.NewError(response.CodeWorkflowNodeNotFound, "流程节点不存在: "+nodeID)
+	}
+	stage, _ := node.Config["taskStage"].(string)
+	return stage, nil
+}
+
+func (e *FlowEngine) advancePastApprovalNode(ctx context.Context, inst *model.FlowInstance, nodeID string, _ uuid.UUID) error {
+	version, err := e.defRepo.GetVersionByID(ctx, inst.DefinitionVersionID)
+	if err != nil {
+		return err
+	}
+	if version == nil {
+		return response.NewError(response.CodeWorkflowVerNotFound, "任务流程版本不存在")
+	}
+	graph, err := ParseGraph(version.BpmnData)
+	if err != nil {
+		return err
+	}
+	node := graph.GetNode(nodeID)
+	if node == nil {
+		return response.NewError(response.CodeWorkflowNodeNotFound, "流程节点不存在: "+nodeID)
+	}
+	vars, err := e.varRepo.GetMap(ctx, inst.ID)
+	if err != nil {
+		return err
+	}
+	next, err := e.executeNode(ctx, inst, graph, node, vars)
+	if err != nil {
+		return err
+	}
+	currentIDs := []string{}
+	for _, id := range GetCurrentNodeIDs(inst.CurrentNodeIDs) {
+		if id != nodeID {
+			currentIDs = append(currentIDs, id)
+		}
+	}
+	if err := e.updateCurrentNodes(ctx, inst, currentIDs); err != nil {
+		return err
+	}
+	if len(next) == 0 {
+		return nil
+	}
+	return e.executeFromNodes(ctx, inst, graph, next, vars, node.ID)
+}
+
+// InstanceTerminated reports whether a collaboration instance was force-stopped.
+func (e *FlowEngine) InstanceTerminated(ctx context.Context, id uuid.UUID) (bool, error) {
+	inst, err := e.instRepo.GetByID(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	if inst == nil {
+		return false, response.NewError(response.CodeWorkflowInstNotFound, "流程实例不存在")
+	}
+	return inst.Status == 2, nil
+}

--- a/backend/internal/workflow/engine/task_approval_test.go
+++ b/backend/internal/workflow/engine/task_approval_test.go
@@ -1,0 +1,135 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Yogdunana/StarByte/backend/internal/workflow/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/events"
+)
+
+func taskLifecycleEngine(t *testing.T, tasks *mockTaskRepo) (*FlowEngine, *storingInstRepo) {
+	t.Helper()
+	defID, verID := uuid.New(), uuid.New()
+	def := &model.FlowDefinition{ID: defID, Key: TaskDefinitionKey, Status: 1}
+	ver := &model.FlowDefinitionVersion{ID: verID, DefinitionID: defID, BpmnData: TaskLifecycleBPMN(), Status: 1}
+	insts := &storingInstRepo{insts: map[uuid.UUID]*model.FlowInstance{}}
+	e := NewFlowEngine(&mockDefRepo{def: def, version: ver}, insts, tasks, newMockVarRepo(), nil, &mockRegistryForTest{handlers: map[string]NodeHandler{
+		"start": stubStartHandler{}, "end": stubEndHandler{}, "approval": &waitingTestNode{},
+	}}, NewExpressionEngine(), events.NewEventBus(), nil)
+	e.businessTransaction = true
+	return e, insts
+}
+
+func TestTaskLifecycleStartApproveSpineComplete(t *testing.T) {
+	creator, assignee, reviewer, acceptor := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	tasks := newMockTaskRepo()
+	e, insts := taskLifecycleEngine(t, tasks)
+
+	inst, err := e.Start(context.Background(), TaskDefinitionKey, uuid.New().String(), TaskBusinessType, creator, map[string]interface{}{
+		"task_id": uuid.New().String(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, inst.Status)
+	nodeID, done, err := e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, "assignment", nodeID)
+
+	addApprovalTask(tasks, inst.ID, "assignment", creator)
+	require.NoError(t, e.CompleteTaskApproval(context.Background(), inst.ID, creator, ActionApprove, "指定执行人"))
+	nodeID, done, err = e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, "execution", nodeID)
+
+	addApprovalTask(tasks, inst.ID, "execution", assignee)
+	require.NoError(t, e.CompleteTaskApproval(context.Background(), inst.ID, assignee, ActionApprove, "提交交付"))
+	nodeID, _, err = e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.Equal(t, "review", nodeID)
+
+	addApprovalTask(tasks, inst.ID, "review", reviewer)
+	require.NoError(t, e.CompleteTaskApproval(context.Background(), inst.ID, reviewer, ActionApprove, "审核通过"))
+	nodeID, _, err = e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.Equal(t, "acceptance", nodeID)
+
+	addApprovalTask(tasks, inst.ID, "acceptance", acceptor)
+	require.NoError(t, e.CompleteTaskApproval(context.Background(), inst.ID, acceptor, ActionApprove, "验收通过"))
+	_, done, err = e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, 1, insts.insts[inst.ID].Status)
+}
+
+func TestTaskLifecycleRejectTerminatesPendingTodos(t *testing.T) {
+	creator, reviewer, other := uuid.New(), uuid.New(), uuid.New()
+	tasks := newMockTaskRepo()
+	e, insts := taskLifecycleEngine(t, tasks)
+
+	inst, err := e.Start(context.Background(), TaskDefinitionKey, uuid.New().String(), TaskBusinessType, creator, nil)
+	require.NoError(t, err)
+	addApprovalTask(tasks, inst.ID, "assignment", creator)
+	require.NoError(t, e.CompleteTaskApproval(context.Background(), inst.ID, creator, ActionApprove, "分配"))
+	addApprovalTask(tasks, inst.ID, "execution", creator)
+	require.NoError(t, e.CompleteTaskApproval(context.Background(), inst.ID, creator, ActionApprove, "交付"))
+	addApprovalTask(tasks, inst.ID, "review", reviewer)
+	addApprovalTask(tasks, inst.ID, "review", other)
+	require.NoError(t, e.CompleteTaskApproval(context.Background(), inst.ID, reviewer, ActionReject, "质量不符"))
+	require.Equal(t, 2, insts.insts[inst.ID].Status)
+
+	var canceled, rejected int
+	for _, task := range tasks.tasks {
+		if task.InstanceID != inst.ID {
+			continue
+		}
+		if task.AssigneeID != nil && *task.AssigneeID == reviewer && task.NodeID == "review" {
+			require.Equal(t, 2, task.Status)
+			rejected++
+		}
+		if task.AssigneeID != nil && *task.AssigneeID == other && task.NodeID == "review" {
+			require.Equal(t, 5, task.Status)
+			require.Equal(t, "cancel", task.Action)
+			canceled++
+		}
+	}
+	require.Equal(t, 1, rejected)
+	require.Equal(t, 1, canceled)
+	require.Error(t, e.CompleteTaskApproval(context.Background(), inst.ID, other, ActionApprove, "不能救活"))
+	terminated, err := e.InstanceTerminated(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.True(t, terminated)
+}
+
+func TestClaimTaskAssignmentAdvancesToExecution(t *testing.T) {
+	creator, claimer := uuid.New(), uuid.New()
+	tasks := newMockTaskRepo()
+	e, _ := taskLifecycleEngine(t, tasks)
+
+	inst, err := e.Start(context.Background(), TaskDefinitionKey, uuid.New().String(), TaskBusinessType, creator, nil)
+	require.NoError(t, err)
+	addApprovalTask(tasks, inst.ID, "assignment", creator)
+	require.NoError(t, e.ClaimTaskAssignment(context.Background(), inst.ID, claimer, "我来认领"))
+	nodeID, done, err := e.RunningApprovalNode(context.Background(), inst.ID)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, "execution", nodeID)
+	for _, task := range tasks.tasks {
+		if task.InstanceID == inst.ID && task.NodeID == "assignment" && task.AssigneeID != nil && *task.AssigneeID == creator {
+			require.Equal(t, 5, task.Status)
+			require.Equal(t, "cancel", task.Action)
+		}
+	}
+}
+
+func TestTaskLifecycleBPMNMatchesDefinitionKey(t *testing.T) {
+	require.Equal(t, "task_lifecycle", TaskDefinitionKey)
+	graph, err := ParseGraph(TaskLifecycleBPMN())
+	require.NoError(t, err)
+	require.NoError(t, ValidateBusinessDefinition(TaskDefinitionKey, graph))
+	require.Equal(t, "start", graph.FindStartNode().ID)
+}

--- a/backend/internal/workflow/engine/task_checkpoint.go
+++ b/backend/internal/workflow/engine/task_checkpoint.go
@@ -21,6 +21,26 @@ func (e *FlowEngine) TaskCheckpoint(ctx context.Context, id uuid.UUID, stage str
 	switch action {
 	case "approve":
 		return e.CompleteTask(ctx, task.ID, actor, ActionApprove, "任务业务确认（"+stage+"）", nil)
+	case "reject":
+		// TODO(#65): timeout escalate/reassign — nodes already carry dueDays, but
+		// there is no scheduler hook to auto-upgrade or reassign overdue todos.
+		if stage != "review" && stage != "acceptance" {
+			return response.NewError(response.CodeBadRequest, "该环节不能拒绝任务")
+		}
+		if strings.TrimSpace(comment) == "" {
+			return response.NewError(response.CodeBadRequest, "拒绝须填写原因")
+		}
+		if err := e.CompleteTask(ctx, task.ID, actor, ActionReject, comment, nil); err != nil {
+			return err
+		}
+		fresh, err := e.instRepo.GetByID(ctx, id)
+		if err != nil {
+			return err
+		}
+		if fresh != nil && fresh.Status == 0 {
+			return e.Terminate(ctx, id, actor, "任务审批拒绝："+comment)
+		}
+		return nil
 	case "return":
 		if stage != "review" && stage != "acceptance" {
 			return response.NewError(response.CodeBadRequest, "该环节不能退回执行")

--- a/backend/internal/workflow/engine/task_graph.go
+++ b/backend/internal/workflow/engine/task_graph.go
@@ -1,12 +1,49 @@
 package engine
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 const TaskBusinessType = "collaboration_task"
 const TaskDefinitionKey = "task_lifecycle"
 
 func IsProtectedBusiness(kind string) bool {
 	return kind == "member_application" || kind == TaskBusinessType || kind == TaskTransferBusinessType
+}
+
+// TaskLifecycleBPMN is the default published graph seeded by 000046 / 000062.
+// 发布 → 认领/分配 → 执行 → 审核 → 验收 → 完成
+func TaskLifecycleBPMN() []byte {
+	stage := func(id, label string, y int) map[string]interface{} {
+		return node(id, "approval", label, y, map[string]interface{}{
+			"assigneeStrategy": "business_role", "businessType": TaskBusinessType,
+			"taskStage": id, "approvalType": "single", "dueDays": 1,
+			"allowReject": true, "allowTransfer": false, "allowRollback": false,
+		})
+	}
+	raw, err := json.Marshal(map[string]interface{}{
+		"nodes": []map[string]interface{}{
+			node("start", "start", "发布任务", 0, nil),
+			stage("assignment", "认领 / 分配", 140),
+			stage("execution", "执行与提交交付", 280),
+			stage("review", "负责人审核", 420),
+			stage("acceptance", "正式验收", 560),
+			node("end", "end", "任务完成", 700, nil),
+		},
+		"edges": []map[string]string{
+			{"id": "start-assignment", "source": "start", "target": "assignment"},
+			{"id": "assignment-execution", "source": "assignment", "target": "execution"},
+			{"id": "execution-review", "source": "execution", "target": "review"},
+			{"id": "review-acceptance", "source": "review", "target": "acceptance"},
+			{"id": "acceptance-end", "source": "acceptance", "target": "end"},
+		},
+		"viewport": map[string]interface{}{"x": 0, "y": 0, "zoom": 1},
+	})
+	if err != nil {
+		return []byte(`{"nodes":[],"edges":[]}`)
+	}
+	return raw
 }
 
 // The lifecycle checkpoints cannot be removed by changing layout or assignees.

--- a/backend/migrations/000062_task_lifecycle_workflow.down.sql
+++ b/backend/migrations/000062_task_lifecycle_workflow.down.sql
@@ -1,0 +1,4 @@
+-- 000046 already owns key=task_lifecycle. This slice only publishes a version
+-- when none exists, so rolling back must not drop a designer-published graph
+-- or the 000046 template.
+SELECT 1;

--- a/backend/migrations/000062_task_lifecycle_workflow.up.sql
+++ b/backend/migrations/000062_task_lifecycle_workflow.up.sql
@@ -1,0 +1,52 @@
+-- Default task lifecycle template (#65 phase-1):
+-- 发布 → 认领/分配 → 执行 → 审核 → 验收 → 完成
+-- Assignees are resolved at runtime via business_role (collaboration_task).
+-- Idempotent: publish only when no current version exists, so later designer
+-- edits and the 000046 seed are not overwritten.
+
+DO $migration$
+DECLARE
+  target_definition_id uuid;
+  graph jsonb := $json${
+    "nodes": [
+      {"id": "start", "type": "start", "position": {"x": 280, "y": 0}, "data": {"label": "发布任务", "config": {}}},
+      {"id": "assignment", "type": "approval", "position": {"x": 280, "y": 140}, "data": {"label": "认领 / 分配", "config": {"assigneeStrategy": "business_role", "businessType": "collaboration_task", "taskStage": "assignment", "approvalType": "single", "dueDays": 1, "allowReject": true, "allowTransfer": false, "allowRollback": false}}},
+      {"id": "execution", "type": "approval", "position": {"x": 280, "y": 280}, "data": {"label": "执行与提交交付", "config": {"assigneeStrategy": "business_role", "businessType": "collaboration_task", "taskStage": "execution", "approvalType": "single", "dueDays": 1, "allowReject": true, "allowTransfer": false, "allowRollback": false}}},
+      {"id": "review", "type": "approval", "position": {"x": 280, "y": 420}, "data": {"label": "负责人审核", "config": {"assigneeStrategy": "business_role", "businessType": "collaboration_task", "taskStage": "review", "approvalType": "single", "dueDays": 1, "allowReject": true, "allowTransfer": false, "allowRollback": false}}},
+      {"id": "acceptance", "type": "approval", "position": {"x": 280, "y": 560}, "data": {"label": "正式验收", "config": {"assigneeStrategy": "business_role", "businessType": "collaboration_task", "taskStage": "acceptance", "approvalType": "single", "dueDays": 1, "allowReject": true, "allowTransfer": false, "allowRollback": false}}},
+      {"id": "end", "type": "end", "position": {"x": 280, "y": 700}, "data": {"label": "任务完成", "config": {}}}
+    ],
+    "edges": [
+      {"id": "start-assignment", "source": "start", "target": "assignment"},
+      {"id": "assignment-execution", "source": "assignment", "target": "execution"},
+      {"id": "execution-review", "source": "execution", "target": "review"},
+      {"id": "review-acceptance", "source": "review", "target": "acceptance"},
+      {"id": "acceptance-end", "source": "acceptance", "target": "end"}
+    ],
+    "viewport": {"x": 0, "y": 0, "zoom": 1}
+  }$json$::jsonb;
+BEGIN
+  INSERT INTO flow_definitions(id, key, name, description, category, status, created_at, updated_at)
+  VALUES (
+    uuid_generate_v4(),
+    'task_lifecycle',
+    '任务交付与验收',
+    '默认任务链：发布 → 认领/分配 → 执行 → 审核 → 验收 → 完成。可在流程设计器调整标签与布局；增删分支属后续迭代。',
+    'task',
+    0,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (key) DO NOTHING;
+
+  SELECT id INTO target_definition_id FROM flow_definitions WHERE key = 'task_lifecycle' FOR UPDATE;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM flow_definition_versions
+    WHERE definition_id = target_definition_id AND status = 1
+  ) THEN
+    INSERT INTO flow_definition_versions(id, definition_id, version, bpmn_data, status, published_at, created_at)
+    VALUES (uuid_generate_v4(), target_definition_id, 1, graph, 1, NOW(), NOW());
+    UPDATE flow_definitions SET status = 1, updated_at = NOW() WHERE id = target_definition_id;
+  END IF;
+END $migration$;

--- a/docs/api.md
+++ b/docs/api.md
@@ -135,7 +135,7 @@ POST /api/v1/contracts
 - 入会：`/member/applications`、审核 approve/reject/supplement（新申请走 `member_application` 流程实例）、`/member/profiles`
 - 面试：`/interviews`、sessions、evaluations、stats
 - 会议：`/meetings`、attendees、agendas、votes
-- 任务：`/tasks`、指派/转交/评论/附件、`/tasks/my/*`
+- 任务：`/tasks`、指派/转交/评论/附件、`/tasks/my/*`；开启审核验收的新任务走 `task_lifecycle` 流程实例（`GET|POST /tasks/:id/workflow`，拒绝终止实例）
 - 实习：`/internships`、complete/report、stats
 - 请假：`GET|POST /leave`、`GET /leave/my`、`GET /leave/types`、`GET /leave/balance`、`GET /leave/stats`、`PUT /leave/:id/approve|reject`
 

--- a/frontend/src/api/taskWorkflow.ts
+++ b/frontend/src/api/taskWorkflow.ts
@@ -3,7 +3,7 @@ import type { TaskLog, TaskPerson } from '@/types/api';
 export interface TaskWorkflow {
   assignment_mode: string; revision: number; task_id: string; title: string; instance_id: string; stage: string; submission: string;
   creator: TaskPerson; assignee?: TaskPerson; reviewer: TaskPerson; acceptor: TaskPerson;
-  can_start: boolean; can_pause: boolean; can_resume: boolean; can_submit: boolean; can_approve: boolean; can_return: boolean; updated_at: string; history: TaskLog[];
+  can_start: boolean; can_pause: boolean; can_resume: boolean; can_submit: boolean; can_approve: boolean; can_return: boolean; can_reject: boolean; can_claim: boolean; updated_at: string; history: TaskLog[];
 }
 export function getTaskWorkflow(id: string): Promise<TaskWorkflow> { return request.get(`/tasks/${id}/workflow`); }
-export function actTaskWorkflow(id: string, action: 'start' | 'pause' | 'resume' | 'submit' | 'approve' | 'return', comment: string, revision: number): Promise<TaskWorkflow> { return request.post(`/tasks/${id}/workflow/actions`, { action, comment, revision }); }
+export function actTaskWorkflow(id: string, action: 'start' | 'pause' | 'resume' | 'submit' | 'approve' | 'return' | 'reject' | 'claim', comment: string, revision: number): Promise<TaskWorkflow> { return request.post(`/tasks/${id}/workflow/actions`, { action, comment, revision }); }

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -488,6 +488,7 @@
       "rejected": "Rejected; the workflow stopped",
       "claimed": "Task claimed",
       "closed": "This task workflow has ended. History is kept.",
+      "loadFailed": "Failed to load the task workflow. Refresh and try again.",
       "waitingAssignee": "Waiting for an assignee",
       "assignmentMode": "Assignment",
       "assignmentManual": "Manual / claim",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -466,5 +466,40 @@
       "supplementHint": "More materials were requested. Wait for the applicant to resubmit.",
       "viewFlow": "Open workflow instance"
     }
+  },
+  "task": {
+    "engine": {
+      "title": "Task review progress",
+      "hint": "New tasks use publish → claim/assign → execute → review → accept. Edit the task_lifecycle definition in the designer to publish a new version. Timeout escalation and extra auto-assign strategies are follow-ups.",
+      "viewFlow": "Open workflow instance",
+      "refresh": "Refresh progress",
+      "comment": "Delivery note or review comment",
+      "commentRequired": "Please enter 1–5000 characters",
+      "updated": "Task workflow updated",
+      "approve": "Sign off",
+      "reject": "Reject and stop",
+      "return": "Return for rework",
+      "claim": "Claim task",
+      "submit": "Submit delivery",
+      "start": "Start work",
+      "pause": "Hold",
+      "resume": "Resume",
+      "approved": "Workflow advanced",
+      "rejected": "Rejected; the workflow stopped",
+      "claimed": "Task claimed",
+      "closed": "This task workflow has ended. History is kept.",
+      "waitingAssignee": "Waiting for an assignee",
+      "assignmentMode": "Assignment",
+      "assignmentManual": "Manual / claim",
+      "submission": "Delivery note",
+      "submissionEmpty": "The assignee has not submitted a delivery note",
+      "steps": {
+        "assignment": "Claim / assign",
+        "execution": "Execute",
+        "review": "Review",
+        "acceptance": "Accept",
+        "completed": "Done"
+      }
+    }
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -466,5 +466,40 @@
       "supplementHint": "已要求补充材料，请等待申请人重新提交。",
       "viewFlow": "查看流程实例"
     }
+  },
+  "task": {
+    "engine": {
+      "title": "任务审批进度",
+      "hint": "新任务走默认发布 → 认领/分配 → 执行 → 审核 → 验收链。可在流程设计器编辑 task_lifecycle 后发布新版本。超时升级与轮询分配属后续迭代。",
+      "viewFlow": "查看流程实例",
+      "refresh": "刷新进度",
+      "comment": "交付说明或审批意见",
+      "commentRequired": "请填写 1 至 5000 字说明",
+      "updated": "任务流程已更新",
+      "approve": "签字通过",
+      "reject": "拒绝并终止",
+      "return": "退回返工",
+      "claim": "认领任务",
+      "submit": "提交交付",
+      "start": "开始处理",
+      "pause": "暂时挂起",
+      "resume": "恢复处理",
+      "approved": "已推进流程",
+      "rejected": "已拒绝并终止流程",
+      "claimed": "已认领任务",
+      "closed": "该任务流程已结束，历史记录仍保留。",
+      "waitingAssignee": "等待指定执行人",
+      "assignmentMode": "分配方式",
+      "assignmentManual": "手动指定 / 认领",
+      "submission": "交付说明",
+      "submissionEmpty": "执行人尚未提交交付说明",
+      "steps": {
+        "assignment": "认领 / 分配",
+        "execution": "执行",
+        "review": "审核",
+        "acceptance": "验收",
+        "completed": "完成"
+      }
+    }
   }
 }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -488,6 +488,7 @@
       "rejected": "已拒绝并终止流程",
       "claimed": "已认领任务",
       "closed": "该任务流程已结束，历史记录仍保留。",
+      "loadFailed": "任务流程加载失败，请刷新后重试。",
       "waitingAssignee": "等待指定执行人",
       "assignmentMode": "分配方式",
       "assignmentManual": "手动指定 / 认领",

--- a/frontend/src/pages/task/FormModal.tsx
+++ b/frontend/src/pages/task/FormModal.tsx
@@ -14,7 +14,7 @@ export default function FormModal({ open, editing, onCancel, onSubmit }: Props) 
   useEffect(() => {
     if (!open) return;
     form.resetFields();
-    form.setFieldsValue(editing ? { title: editing.title, description: editing.description, priority: editing.priority, tags: editing.tags, due_date: editing.due_date ? dayjs(editing.due_date) : undefined } : { priority: 1 });
+    form.setFieldsValue(editing ? { title: editing.title, description: editing.description, priority: editing.priority, tags: editing.tags, due_date: editing.due_date ? dayjs(editing.due_date) : undefined } : { priority: 1, use_workflow: true });
   }, [open, editing, form]);
   return <Modal title={editing ? '编辑任务' : '安排一项任务'} open={open} onCancel={() => { if (!busy) onCancel(); }} onOk={() => form.submit()} confirmLoading={busy} okText={editing ? '保存修改' : '创建任务'} cancelText="暂不保存">
     <Form form={form} layout="vertical" onFinish={async values => {

--- a/frontend/src/pages/task/WorkflowPanel.module.css
+++ b/frontend/src/pages/task/WorkflowPanel.module.css
@@ -1,0 +1,8 @@
+.panel { margin:24px 0; padding-top:20px; border-top:1px solid var(--sb-border); }
+.heading { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:20px; }
+.heading h3 { margin:0; font-size:18px; }
+.form { margin:20px 0; padding:20px; background:var(--sb-bg); border-radius:10px; }
+.hint, .panel p { color:var(--sb-muted); font-size:13px; line-height:1.8; }
+.panel h4 { margin:24px 0; }
+.placeholder { min-height:120px; }
+@media(max-width:600px) { .form { padding:16px; } }

--- a/frontend/src/pages/task/WorkflowPanel.tsx
+++ b/frontend/src/pages/task/WorkflowPanel.tsx
@@ -1,46 +1,108 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, Button, Descriptions, Input, Modal, Space, Spin, Steps, Timeline, Typography, message } from 'antd';
-import dayjs from 'dayjs';
+import { Alert, Button, Form, Input, Space, Spin, Steps, message } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import { actTaskWorkflow, getTaskWorkflow, type TaskWorkflow } from '@/api/taskWorkflow';
-import styles from './TaskWorkspace.module.css';
+import { TASK_ENGINE_STAGES, taskEngineClosed, taskEngineStatus, taskEngineStep } from './engineChain';
+import styles from './WorkflowPanel.module.css';
+
 interface Props { taskId: string; onChanged: () => void }
-const stages = ['assignment', 'execution', 'review', 'acceptance', 'completed'];
-export const workflowStageNames: Record<string, string> = { assignment: '待分配', execution: '执行中', review: '待审核', acceptance: '待验收', completed: '已验收', cancelled: '已取消' };
-const actionNames: Record<string, string> = { workflow_start: '开始处理', workflow_pause: '暂停处理', workflow_resume: '恢复处理', workflow_submit: '提交交付', workflow_approve: '正式签字', workflow_return: '退回返工' };
+
 export default function WorkflowPanel({ taskId, onChanged }: Props) {
+  const { t } = useTranslation();
+  const [form] = Form.useForm<{ comment?: string }>();
   const [flow, setFlow] = useState<TaskWorkflow | null>(null);
   const [error, setError] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [comment, setComment] = useState('');
-  const [modal, holder] = Modal.useModal();
   const sequence = useRef(0);
   const invalidate = useCallback(() => { sequence.current++; }, []);
   const load = useCallback(async () => {
     const current = ++sequence.current;
-    try { const result = await getTaskWorkflow(taskId); if (sequence.current === current) { setFlow(result); setError(false); } }
-    catch { if (sequence.current === current) setError(true); }
+    try {
+      const result = await getTaskWorkflow(taskId);
+      if (sequence.current === current) { setFlow(result); setError(false); }
+    } catch {
+      if (sequence.current === current) setError(true);
+    }
   }, [taskId]);
-  useEffect(() => { setFlow(null); setComment(''); void load(); return invalidate; }, [load, invalidate]);
-  const move = async (action: 'start' | 'pause' | 'resume') => {
-    if (!flow || busy) return; setBusy(true);
-    try { const result = await actTaskWorkflow(taskId, action, ({ start: '执行人开始处理', pause: '执行人暂时暂停', resume: '执行人恢复处理' })[action], flow.revision); setFlow(result); onChanged(); } finally { setBusy(false); }
+  useEffect(() => { setFlow(null); form.resetFields(); void load(); return invalidate; }, [load, invalidate, form]);
+
+  const run = async (action: 'start' | 'pause' | 'resume' | 'submit' | 'approve' | 'return' | 'reject' | 'claim', ok: string, requireComment: boolean) => {
+    if (!flow || busy) return;
+    const comment = (form.getFieldValue('comment') || '').trim();
+    if (requireComment && !comment) {
+      form.setFields([{ name: 'comment', errors: [t('task.engine.commentRequired')] }]);
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await actTaskWorkflow(taskId, action, comment || t('task.engine.updated'), flow.revision);
+      setFlow(result);
+      form.resetFields();
+      message.success(ok);
+      onChanged();
+    } finally {
+      setBusy(false);
+    }
   };
-  const act = (action: 'submit' | 'approve' | 'return') => {
-    if (!flow || !comment.trim() || busy) return;
-    modal.confirm({ title: action === 'submit' ? '提交这份交付说明？' : action === 'return' ? '退回给执行人返工？' : '确认以本人身份签字？', content: action === 'approve' ? '本次意见将记入审批历史。审核通过后还需完成正式验收。' : comment.trim(), okText: action === 'return' ? '退回返工' : '确认提交', cancelText: '继续检查', onOk: async () => {
-      setBusy(true);
-      try { const result = await actTaskWorkflow(taskId, action, comment.trim(), flow.revision); setFlow(result); setComment(''); message.success('任务流程已更新'); onChanged(); } finally { setBusy(false); }
-    } });
+
+  const closed = flow ? taskEngineClosed(flow.stage) : false;
+  const person = (stage: string) => {
+    if (!flow) return undefined;
+    if (stage === 'assignment') return flow.creator.name;
+    if (stage === 'execution') return flow.assignee?.name || t('task.engine.waitingAssignee');
+    if (stage === 'review') return flow.reviewer.name;
+    if (stage === 'acceptance') return flow.acceptor.name;
+    return undefined;
   };
-  return <section aria-label="任务审核验收">{holder}
-    {error && <Alert type="error" showIcon message="审批进度暂时无法读取" description="仅指定参与人可查看和处理本任务审批。" action={<Button onClick={() => void load()}>重试</Button>} />}
-    {!flow && !error && <Spin tip="正在读取审批进度"><div style={{ minHeight: 120 }} /></Spin>}
-    {flow && <><Typography.Title level={4}>{flow.title}</Typography.Title><Button size="small" disabled={busy} onClick={() => void load()} style={{ marginBottom: 16 }}>刷新审批进度</Button><Steps size="small" direction="vertical" current={Math.max(0, stages.indexOf(flow.stage))} status={flow.stage === 'cancelled' ? 'error' : flow.stage === 'completed' ? 'finish' : 'process'} items={stages.map(stage => ({ title: workflowStageNames[stage], description: stage === 'assignment' ? flow.creator.name : stage === 'execution' ? flow.assignee?.name || '等待指定执行人' : stage === 'review' ? flow.reviewer.name : stage === 'acceptance' ? flow.acceptor.name : undefined }))} />
-      <Space wrap style={{ marginBlock: 16 }}>{flow.can_start && <Button type="primary" loading={busy} onClick={() => void move('start')}>开始处理</Button>}{flow.can_pause && <Button disabled={busy} onClick={() => void move('pause')}>暂时挂起</Button>}{flow.can_resume && <Button type="primary" loading={busy} onClick={() => void move('resume')}>恢复处理</Button>}</Space>
-      {flow.stage === 'cancelled' && <Alert type="warning" message="该任务流程已取消，历史记录仍保留" />}
-      <Descriptions column={1} size="small" style={{ marginTop: 20 }}><Descriptions.Item label="分配方式">{({ department: "部门内按待办量分配", role: "部门内按角色及待办量分配", round_robin: "部门内轮流分配" } as Record<string, string>)[flow.assignment_mode] || "手动指定"}</Descriptions.Item><Descriptions.Item label="交付说明"><span style={{ whiteSpace: 'pre-wrap' }}>{flow.submission || '执行人尚未提交交付说明'}</span></Descriptions.Item></Descriptions>
-      {(flow.can_submit || flow.can_approve) && <div className={styles.composer}><label htmlFor={`task-workflow-comment-${taskId}`}>{flow.can_submit ? '本次交付内容' : '审核 / 验收意见'}</label><Input.TextArea id={`task-workflow-comment-${taskId}`} value={comment} onChange={e => setComment(e.target.value)} rows={4} maxLength={5000} showCount disabled={busy} placeholder={flow.can_submit ? '写明完成情况、成果位置和需要确认的事项' : '写明检查结果；退回时说明需要修改的内容'} /><Space wrap style={{ marginTop: 16 }}>{flow.can_submit && <Button type="primary" disabled={!comment.trim()} loading={busy} onClick={() => act('submit')}>提交交付</Button>}{flow.can_approve && <Button type="primary" disabled={!comment.trim()} loading={busy} onClick={() => act('approve')}>{flow.stage === 'acceptance' ? '签字验收' : '签字通过审核'}</Button>}{flow.can_return && <Button danger disabled={!comment.trim() || busy} onClick={() => act('return')}>退回返工</Button>}</Space></div>}
-      <Typography.Title level={5}>审批记录</Typography.Title>{!flow.history.length && <Typography.Text type="secondary">尚未提交交付或签字。</Typography.Text>}<Timeline items={flow.history.map(log => ({ children: <><strong>{log.operator.name} · {actionNames[log.action_type] || '流程更新'}</strong><p style={{ whiteSpace: 'pre-wrap' }}>{log.comment}</p><small>{dayjs(log.created_at).format('YYYY-MM-DD HH:mm')}</small></> }))} />
-    </>}
-  </section>;
+
+  return (
+    <section className={styles.panel} aria-label={t('task.engine.title')}>
+      <div className={styles.heading}>
+        <h3>{t('task.engine.title')}</h3>
+        <Button size="small" disabled={busy} onClick={() => void load()}>{t('task.engine.refresh')}</Button>
+      </div>
+      {error && <Alert type="error" showIcon message={t('task.engine.closed')} action={<Button onClick={() => void load()}>{t('task.engine.refresh')}</Button>} />}
+      {!flow && !error && <Spin tip={t('common.loading')}><div className={styles.placeholder} /></Spin>}
+      {flow && (
+        <>
+          <Steps
+            direction="vertical"
+            size="small"
+            current={taskEngineStep(flow.stage)}
+            status={taskEngineStatus(flow.stage)}
+            items={TASK_ENGINE_STAGES.map((stage) => ({ title: t(`task.engine.steps.${stage}`), description: person(stage) }))}
+          />
+          {flow.instance_id && (
+            <p>
+              <Link to={`/workflow/instances?instance_id=${encodeURIComponent(flow.instance_id)}`}>
+                {t('task.engine.viewFlow')}
+              </Link>
+            </p>
+          )}
+          <p className={styles.hint}>{t('task.engine.hint')}</p>
+          <p className={styles.hint}>{t('task.engine.assignmentMode')}：{t('task.engine.assignmentManual')}</p>
+          <p className={styles.hint}>{t('task.engine.submission')}：{flow.submission || t('task.engine.submissionEmpty')}</p>
+          {closed && <p className={styles.hint}>{t('task.engine.closed')}</p>}
+          {!closed && (flow.can_start || flow.can_pause || flow.can_resume || flow.can_submit || flow.can_approve || flow.can_claim) && (
+            <Form form={form} layout="vertical" className={styles.form}>
+              <Form.Item name="comment" label={t('task.engine.comment')} rules={[{ max: 5000 }]}>
+                <Input.TextArea rows={3} maxLength={5000} />
+              </Form.Item>
+              <Space wrap>
+                {flow.can_start && <Button type="primary" loading={busy} onClick={() => void run('start', t('task.engine.updated'), false)}>{t('task.engine.start')}</Button>}
+                {flow.can_pause && <Button loading={busy} onClick={() => void run('pause', t('task.engine.updated'), false)}>{t('task.engine.pause')}</Button>}
+                {flow.can_resume && <Button type="primary" loading={busy} onClick={() => void run('resume', t('task.engine.updated'), false)}>{t('task.engine.resume')}</Button>}
+                {flow.can_claim && <Button type="primary" loading={busy} onClick={() => void run('claim', t('task.engine.claimed'), true)}>{t('task.engine.claim')}</Button>}
+                {flow.can_submit && <Button type="primary" loading={busy} onClick={() => void run('submit', t('task.engine.updated'), true)}>{t('task.engine.submit')}</Button>}
+                {flow.can_approve && <Button type="primary" loading={busy} onClick={() => void run('approve', t('task.engine.approved'), true)}>{t('task.engine.approve')}</Button>}
+                {flow.can_return && <Button loading={busy} onClick={() => void run('return', t('task.engine.updated'), true)}>{t('task.engine.return')}</Button>}
+                {flow.can_reject && <Button danger loading={busy} onClick={() => void run('reject', t('task.engine.rejected'), true)}>{t('task.engine.reject')}</Button>}
+              </Space>
+            </Form>
+          )}
+        </>
+      )}
+    </section>
+  );
 }

--- a/frontend/src/pages/task/WorkflowPanel.tsx
+++ b/frontend/src/pages/task/WorkflowPanel.tsx
@@ -62,7 +62,7 @@ export default function WorkflowPanel({ taskId, onChanged }: Props) {
         <h3>{t('task.engine.title')}</h3>
         <Button size="small" disabled={busy} onClick={() => void load()}>{t('task.engine.refresh')}</Button>
       </div>
-      {error && <Alert type="error" showIcon message={t('task.engine.closed')} action={<Button onClick={() => void load()}>{t('task.engine.refresh')}</Button>} />}
+      {error && <Alert type="error" showIcon message={t('task.engine.loadFailed')} action={<Button onClick={() => void load()}>{t('task.engine.refresh')}</Button>} />}
       {!flow && !error && <Spin tip={t('common.loading')}><div className={styles.placeholder} /></Spin>}
       {flow && (
         <>

--- a/frontend/src/pages/task/engineChain.test.ts
+++ b/frontend/src/pages/task/engineChain.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { taskEngineClosed, taskEngineStatus, taskEngineStep } from './engineChain';
+
+describe('task engine helpers', () => {
+  it('hides actions for completed, cancelled, and rejected', () => {
+    expect(taskEngineClosed('assignment')).toBe(false);
+    expect(taskEngineClosed('review')).toBe(false);
+    expect(taskEngineClosed('completed')).toBe(true);
+    expect(taskEngineClosed('cancelled')).toBe(true);
+    expect(taskEngineClosed('rejected')).toBe(true);
+  });
+
+  it('maps stages to step index and status', () => {
+    expect(taskEngineStep('assignment')).toBe(0);
+    expect(taskEngineStep('acceptance')).toBe(3);
+    expect(taskEngineStep('rejected')).toBe(0);
+    expect(taskEngineStatus('rejected')).toBe('error');
+    expect(taskEngineStatus('completed')).toBe('finish');
+    expect(taskEngineStatus('review')).toBe('process');
+  });
+});

--- a/frontend/src/pages/task/engineChain.ts
+++ b/frontend/src/pages/task/engineChain.ts
@@ -1,0 +1,18 @@
+export const TASK_ENGINE_STAGES = ['assignment', 'execution', 'review', 'acceptance', 'completed'] as const;
+
+export type TaskEngineStage = (typeof TASK_ENGINE_STAGES)[number] | 'cancelled' | 'rejected';
+
+export function taskEngineClosed(stage: string): boolean {
+  return stage === 'completed' || stage === 'cancelled' || stage === 'rejected';
+}
+
+export function taskEngineStep(stage: string): number {
+  const index = TASK_ENGINE_STAGES.indexOf(stage as (typeof TASK_ENGINE_STAGES)[number]);
+  return index < 0 ? 0 : index;
+}
+
+export function taskEngineStatus(stage: string): 'error' | 'finish' | 'process' {
+  if (stage === 'cancelled' || stage === 'rejected') return 'error';
+  if (stage === 'completed') return 'finish';
+  return 'process';
+}

--- a/frontend/src/pages/task/engineI18n.test.ts
+++ b/frontend/src/pages/task/engineI18n.test.ts
@@ -5,7 +5,7 @@ import zh from '../../locales/zh-CN.json';
 const keys = [
   'title', 'hint', 'viewFlow', 'refresh', 'comment', 'commentRequired', 'updated',
   'approve', 'reject', 'return', 'claim', 'submit', 'start', 'pause', 'resume',
-  'approved', 'rejected', 'claimed', 'closed',
+  'approved', 'rejected', 'claimed', 'closed', 'loadFailed',
   'steps.assignment', 'steps.execution', 'steps.review', 'steps.acceptance', 'steps.completed',
   'waitingAssignee', 'assignmentMode', 'assignmentManual', 'submission', 'submissionEmpty',
 ] as const;

--- a/frontend/src/pages/task/engineI18n.test.ts
+++ b/frontend/src/pages/task/engineI18n.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import en from '../../locales/en-US.json';
+import zh from '../../locales/zh-CN.json';
+
+const keys = [
+  'title', 'hint', 'viewFlow', 'refresh', 'comment', 'commentRequired', 'updated',
+  'approve', 'reject', 'return', 'claim', 'submit', 'start', 'pause', 'resume',
+  'approved', 'rejected', 'claimed', 'closed',
+  'steps.assignment', 'steps.execution', 'steps.review', 'steps.acceptance', 'steps.completed',
+  'waitingAssignee', 'assignmentMode', 'assignmentManual', 'submission', 'submissionEmpty',
+] as const;
+
+function pick(obj: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object') {
+      return (acc as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
+}
+
+describe('task engine i18n', () => {
+  it('has matching zh-CN and en-US keys', () => {
+    keys.forEach((key) => {
+      expect(pick(zh.task.engine, key), `zh missing task.engine.${key}`).toBeTruthy();
+      expect(pick(en.task.engine, key), `en missing task.engine.${key}`).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/pages/task/meta.ts
+++ b/frontend/src/pages/task/meta.ts
@@ -23,4 +23,4 @@ export const BOARD_COLUMNS: Array<{ status: 0 | 1 | 4 | 2 | 3; title: string }> 
   { status: 3, title: '已取消' },
 ];
 
-export const TaskWorkflowStageMap: Record<string, string> = { assignment: "待分配", execution: "执行中", review: "待审核", acceptance: "待验收", completed: "已验收", cancelled: "已取消" };
+export const TaskWorkflowStageMap: Record<string, string> = { assignment: "待分配", execution: "执行中", review: "待审核", acceptance: "待验收", completed: "已验收", cancelled: "已取消", rejected: "已拒绝" };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

将任务流转接到现有流程引擎（`backend/internal/workflow/`），**不重写引擎**。沿用已有定义 key=`task_lifecycle`、业务类型 `collaboration_task`，以及 `TaskCheckpoint` / 业务指派。

新任务在创建表单默认开启审核验收，启动已发布定义 **`task_lifecycle`**：

发布 → 认领/分配 → 执行 → 审核 → 验收 → 完成。

- 审核/验收**拒绝**走 `CompleteTaskApproval`（业务事务内 CompleteTask + 若实例仍 running 则 Terminate），取消全部 pending 待办，任务状态=已取消、环节=`rejected`，其他人不能再 approve 救活。
- **认领**：待分配且可见的成员可将自己设为执行人，引擎跳过分配节点进入执行（取消发布人分配待办）。
- 指定执行人仍走原 `Assign` + `TaskCheckpoint(assignment)`；提交/退回仍走 `TaskCheckpoint`。
- 未带 `workflow` 的创建、以及已在途的无实例任务，继续走原状态机（开始/完成/取消）。
- 通用流程待办接口仍禁止直接 CompleteTask（`collaboration_task` 受保护）。

### 如何以后改流程

在「流程设计器」打开 key=`task_lifecycle` 的定义，改标签/布局后发布新版本即可。phase-1 校验仍要求保留 **分配 → 执行 → 审核 → 验收** 脊骨（`business_role` + `approvalType=single`）。

## 关联 Issue

Refs #65

（本切片未覆盖全部自动分配策略、超时升级、可视化设计器重做、任务委托表单、≥70% 全模块覆盖，故不 Closes。）

## 测试方式

1. 基于最新 `main`（含 #174 / `000061`）迁移到 `000062`。
2. `cd backend && go test ./internal/workflow/engine/ ./internal/workflow/engine/nodes/ ./internal/task/service/ ./internal/member/service/`
3. `cd frontend && npx vitest --run src/pages/task/engineI18n.test.ts src/pages/task/engineChain.test.ts`
4. `go build ./cmd/server`
5. 启动后创建任务并打开「审核与正式验收」：应启动引擎实例，详情里看到「任务审批进度」。
6. 不指定执行人：有权限的成员可认领，进入执行。
7. 执行人提交 → 审核人同意 → 验收人同意：任务完成，实例 completed。
8. 审核或验收拒绝：任务=已取消，流程终止，剩余待办取消，不能再同意。
9. 不开启审核验收的旧路径任务仍可直接改状态。

### 自测记录

- `go test`：引擎启动→分配同意→执行→审核→验收→完成；拒绝终止且另一方无法同意；认领进入执行。
- 任务服务：拒绝后实例 terminated + 任务 cancelled；认领推进 assignment。
- `vitest`：zh-CN / en-US 键对齐；closed/step helpers。
- `go build ./cmd/server` 通过。
- 本环境无完整登录联调，未做浏览器走查。

## 截图 / GIF

前端进度面板改为与入会 `EngineChainPanel` 同一套 Steps + 表单样式，并补 zh-CN / en-US。完整登录联调截图待补。

| 页面/功能 | 截图 |
|----------|------|
| 任务审批进度 | 待有库环境补 |

## 注意事项

- 迁移 `000062` 仅在 **没有已发布版本** 时写入默认图，不会覆盖 000046 或之后在设计器里发布的版本。回滚不删除 `task_lifecycle`（000046 已拥有该 key）。
- 自动分配仍只有现有 department/role/round_robin 钩子；未做新策略。
- **TODO(#65)**：超时升级/重新分配（节点已有 `dueDays`，无调度钩子）。
- 跨部门转办签字链仍未完成（原冲突提示保留），委托表单不在本切片。
- 不影响入会 #174、backup、请假、公告。

## 检查清单

- [x] 代码遵循项目开发规范（参考 docs/dev-guide/）
- [x] 已进行自测（单测 + build）
- [x] 已添加/更新必要的文档（`docs/api.md` 一行）
- [ ] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码（console.log / println 等）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f5e371f-ca52-5900-acc6-fd98eb0bedd4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f5e371f-ca52-5900-acc6-fd98eb0bedd4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

