### PR TITLE
feat(monitor): WebSocket 实时推送、慢查询与 API 分位数

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -440,6 +440,8 @@ func main() {
 	schedEng := schedService.NewEngine(schedR, redis.Client(), schedService.NewNotifAlerter(notifSvc))
 	schedSvc := schedService.NewService(schedR, schedEng)
 
+	monitorSvc := monitorService.New(database.DB(), redis.Client())
+
 	// 10. API 路由组
 	api := r.Group("/api/v1")
 	// API 组限流：全局 1000 req/s（#14 固定窗口）+ 令牌桶 IP/接口 + 熔断（#75）
@@ -533,8 +535,8 @@ func main() {
 		cacheAdminH := cacheadminHandler.NewCacheHandler(cacheAdminSvc)
 		cacheadminHandler.RegisterRoutes(protected, cacheAdminH, cacheService)
 
-		// 运维监控仪表盘（/monitor，#87 phase-1）
-		monitorH := monitorHandler.New(monitorService.New(database.DB(), redis.Client()))
+		// 运维监控仪表盘（/monitor，#87）
+		monitorH := monitorHandler.New(monitorSvc)
 		monitorHandler.RegisterRoutes(protected, monitorH, cacheService)
 
 		// 数据备份与恢复（/system/backups，#88 phase-1）
@@ -574,6 +576,7 @@ func main() {
 
 	// WebSocket 路由（独立于 API 组，JWT 认证在 handler 内部完成）
 	notifHandler.RegisterWSRoute(r, wsHandler)
+	monitorHandler.RegisterWSRoute(r, monitorHandler.NewWSHandler(monitorSvc, &cfg.JWT, cacheService, cfg.CORS.AllowedOrigins))
 
 	// 11. 404 处理
 	r.NoRoute(func(c *gin.Context) {

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -576,7 +576,7 @@ func main() {
 
 	// WebSocket 路由（独立于 API 组，JWT 认证在 handler 内部完成）
 	notifHandler.RegisterWSRoute(r, wsHandler)
-	monitorHandler.RegisterWSRoute(r, monitorHandler.NewWSHandler(monitorSvc, &cfg.JWT, cacheService, cfg.CORS.AllowedOrigins))
+	monitorHandler.RegisterWSRoute(r, monitorHandler.NewWSHandler(monitorSvc, &cfg.JWT, cacheService, cfg.CORS.AllowedOrigins).WithRedis(redis.Client()))
 
 	// 11. 404 处理
 	r.NoRoute(func(c *gin.Context) {

--- a/backend/internal/monitor/dto/dto.go
+++ b/backend/internal/monitor/dto/dto.go
@@ -67,8 +67,7 @@ type RedisStatus struct {
 	CollectedAt      string  `json:"collected_at"`
 }
 
-// APIStats is GET /monitor/api-stats. Phase-1 reads Prometheus counters only.
-// P50/P95/P99 persistence is deferred (scrape /metrics histograms later).
+// APIStats is GET /monitor/api-stats (counters + latency percentiles).
 type APIStats struct {
 	Available       bool     `json:"available"`
 	Source          string   `json:"source"`
@@ -80,4 +79,36 @@ type APIStats struct {
 	P99Seconds      *float64 `json:"p99_seconds"`
 	PercentilesNote string   `json:"percentiles_note"`
 	CollectedAt     string   `json:"collected_at"`
+}
+
+// SlowQuery is one statement or Redis command sample.
+type SlowQuery struct {
+	Query       string  `json:"query"`
+	Calls       int64   `json:"calls"`
+	MeanTimeMs  float64 `json:"mean_time_ms"`
+	TotalTimeMs float64 `json:"total_time_ms"`
+	MaxTimeMs   float64 `json:"max_time_ms"`
+	Rows        int64   `json:"rows"`
+	Source      string  `json:"source"`
+	CollectedAt string  `json:"collected_at,omitempty"`
+}
+
+// SlowQueries is GET /monitor/slow-queries.
+type SlowQueries struct {
+	Available     bool        `json:"available"`
+	Source        string      `json:"source"`
+	Note          string      `json:"note"`
+	Queries       []SlowQuery `json:"queries"`
+	RedisCommands []SlowQuery `json:"redis_commands"`
+	CollectedAt   string      `json:"collected_at"`
+}
+
+// LiveSnapshot is pushed on /ws/monitor (partial fields allowed).
+type LiveSnapshot struct {
+	Server   *ServerStatus   `json:"server,omitempty"`
+	App      *AppHealth      `json:"app,omitempty"`
+	Database *DatabaseStatus `json:"database,omitempty"`
+	Redis    *RedisStatus    `json:"redis,omitempty"`
+	API      *APIStats       `json:"api,omitempty"`
+	Errors   []string        `json:"errors,omitempty"`
 }

--- a/backend/internal/monitor/handler/handler.go
+++ b/backend/internal/monitor/handler/handler.go
@@ -28,6 +28,7 @@ func RegisterRoutes(r *gin.RouterGroup, h *Handler, cache rbacService.Permission
 	read.GET("/database", h.Database)
 	read.GET("/redis", h.Redis)
 	read.GET("/api-stats", h.APIStats)
+	read.GET("/slow-queries", h.SlowQueries)
 }
 
 // Server 服务器状态
@@ -90,9 +91,9 @@ func (h *Handler) Redis(c *gin.Context) {
 	write(c, out, err)
 }
 
-// APIStats API 调用计数
-// @Summary API 调用计数
-// @Description 复用 Prometheus 计数器；P50/P95 持久化见 percentiles_note
+// APIStats API 调用统计
+// @Summary API 调用统计
+// @Description 请求计数、错误率、P50/P95/P99（最近窗口或直方图插值）
 // @Tags 监控
 // @Produce json
 // @Success 200 {object} response.Response
@@ -102,6 +103,21 @@ func (h *Handler) Redis(c *gin.Context) {
 // @Security BearerAuth
 func (h *Handler) APIStats(c *gin.Context) {
 	out, err := h.svc.APIStats(c.Request.Context())
+	write(c, out, err)
+}
+
+// SlowQueries 慢查询
+// @Summary 慢查询
+// @Description pg_stat_statements（若已安装）或 pg_stat_activity + 进程内 GORM 环；附 Redis SLOWLOG
+// @Tags 监控
+// @Produce json
+// @Success 200 {object} response.Response
+// @Failure 401 {object} response.Response
+// @Failure 403 {object} response.Response
+// @Router /monitor/slow-queries [get]
+// @Security BearerAuth
+func (h *Handler) SlowQueries(c *gin.Context) {
+	out, err := h.svc.SlowQueries(c.Request.Context())
 	write(c, out, err)
 }
 

--- a/backend/internal/monitor/handler/handler_test.go
+++ b/backend/internal/monitor/handler/handler_test.go
@@ -22,6 +22,7 @@ type stubSvc struct {
 	db     *dto.DatabaseStatus
 	redis  *dto.RedisStatus
 	api    *dto.APIStats
+	slow   *dto.SlowQueries
 	err    error
 }
 
@@ -30,6 +31,10 @@ func (s *stubSvc) App(context.Context) (*dto.AppHealth, error)           { retur
 func (s *stubSvc) Database(context.Context) (*dto.DatabaseStatus, error) { return s.db, s.err }
 func (s *stubSvc) Redis(context.Context) (*dto.RedisStatus, error)       { return s.redis, s.err }
 func (s *stubSvc) APIStats(context.Context) (*dto.APIStats, error)       { return s.api, s.err }
+func (s *stubSvc) SlowQueries(context.Context) (*dto.SlowQueries, error) { return s.slow, s.err }
+func (s *stubSvc) Snapshot(context.Context) *dto.LiveSnapshot {
+	return &dto.LiveSnapshot{Server: s.server, App: s.app, Database: s.db, Redis: s.redis, API: s.api}
+}
 
 func doGET(h gin.HandlerFunc, path string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
@@ -47,6 +52,7 @@ func TestHandlerOK(t *testing.T) {
 		db:     &dto.DatabaseStatus{Available: true},
 		redis:  &dto.RedisStatus{Available: true},
 		api:    &dto.APIStats{Available: true, RequestTotal: 3},
+		slow:   &dto.SlowQueries{Available: true, Source: "in_memory"},
 	})
 	cases := []struct {
 		fn   gin.HandlerFunc
@@ -57,6 +63,7 @@ func TestHandlerOK(t *testing.T) {
 		{h.Database, "/api/v1/monitor/database"},
 		{h.Redis, "/api/v1/monitor/redis"},
 		{h.APIStats, "/api/v1/monitor/api-stats"},
+		{h.SlowQueries, "/api/v1/monitor/slow-queries"},
 	}
 	for _, tc := range cases {
 		w := doGET(tc.fn, tc.path)

--- a/backend/internal/monitor/handler/routes_test.go
+++ b/backend/internal/monitor/handler/routes_test.go
@@ -57,4 +57,16 @@ func TestRegisterRoutes_RequiresMonitorRead(t *testing.T) {
 	w = httptest.NewRecorder()
 	denied.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/monitor/app", nil))
 	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	ok := gin.New()
+	ok.Use(func(c *gin.Context) {
+		c.Set(auth.ContextKeyUserID, uid.String())
+		c.Next()
+	})
+	RegisterRoutes(ok.Group("/api/v1"), New(&stubSvc{slow: &dto.SlowQueries{Available: true}}), stubCache{
+		perms: []string{"monitor:read"},
+	})
+	w = httptest.NewRecorder()
+	ok.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/monitor/slow-queries", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/backend/internal/monitor/handler/ws.go
+++ b/backend/internal/monitor/handler/ws.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"fmt"
+
 	"github.com/Yogdunana/StarByte/backend/internal/monitor/service"
 	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
 	"github.com/Yogdunana/StarByte/backend/pkg/config"
@@ -18,6 +20,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 )
 
@@ -43,6 +46,7 @@ type WSHandler struct {
 	svc      service.Service
 	jwt      *config.JWTConfig
 	cache    rbacService.PermissionCacheService
+	rdb      *redis.Client
 	upgrader websocket.Upgrader
 	interval time.Duration
 }
@@ -66,6 +70,14 @@ func NewWSHandler(svc service.Service, jwt *config.JWTConfig, cache rbacService.
 		},
 		interval: defaultPushInterval,
 	}
+}
+
+// WithRedis enables logout-blacklist checks (same key as JWTAuth).
+func (h *WSHandler) WithRedis(rdb *redis.Client) *WSHandler {
+	if h != nil {
+		h.rdb = rdb
+	}
+	return h
 }
 
 // RegisterWSRoute mounts GET /ws/monitor on the engine (auth is inside the handler).
@@ -124,6 +136,23 @@ func wsAuthFail(msg string) *response.AppError {
 	}
 }
 
+func (h *WSHandler) validateAccessToken(ctx context.Context, token string) (*authmiddleware.Claims, error) {
+	claims, err := authmiddleware.ParseToken(token, h.jwt)
+	if err != nil || claims == nil {
+		return nil, wsAuthFail("WebSocket 认证失败：Token 无效或已过期")
+	}
+	if claims.TokenType != authmiddleware.AccessTokenType {
+		return nil, wsAuthFail("WebSocket 认证失败：Token 类型无效")
+	}
+	if h.rdb != nil && claims.ID != "" {
+		n, berr := h.rdb.Exists(ctx, fmt.Sprintf("auth:blacklist:%s", claims.ID)).Result()
+		if berr == nil && n > 0 {
+			return nil, wsAuthFail("WebSocket 认证失败：Token 已失效")
+		}
+	}
+	return claims, nil
+}
+
 func (h *WSHandler) allowMonitorRead(ctx context.Context, userID uuid.UUID) error {
 	if h.cache == nil {
 		return &response.AppError{
@@ -162,9 +191,9 @@ func (h *WSHandler) HandleConnection(c *gin.Context) {
 		response.Error(c, wsAuthFail("WebSocket 认证失败：未配置签发密钥"))
 		return
 	}
-	claims, err := authmiddleware.ParseToken(token, h.jwt)
-	if err != nil || claims == nil {
-		response.Error(c, wsAuthFail("WebSocket 认证失败：Token 无效或已过期"))
+	claims, err := h.validateAccessToken(c.Request.Context(), token)
+	if err != nil {
+		response.Error(c, err)
 		return
 	}
 	userID, err := uuid.Parse(claims.UserID)

--- a/backend/internal/monitor/handler/ws.go
+++ b/backend/internal/monitor/handler/ws.go
@@ -1,0 +1,275 @@
+package handler
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/monitor/service"
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/config"
+	"github.com/Yogdunana/StarByte/backend/pkg/logger"
+	authmiddleware "github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"go.uber.org/zap"
+)
+
+const (
+	monitorWriteTimeout = 10 * time.Second
+	monitorReadIdle     = 60 * time.Second
+	defaultPushInterval = 5 * time.Second
+)
+
+// WSMessage is a client frame on /ws/monitor.
+type WSMessage struct {
+	Type string `json:"type"`
+}
+
+// WSResponse is a server frame on /ws/monitor.
+type WSResponse struct {
+	Type string      `json:"type"`
+	Data interface{} `json:"data,omitempty"`
+}
+
+// WSHandler pushes monitor snapshots after JWT + monitor:read.
+type WSHandler struct {
+	svc      service.Service
+	jwt      *config.JWTConfig
+	cache    rbacService.PermissionCacheService
+	upgrader websocket.Upgrader
+	interval time.Duration
+}
+
+// NewWSHandler builds /ws/monitor. Empty allowedOrigins permits any Origin (dev).
+func NewWSHandler(svc service.Service, jwt *config.JWTConfig, cache rbacService.PermissionCacheService, allowedOrigins []string) *WSHandler {
+	originSet := make(map[string]bool, len(allowedOrigins))
+	for _, origin := range allowedOrigins {
+		originSet[origin] = true
+	}
+	return &WSHandler{
+		svc:   svc,
+		jwt:   jwt,
+		cache: cache,
+		upgrader: websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin: func(r *http.Request) bool {
+				return checkMonitorWSOrigin(r, originSet)
+			},
+		},
+		interval: defaultPushInterval,
+	}
+}
+
+// RegisterWSRoute mounts GET /ws/monitor on the engine (auth is inside the handler).
+func RegisterWSRoute(r gin.IRouter, h *WSHandler) {
+	r.GET("/ws/monitor", h.HandleConnection)
+}
+
+func checkMonitorWSOrigin(r *http.Request, allowed map[string]bool) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	if allowed[origin] {
+		return true
+	}
+	return originMatchesRequestHost(origin, r.Host)
+}
+
+func originMatchesRequestHost(origin, reqHost string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return strings.EqualFold(stripHostPort(u.Host), stripHostPort(reqHost))
+}
+
+func stripHostPort(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return host[1 : len(host)-1]
+	}
+	return host
+}
+
+func extractWSToken(c *gin.Context) string {
+	if token := c.Query("token"); token != "" {
+		return token
+	}
+	authHeader := c.GetHeader("Authorization")
+	if len(authHeader) > 7 && strings.EqualFold(authHeader[:7], "Bearer ") {
+		return authHeader[7:]
+	}
+	return ""
+}
+
+func wsAuthFail(msg string) *response.AppError {
+	return &response.AppError{
+		Code:       response.CodeMonitorWSAuthFail,
+		Message:    msg,
+		HTTPStatus: http.StatusUnauthorized,
+	}
+}
+
+func (h *WSHandler) allowMonitorRead(ctx context.Context, userID uuid.UUID) error {
+	if h.cache == nil {
+		return &response.AppError{
+			Code:       response.CodeMonitorWSForbidden,
+			Message:    "权限缓存不可用",
+			HTTPStatus: http.StatusForbidden,
+		}
+	}
+	perms, isSuper, err := h.cache.GetUserPermissionsAndSuperAdmin(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if isSuper {
+		return nil
+	}
+	for _, p := range perms {
+		if p == "monitor:read" || p == "*" {
+			return nil
+		}
+	}
+	return &response.AppError{
+		Code:       response.CodeMonitorWSForbidden,
+		Message:    "权限不足: monitor:read",
+		HTTPStatus: http.StatusForbidden,
+	}
+}
+
+// HandleConnection GET /ws/monitor
+func (h *WSHandler) HandleConnection(c *gin.Context) {
+	token := extractWSToken(c)
+	if token == "" {
+		response.Error(c, wsAuthFail("WebSocket 认证失败：缺少 Token"))
+		return
+	}
+	if h.jwt == nil {
+		response.Error(c, wsAuthFail("WebSocket 认证失败：未配置签发密钥"))
+		return
+	}
+	claims, err := authmiddleware.ParseToken(token, h.jwt)
+	if err != nil || claims == nil {
+		response.Error(c, wsAuthFail("WebSocket 认证失败：Token 无效或已过期"))
+		return
+	}
+	userID, err := uuid.Parse(claims.UserID)
+	if err != nil {
+		response.Error(c, wsAuthFail("WebSocket 认证失败：无效的用户标识"))
+		return
+	}
+	if err := h.allowMonitorRead(c.Request.Context(), userID); err != nil {
+		response.Error(c, err)
+		return
+	}
+
+	conn, err := h.upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		logger.Error("monitor websocket upgrade failed",
+			zap.String("user_id", userID.String()),
+			zap.Error(err))
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	writer := &safeWS{conn: conn}
+	if err := writer.writeJSON(WSResponse{Type: "auth_result", Data: map[string]bool{"success": true}}); err != nil {
+		_ = conn.Close()
+		return
+	}
+
+	go func() {
+		defer cancel()
+		h.readLoop(ctx, conn, writer)
+	}()
+	go h.pushLoop(ctx, writer)
+
+	<-ctx.Done()
+	if err := conn.Close(); err != nil {
+		logger.Error("monitor websocket close failed",
+			zap.String("user_id", userID.String()),
+			zap.Error(err))
+	}
+}
+
+type safeWS struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+}
+
+func (s *safeWS) writeJSON(v any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_ = s.conn.SetWriteDeadline(time.Now().Add(monitorWriteTimeout))
+	return s.conn.WriteJSON(v)
+}
+
+func (h *WSHandler) readLoop(ctx context.Context, conn *websocket.Conn, writer *safeWS) {
+	_ = conn.SetReadDeadline(time.Now().Add(monitorReadIdle))
+	conn.SetPongHandler(func(string) error {
+		_ = conn.SetReadDeadline(time.Now().Add(monitorReadIdle))
+		return nil
+	})
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			var msg WSMessage
+			if err := conn.ReadJSON(&msg); err != nil {
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					logger.Error("monitor websocket read error", zap.Error(err))
+				}
+				return
+			}
+			_ = conn.SetReadDeadline(time.Now().Add(monitorReadIdle))
+			if msg.Type == "ping" {
+				_ = writer.writeJSON(WSResponse{Type: "pong"})
+			}
+		}
+	}
+}
+
+func (h *WSHandler) pushLoop(ctx context.Context, writer *safeWS) {
+	interval := h.interval
+	if interval <= 0 {
+		interval = defaultPushInterval
+	}
+	h.pushSnapshot(ctx, writer)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.pushSnapshot(ctx, writer)
+		}
+	}
+}
+
+func (h *WSHandler) pushSnapshot(ctx context.Context, writer *safeWS) {
+	if h.svc == nil {
+		return
+	}
+	snap := h.svc.Snapshot(ctx)
+	if err := writer.writeJSON(WSResponse{Type: "snapshot", Data: snap}); err != nil {
+		logger.Error("monitor websocket push failed", zap.Error(err))
+	}
+}

--- a/backend/internal/monitor/handler/ws.go
+++ b/backend/internal/monitor/handler/ws.go
@@ -196,9 +196,9 @@ func (h *WSHandler) HandleConnection(c *gin.Context) {
 
 	go func() {
 		defer cancel()
-		h.readLoop(ctx, conn, writer)
+		h.readLoop(ctx, cancel, conn, writer)
 	}()
-	go h.pushLoop(ctx, writer)
+	go h.pushLoop(ctx, cancel, writer)
 
 	<-ctx.Done()
 	if err := conn.Close(); err != nil {
@@ -220,7 +220,7 @@ func (s *safeWS) writeJSON(v any) error {
 	return s.conn.WriteJSON(v)
 }
 
-func (h *WSHandler) readLoop(ctx context.Context, conn *websocket.Conn, writer *safeWS) {
+func (h *WSHandler) readLoop(ctx context.Context, cancel context.CancelFunc, conn *websocket.Conn, writer *safeWS) {
 	_ = conn.SetReadDeadline(time.Now().Add(monitorReadIdle))
 	conn.SetPongHandler(func(string) error {
 		_ = conn.SetReadDeadline(time.Now().Add(monitorReadIdle))
@@ -240,18 +240,24 @@ func (h *WSHandler) readLoop(ctx context.Context, conn *websocket.Conn, writer *
 			}
 			_ = conn.SetReadDeadline(time.Now().Add(monitorReadIdle))
 			if msg.Type == "ping" {
-				_ = writer.writeJSON(WSResponse{Type: "pong"})
+				if err := writer.writeJSON(WSResponse{Type: "pong"}); err != nil {
+					cancel()
+					return
+				}
 			}
 		}
 	}
 }
 
-func (h *WSHandler) pushLoop(ctx context.Context, writer *safeWS) {
+func (h *WSHandler) pushLoop(ctx context.Context, cancel context.CancelFunc, writer *safeWS) {
 	interval := h.interval
 	if interval <= 0 {
 		interval = defaultPushInterval
 	}
-	h.pushSnapshot(ctx, writer)
+	if err := h.pushSnapshot(ctx, writer); err != nil {
+		cancel()
+		return
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -259,17 +265,22 @@ func (h *WSHandler) pushLoop(ctx context.Context, writer *safeWS) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			h.pushSnapshot(ctx, writer)
+			if err := h.pushSnapshot(ctx, writer); err != nil {
+				cancel()
+				return
+			}
 		}
 	}
 }
 
-func (h *WSHandler) pushSnapshot(ctx context.Context, writer *safeWS) {
+func (h *WSHandler) pushSnapshot(ctx context.Context, writer *safeWS) error {
 	if h.svc == nil {
-		return
+		return nil
 	}
 	snap := h.svc.Snapshot(ctx)
 	if err := writer.writeJSON(WSResponse{Type: "snapshot", Data: snap}); err != nil {
 		logger.Error("monitor websocket push failed", zap.Error(err))
+		return err
 	}
+	return nil
 }

--- a/backend/internal/monitor/handler/ws_test.go
+++ b/backend/internal/monitor/handler/ws_test.go
@@ -1,0 +1,134 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/monitor/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/config"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testJWT() *config.JWTConfig {
+	return &config.JWTConfig{Secret: "monitor-ws-test-secret", Issuer: "starbyte", AccessTokenExp: 3600}
+}
+
+func TestCheckMonitorWSOrigin(t *testing.T) {
+	allowed := map[string]bool{"https://starbyte.smbu.edu.cn": true}
+	r := httptest.NewRequest(http.MethodGet, "/ws/monitor", nil)
+	r.Host = "10.0.0.8"
+	r.Header.Set("Origin", "http://10.0.0.8")
+	assert.True(t, checkMonitorWSOrigin(r, allowed))
+
+	r = httptest.NewRequest(http.MethodGet, "/ws/monitor", nil)
+	r.Host = "10.0.0.8"
+	r.Header.Set("Origin", "https://evil.example")
+	assert.False(t, checkMonitorWSOrigin(r, allowed))
+
+	r = httptest.NewRequest(http.MethodGet, "/ws/monitor", nil)
+	assert.True(t, checkMonitorWSOrigin(r, map[string]bool{}))
+}
+
+func TestMonitorWSAuthFailures(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewWSHandler(&stubSvc{app: &dto.AppHealth{}}, testJWT(), stubCache{perms: []string{"monitor:read"}}, nil)
+	r := gin.New()
+	RegisterWSRoute(r, h)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ws/monitor", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ws/monitor?token=bad", nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	denied := NewWSHandler(&stubSvc{}, testJWT(), stubCache{perms: []string{"leave:read"}}, nil)
+	token, _, err := auth.GenerateAccessToken(uuid.NewString(), "u", nil, nil, testJWT())
+	require.NoError(t, err)
+	rd := gin.New()
+	RegisterWSRoute(rd, denied)
+	w = httptest.NewRecorder()
+	rd.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ws/monitor?token="+token, nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	var env response.Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, response.CodeMonitorWSForbidden, env.Code)
+}
+
+func TestMonitorWSPushAndPing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	uid := uuid.New()
+	token, _, err := auth.GenerateAccessToken(uid.String(), "ops", nil, nil, testJWT())
+	require.NoError(t, err)
+
+	h := NewWSHandler(&stubSvc{
+		server: &dto.ServerStatus{CPUPercent: 9},
+		app:    &dto.AppHealth{Goroutines: 4},
+	}, testJWT(), stubCache{perms: []string{"monitor:read"}}, nil)
+	h.interval = 40 * time.Millisecond
+
+	engine := gin.New()
+	RegisterWSRoute(engine, h)
+	srv := httptest.NewServer(engine)
+	t.Cleanup(srv.Close)
+
+	u := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/monitor?token=" + token
+	conn, resp, err := websocket.DefaultDialer.Dial(u, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var authFrame WSResponse
+	require.NoError(t, conn.ReadJSON(&authFrame))
+	assert.Equal(t, "auth_result", authFrame.Type)
+
+	var snapFrame WSResponse
+	require.NoError(t, conn.ReadJSON(&snapFrame))
+	assert.Equal(t, "snapshot", snapFrame.Type)
+
+	require.NoError(t, conn.WriteJSON(WSMessage{Type: "ping"}))
+	deadline := time.Now().Add(2 * time.Second)
+	sawPong := false
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		var frame WSResponse
+		if err := conn.ReadJSON(&frame); err != nil {
+			continue
+		}
+		if frame.Type == "pong" {
+			sawPong = true
+			break
+		}
+	}
+	assert.True(t, sawPong)
+}
+
+func TestExtractWSTokenBearer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/ws/monitor", nil)
+	c.Request.Header.Set("Authorization", "Bearer abc.def")
+	assert.Equal(t, "abc.def", extractWSToken(c))
+}
+
+func TestAllowMonitorReadSuperAdmin(t *testing.T) {
+	h := NewWSHandler(&stubSvc{}, testJWT(), stubCache{super: true}, nil)
+	require.NoError(t, h.allowMonitorRead(context.Background(), uuid.New()))
+	h.cache = nil
+	err := h.allowMonitorRead(context.Background(), uuid.New())
+	require.Error(t, err)
+}

--- a/backend/internal/monitor/handler/ws_test.go
+++ b/backend/internal/monitor/handler/ws_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/Yogdunana/StarByte/backend/pkg/config"
 	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
 	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/alicebob/miniredis/v2"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,6 +68,52 @@ func TestMonitorWSAuthFailures(t *testing.T) {
 	var env response.Response
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
 	assert.Equal(t, response.CodeMonitorWSForbidden, env.Code)
+}
+
+func TestMonitorWSRejectsRefreshAndBlacklistedTokens(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	uid := uuid.NewString()
+	cfg := testJWT()
+
+	refreshClaims := &auth.Claims{
+		UserID:    uid,
+		Username:  "u",
+		TokenType: auth.RefreshTokenType,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        uuid.NewString(),
+			Issuer:    cfg.Issuer,
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	refresh, err := jwt.NewWithClaims(jwt.SigningMethodHS256, refreshClaims).SignedString([]byte(cfg.Secret))
+	require.NoError(t, err)
+
+	h := NewWSHandler(&stubSvc{}, cfg, stubCache{perms: []string{"monitor:read"}}, nil)
+	r := gin.New()
+	RegisterWSRoute(r, h)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ws/monitor?token="+refresh, nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	access, _, err := auth.GenerateAccessToken(uid, "u", nil, nil, cfg)
+	require.NoError(t, err)
+	claims, err := auth.ParseToken(access, cfg)
+	require.NoError(t, err)
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	require.NoError(t, rdb.Set(context.Background(), "auth:blacklist:"+claims.ID, "1", 0).Err())
+
+	blocked := NewWSHandler(&stubSvc{}, cfg, stubCache{perms: []string{"monitor:read"}}, nil).WithRedis(rdb)
+	rb := gin.New()
+	RegisterWSRoute(rb, blocked)
+	w = httptest.NewRecorder()
+	rb.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ws/monitor?token="+access, nil))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	var env response.Response
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, response.CodeMonitorWSAuthFail, env.Code)
 }
 
 func TestMonitorWSPushAndPing(t *testing.T) {

--- a/backend/internal/monitor/repo/slow_query.go
+++ b/backend/internal/monitor/repo/slow_query.go
@@ -1,0 +1,235 @@
+package repo
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/monitor/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/database"
+	"gorm.io/gorm"
+)
+
+const defaultSlowLimit = 20
+
+// SlowQueryRepo loads slow SQL from Postgres and/or the in-process GORM ring.
+type SlowQueryRepo interface {
+	List(ctx context.Context, limit int) *dto.SlowQueries
+}
+
+type gormRunner interface {
+	WithContext(ctx context.Context) *gorm.DB
+}
+
+type pgQuerier interface {
+	hasExtension(ctx context.Context, name string) (bool, error)
+	listStatements(ctx context.Context, limit int) ([]dto.SlowQuery, error)
+	listActivity(ctx context.Context, limit int) ([]dto.SlowQuery, error)
+}
+
+type slowQueryRepo struct {
+	db      gormRunner
+	querier pgQuerier
+	now     func() time.Time
+}
+
+// NewSlowQueryRepo uses GORM when db is non-nil; otherwise only the in-memory ring.
+func NewSlowQueryRepo(db *gorm.DB) SlowQueryRepo {
+	r := &slowQueryRepo{now: time.Now}
+	if db != nil {
+		r.db = db
+		r.querier = r
+	}
+	return r
+}
+
+func (r *slowQueryRepo) List(ctx context.Context, limit int) *dto.SlowQueries {
+	if limit <= 0 {
+		limit = defaultSlowLimit
+	}
+	stamp := r.now().UTC().Format(time.RFC3339)
+	out := &dto.SlowQueries{
+		Queries:     []dto.SlowQuery{},
+		CollectedAt: stamp,
+	}
+
+	memory := fromGormRing(limit, stamp)
+	if r.db == nil && r.querier == nil {
+		out.Source = "in_memory"
+		out.Note = "数据库未配置；仅返回进程内 GORM 慢查询环（阈值 500ms）。未启用 pg_stat_statements。"
+		out.Queries = memory
+		out.Available = true
+		return out
+	}
+
+	q := r.querier
+	if q == nil {
+		q = r
+	}
+	if has, err := q.hasExtension(ctx, "pg_stat_statements"); err == nil && has {
+		if rows, qerr := q.listStatements(ctx, limit); qerr == nil {
+			out.Source = "pg_stat_statements"
+			out.Note = "来自 pg_stat_statements；SQL 已截断。"
+			out.Queries = mergeSlow(rows, memory, limit)
+			out.Available = true
+			return out
+		}
+	}
+
+	activity, aerr := q.listActivity(ctx, limit)
+	sources := []string{"in_memory"}
+	combined := memory
+	if aerr == nil && len(activity) > 0 {
+		sources = append([]string{"pg_stat_activity"}, sources...)
+		combined = mergeSlow(activity, memory, limit)
+	}
+	out.Source = strings.Join(sources, "+")
+	out.Note = "未安装或无法读取 pg_stat_statements；已回退到 pg_stat_activity（当前长查询）与进程内 GORM 慢查询环。"
+	out.Queries = combined
+	out.Available = true
+	return out
+}
+
+func (r *slowQueryRepo) hasExtension(ctx context.Context, name string) (bool, error) {
+	var ok bool
+	err := r.db.WithContext(ctx).
+		Raw("SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = ?)", name).
+		Scan(&ok).Error
+	return ok, err
+}
+
+type statementRow struct {
+	Query       string  `gorm:"column:query"`
+	Calls       int64   `gorm:"column:calls"`
+	MeanTimeMs  float64 `gorm:"column:mean_time_ms"`
+	TotalTimeMs float64 `gorm:"column:total_time_ms"`
+	MaxTimeMs   float64 `gorm:"column:max_time_ms"`
+	Rows        int64   `gorm:"column:rows"`
+}
+
+func (r *slowQueryRepo) listStatements(ctx context.Context, limit int) ([]dto.SlowQuery, error) {
+	var rows []statementRow
+	err := r.db.WithContext(ctx).Raw(`
+SELECT
+  query,
+  calls,
+  mean_exec_time AS mean_time_ms,
+  total_exec_time AS total_time_ms,
+  max_exec_time AS max_time_ms,
+  rows
+FROM pg_stat_statements
+WHERE query NOT ILIKE '%pg_stat_statements%'
+ORDER BY mean_exec_time DESC
+LIMIT ?`, limit).Scan(&rows).Error
+	if err != nil {
+		err = r.db.WithContext(ctx).Raw(`
+SELECT
+  query,
+  calls,
+  mean_time AS mean_time_ms,
+  total_time AS total_time_ms,
+  max_time AS max_time_ms,
+  rows
+FROM pg_stat_statements
+WHERE query NOT ILIKE '%pg_stat_statements%'
+ORDER BY mean_time DESC
+LIMIT ?`, limit).Scan(&rows).Error
+	}
+	if err != nil {
+		return nil, err
+	}
+	return mapStatementRows(rows, "pg_stat_statements", r.now().UTC().Format(time.RFC3339)), nil
+}
+
+func (r *slowQueryRepo) listActivity(ctx context.Context, limit int) ([]dto.SlowQuery, error) {
+	var rows []statementRow
+	err := r.db.WithContext(ctx).Raw(`
+SELECT
+  query,
+  1::bigint AS calls,
+  EXTRACT(EPOCH FROM (now() - query_start)) * 1000 AS mean_time_ms,
+  EXTRACT(EPOCH FROM (now() - query_start)) * 1000 AS total_time_ms,
+  EXTRACT(EPOCH FROM (now() - query_start)) * 1000 AS max_time_ms,
+  0::bigint AS rows
+FROM pg_stat_activity
+WHERE datname = current_database()
+  AND state = 'active'
+  AND pid <> pg_backend_pid()
+  AND query_start IS NOT NULL
+  AND now() - query_start >= interval '500 milliseconds'
+  AND query NOT ILIKE '%pg_stat_%'
+ORDER BY query_start
+LIMIT ?`, limit).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return mapStatementRows(rows, "pg_stat_activity", r.now().UTC().Format(time.RFC3339)), nil
+}
+
+func mapStatementRows(rows []statementRow, source, stamp string) []dto.SlowQuery {
+	out := make([]dto.SlowQuery, 0, len(rows))
+	for _, row := range rows {
+		q := database.SanitizeSQL(row.Query)
+		if q == "" {
+			continue
+		}
+		out = append(out, dto.SlowQuery{
+			Query:       q,
+			Calls:       row.Calls,
+			MeanTimeMs:  round2(row.MeanTimeMs),
+			TotalTimeMs: round2(row.TotalTimeMs),
+			MaxTimeMs:   round2(row.MaxTimeMs),
+			Rows:        row.Rows,
+			Source:      source,
+			CollectedAt: stamp,
+		})
+	}
+	return out
+}
+
+func fromGormRing(limit int, stamp string) []dto.SlowQuery {
+	raw := database.RecentSlowQueries(limit)
+	out := make([]dto.SlowQuery, 0, len(raw))
+	for _, item := range raw {
+		collected := stamp
+		if !item.At.IsZero() {
+			collected = item.At.UTC().Format(time.RFC3339)
+		}
+		out = append(out, dto.SlowQuery{
+			Query:       item.SQL,
+			Calls:       1,
+			MeanTimeMs:  float64(item.DurationMs),
+			TotalTimeMs: float64(item.DurationMs),
+			MaxTimeMs:   float64(item.DurationMs),
+			Rows:        item.Rows,
+			Source:      "in_memory",
+			CollectedAt: collected,
+		})
+	}
+	return out
+}
+
+func mergeSlow(primary, extra []dto.SlowQuery, limit int) []dto.SlowQuery {
+	seen := map[string]struct{}{}
+	out := make([]dto.SlowQuery, 0, limit)
+	add := func(items []dto.SlowQuery) {
+		for _, item := range items {
+			if len(out) >= limit {
+				return
+			}
+			key := item.Source + "\n" + item.Query
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, item)
+		}
+	}
+	add(primary)
+	add(extra)
+	return out
+}
+
+func round2(v float64) float64 {
+	return float64(int(v*100+0.5)) / 100
+}

--- a/backend/internal/monitor/repo/slow_query_test.go
+++ b/backend/internal/monitor/repo/slow_query_test.go
@@ -1,0 +1,118 @@
+package repo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/monitor/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListWithoutDBUsesInMemory(t *testing.T) {
+	database.ResetSlowQueriesForTest()
+	t.Cleanup(database.ResetSlowQueriesForTest)
+
+	r := NewSlowQueryRepo(nil)
+	out := r.List(context.Background(), 0)
+	require.NotNil(t, out)
+	assert.True(t, out.Available)
+	assert.Equal(t, "in_memory", out.Source)
+	assert.Empty(t, out.Queries)
+	assert.Contains(t, out.Note, "pg_stat_statements")
+
+	database.RecordSlowQueryForTest("SELECT * FROM members", time.Second, 3)
+	filled := r.List(context.Background(), 10)
+	require.Len(t, filled.Queries, 1)
+	assert.Equal(t, "in_memory", filled.Queries[0].Source)
+	assert.Equal(t, "SELECT * FROM members", filled.Queries[0].Query)
+}
+
+type fakePG struct {
+	hasExt      bool
+	hasErr      error
+	stmts       []dto.SlowQuery
+	stmtErr     error
+	activity    []dto.SlowQuery
+	activityErr error
+}
+
+func (f fakePG) hasExtension(context.Context, string) (bool, error) {
+	return f.hasExt, f.hasErr
+}
+func (f fakePG) listStatements(context.Context, int) ([]dto.SlowQuery, error) {
+	return f.stmts, f.stmtErr
+}
+func (f fakePG) listActivity(context.Context, int) ([]dto.SlowQuery, error) {
+	return f.activity, f.activityErr
+}
+
+func TestListPrefersPgStatStatements(t *testing.T) {
+	r := &slowQueryRepo{
+		querier: fakePG{
+			hasExt: true,
+			stmts:  []dto.SlowQuery{{Query: "SELECT 1", Source: "pg_stat_statements", Calls: 9}},
+		},
+		now: time.Now,
+	}
+	out := r.List(context.Background(), 10)
+	assert.Equal(t, "pg_stat_statements", out.Source)
+	require.Len(t, out.Queries, 1)
+	assert.Equal(t, int64(9), out.Queries[0].Calls)
+}
+
+func TestListFallsBackWhenExtensionMissing(t *testing.T) {
+	r := &slowQueryRepo{
+		querier: fakePG{
+			activity: []dto.SlowQuery{{Query: "SELECT pg_sleep(1)", Source: "pg_stat_activity"}},
+		},
+		now: time.Now,
+	}
+	out := r.List(context.Background(), 10)
+	assert.Contains(t, out.Source, "pg_stat_activity")
+	require.NotEmpty(t, out.Queries)
+	assert.Equal(t, "pg_stat_activity", out.Queries[0].Source)
+}
+
+func TestListFallsBackWhenStatementsFail(t *testing.T) {
+	r := &slowQueryRepo{
+		querier: fakePG{
+			hasExt:   true,
+			stmtErr:  assert.AnError,
+			activity: []dto.SlowQuery{{Query: "SELECT long", Source: "pg_stat_activity"}},
+		},
+		now: time.Now,
+	}
+	out := r.List(context.Background(), 5)
+	assert.Contains(t, out.Source, "pg_stat_activity")
+}
+
+func TestListInMemoryWhenActivityFails(t *testing.T) {
+	r := &slowQueryRepo{
+		querier: fakePG{activityErr: assert.AnError},
+		now:     time.Now,
+	}
+	out := r.List(context.Background(), 5)
+	assert.Equal(t, "in_memory", out.Source)
+	assert.True(t, out.Available)
+}
+
+func TestMapStatementRowsAndMerge(t *testing.T) {
+	rows := mapStatementRows([]statementRow{
+		{Query: "  SELECT id FROM users  ", Calls: 3, MeanTimeMs: 12.345, TotalTimeMs: 36, MaxTimeMs: 20, Rows: 2},
+		{Query: "   ", Calls: 1},
+	}, "pg_stat_statements", "2026-09-12T08:00:00Z")
+	require.Len(t, rows, 1)
+	assert.Equal(t, "SELECT id FROM users", rows[0].Query)
+	assert.Equal(t, 12.35, rows[0].MeanTimeMs)
+
+	merged := mergeSlow(rows, []dto.SlowQuery{
+		{Query: "SELECT id FROM users", Source: "pg_stat_statements"},
+		{Query: "SELECT 1", Source: "in_memory"},
+	}, 10)
+	require.Len(t, merged, 2)
+	assert.Equal(t, "in_memory", merged[1].Source)
+	assert.Len(t, mergeSlow(rows, nil, 1), 1)
+}

--- a/backend/internal/monitor/service/collectors.go
+++ b/backend/internal/monitor/service/collectors.go
@@ -182,13 +182,19 @@ func hitRate(hits, misses int64) float64 {
 	return round2(float64(hits) / float64(total) * 100)
 }
 
-const apiStatsTODO = "TODO(phase-2): persist request histograms for P50/P95/P99; scrape /metrics starbyte_http_request_duration_seconds"
-
 func collectAPIStats(gatherer prometheus.Gatherer, now time.Time) *dto.APIStats {
 	stamp := now.UTC().Format(time.RFC3339)
+	p50, p95, p99, psrc, note := resolvePercentiles(gatherer)
+	src := "prometheus"
+	if psrc != "" {
+		src = "prometheus+" + psrc
+	}
 	out := &dto.APIStats{
-		Source:          "prometheus",
-		PercentilesNote: apiStatsTODO,
+		Source:          src,
+		P50Seconds:      p50,
+		P95Seconds:      p95,
+		P99Seconds:      p99,
+		PercentilesNote: note,
 		CollectedAt:     stamp,
 	}
 	if gatherer == nil {

--- a/backend/internal/monitor/service/percentiles.go
+++ b/backend/internal/monitor/service/percentiles.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"math"
+	"sort"
+
+	"github.com/Yogdunana/StarByte/backend/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dtoProm "github.com/prometheus/client_model/go"
+)
+
+const httpDurationMetric = "starbyte_http_request_duration_seconds"
+
+func resolvePercentiles(gatherer prometheus.Gatherer) (p50, p95, p99 *float64, source, note string) {
+	if a, b, c, ok := metrics.RecentHTTPPercentiles(); ok {
+		return ptrSec(a), ptrSec(b), ptrSec(c), "recent_requests",
+			"P50/P95/P99 来自进程内最近请求耗时窗口（最多 2048 条）；直方图同时写入 /metrics。"
+	}
+	if gatherer == nil {
+		return nil, nil, nil, "", "尚无请求样本，无法计算分位数。"
+	}
+	families, err := gatherer.Gather()
+	if err != nil {
+		return nil, nil, nil, "", "读取 Prometheus 直方图失败，无法计算分位数。"
+	}
+	bounds, cumul, count := mergeDurationHistograms(families)
+	if count == 0 {
+		return nil, nil, nil, "", "尚无请求样本，无法计算分位数。"
+	}
+	return quantile(0.50, bounds, cumul, count),
+		quantile(0.95, bounds, cumul, count),
+		quantile(0.99, bounds, cumul, count),
+		"prometheus_histogram",
+		"P50/P95/P99 由 starbyte_http_request_duration_seconds 直方图插值（进程累计）。"
+}
+
+func ptrSec(v float64) *float64 {
+	x := math.Round(v*1e6) / 1e6
+	return &x
+}
+
+func mergeDurationHistograms(families []*dtoProm.MetricFamily) (bounds []float64, cumul []uint64, count uint64) {
+	increments := map[float64]uint64{}
+	for _, mf := range families {
+		if mf.GetName() != httpDurationMetric {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			h := m.GetHistogram()
+			if h == nil {
+				continue
+			}
+			count += h.GetSampleCount()
+			var prev uint64
+			for _, b := range h.GetBucket() {
+				inc := b.GetCumulativeCount()
+				if inc >= prev {
+					inc -= prev
+				}
+				increments[b.GetUpperBound()] += inc
+				prev = b.GetCumulativeCount()
+			}
+		}
+	}
+	if len(increments) == 0 {
+		return nil, nil, count
+	}
+	bounds = make([]float64, 0, len(increments))
+	for u := range increments {
+		bounds = append(bounds, u)
+	}
+	sort.Float64s(bounds)
+	cumul = make([]uint64, len(bounds))
+	var running uint64
+	for i, u := range bounds {
+		running += increments[u]
+		cumul[i] = running
+	}
+	return bounds, cumul, count
+}
+
+func quantile(q float64, bounds []float64, cumul []uint64, count uint64) *float64 {
+	if count == 0 || len(bounds) == 0 {
+		return nil
+	}
+	rank := q * float64(count)
+	var prevBound float64
+	var prevCumul uint64
+	for i, bound := range bounds {
+		c := cumul[i]
+		if float64(c) >= rank {
+			if math.IsInf(bound, 1) {
+				return ptrSec(prevBound)
+			}
+			width := bound - prevBound
+			den := float64(c - prevCumul)
+			frac := 0.0
+			if den > 0 {
+				frac = (rank - float64(prevCumul)) / den
+			}
+			return ptrSec(prevBound + width*frac)
+		}
+		prevBound, prevCumul = bound, c
+	}
+	last := bounds[len(bounds)-1]
+	if math.IsInf(last, 1) && len(bounds) > 1 {
+		last = bounds[len(bounds)-2]
+	}
+	return ptrSec(last)
+}

--- a/backend/internal/monitor/service/redis_slow.go
+++ b/backend/internal/monitor/service/redis_slow.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/monitor/dto"
+	"github.com/Yogdunana/StarByte/backend/pkg/database"
+	"github.com/redis/go-redis/v9"
+)
+
+func collectRedisSlow(ctx context.Context, rdb *redis.Client, now time.Time, limit int) []dto.SlowQuery {
+	if rdb == nil {
+		return []dto.SlowQuery{}
+	}
+	if limit <= 0 {
+		limit = 16
+	}
+	qctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	entries, err := rdb.SlowLogGet(qctx, int64(limit)).Result()
+	if err != nil {
+		return []dto.SlowQuery{}
+	}
+	return mapRedisSlow(entries, now)
+}
+
+func mapRedisSlow(entries []redis.SlowLog, now time.Time) []dto.SlowQuery {
+	stamp := now.UTC().Format(time.RFC3339)
+	out := make([]dto.SlowQuery, 0, len(entries))
+	for _, e := range entries {
+		cmd := database.SanitizeSQL(strings.Join(e.Args, " "))
+		if cmd == "" {
+			continue
+		}
+		ms := float64(e.Duration.Microseconds()) / 1000
+		out = append(out, dto.SlowQuery{
+			Query:       cmd,
+			Calls:       1,
+			MeanTimeMs:  round2(ms),
+			TotalTimeMs: round2(ms),
+			MaxTimeMs:   round2(ms),
+			Source:      "redis_slowlog",
+			CollectedAt: stamp,
+		})
+	}
+	return out
+}

--- a/backend/internal/monitor/service/service.go
+++ b/backend/internal/monitor/service/service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/internal/monitor/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/monitor/repo"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
@@ -17,6 +18,8 @@ type Service interface {
 	Database(ctx context.Context) (*dto.DatabaseStatus, error)
 	Redis(ctx context.Context) (*dto.RedisStatus, error)
 	APIStats(ctx context.Context) (*dto.APIStats, error)
+	SlowQueries(ctx context.Context) (*dto.SlowQueries, error)
+	Snapshot(ctx context.Context) *dto.LiveSnapshot
 }
 
 type monitorService struct {
@@ -24,6 +27,7 @@ type monitorService struct {
 	rdb      *redis.Client
 	host     HostSampler
 	gatherer prometheus.Gatherer
+	slow     repo.SlowQueryRepo
 	now      func() time.Time
 }
 
@@ -34,6 +38,7 @@ func New(db *gorm.DB, rdb *redis.Client) Service {
 		rdb:      rdb,
 		host:     newGopsutilHost(),
 		gatherer: prometheus.DefaultGatherer,
+		slow:     repo.NewSlowQueryRepo(db),
 		now:      time.Now,
 	}
 }
@@ -60,4 +65,55 @@ func (s *monitorService) Redis(ctx context.Context) (*dto.RedisStatus, error) {
 
 func (s *monitorService) APIStats(context.Context) (*dto.APIStats, error) {
 	return collectAPIStats(s.gatherer, s.now()), nil
+}
+
+func (s *monitorService) SlowQueries(ctx context.Context) (*dto.SlowQueries, error) {
+	limit := 20
+	var out *dto.SlowQueries
+	if s.slow != nil {
+		out = s.slow.List(ctx, limit)
+	} else {
+		out = &dto.SlowQueries{
+			Available:   true,
+			Source:      "in_memory",
+			Note:        "慢查询仓库未配置",
+			Queries:     []dto.SlowQuery{},
+			CollectedAt: s.now().UTC().Format(time.RFC3339),
+		}
+	}
+	out.RedisCommands = collectRedisSlow(ctx, s.rdb, s.now(), 16)
+	if out.Queries == nil {
+		out.Queries = []dto.SlowQuery{}
+	}
+	return out, nil
+}
+
+func (s *monitorService) Snapshot(ctx context.Context) *dto.LiveSnapshot {
+	out := &dto.LiveSnapshot{}
+	if v, err := s.Server(ctx); err == nil {
+		out.Server = v
+	} else {
+		out.Errors = append(out.Errors, "server")
+	}
+	if v, err := s.App(ctx); err == nil {
+		out.App = v
+	} else {
+		out.Errors = append(out.Errors, "app")
+	}
+	if v, err := s.Database(ctx); err == nil {
+		out.Database = v
+	} else {
+		out.Errors = append(out.Errors, "database")
+	}
+	if v, err := s.Redis(ctx); err == nil {
+		out.Redis = v
+	} else {
+		out.Errors = append(out.Errors, "redis")
+	}
+	if v, err := s.APIStats(ctx); err == nil {
+		out.API = v
+	} else {
+		out.Errors = append(out.Errors, "api")
+	}
+	return out
 }

--- a/backend/internal/monitor/service/service_test.go
+++ b/backend/internal/monitor/service/service_test.go
@@ -149,6 +149,9 @@ db1:keys=2,expires=0,avg_ttl=0
 }
 
 func TestCollectAPIStats(t *testing.T) {
+	metrics.ResetRecentHTTPLatenciesForTest()
+	t.Cleanup(metrics.ResetRecentHTTPLatenciesForTest)
+
 	reg := prometheus.NewRegistry()
 	c := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "starbyte_http_requests_total",
@@ -164,10 +167,22 @@ func TestCollectAPIStats(t *testing.T) {
 	assert.Equal(t, 2.0, out.ErrorTotal)
 	assert.Equal(t, 16.67, out.ErrorRate)
 	assert.Nil(t, out.P50Seconds)
-	assert.Contains(t, out.PercentilesNote, "TODO")
+	assert.Contains(t, out.PercentilesNote, "尚无请求样本")
 
 	empty := collectAPIStats(nil, time.Now())
 	assert.False(t, empty.Available)
+}
+
+func TestCollectAPIStatsRecentPercentiles(t *testing.T) {
+	metrics.ResetRecentHTTPLatenciesForTest()
+	t.Cleanup(metrics.ResetRecentHTTPLatenciesForTest)
+	for i := 0; i < 20; i++ {
+		metrics.RecordHTTPLatency(0.02)
+	}
+	out := collectAPIStats(nil, time.Now())
+	require.NotNil(t, out.P50Seconds)
+	assert.InDelta(t, 0.02, *out.P50Seconds, 0.0001)
+	assert.Contains(t, out.Source, "recent_requests")
 }
 
 func TestLiveHostAndNilDeps(t *testing.T) {
@@ -191,6 +206,17 @@ func TestLiveHostAndNilDeps(t *testing.T) {
 	redisOut, err := svc.Redis(ctx)
 	require.NoError(t, err)
 	assert.False(t, redisOut.Available)
+
+	slow, err := svc.SlowQueries(ctx)
+	require.NoError(t, err)
+	assert.True(t, slow.Available)
+	assert.Equal(t, "in_memory", slow.Source)
+	assert.Empty(t, slow.RedisCommands)
+
+	snap := svc.Snapshot(ctx)
+	require.NotNil(t, snap.Server)
+	require.NotNil(t, snap.App)
+	assert.Contains(t, snap.Errors, "database")
 }
 
 func TestServiceAppAndAPIStats(t *testing.T) {
@@ -211,6 +237,10 @@ func TestServiceAppAndAPIStats(t *testing.T) {
 	server, err := svc.Server(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "/", server.DiskPath)
+
+	slow, err := svc.SlowQueries(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "in_memory", slow.Source)
 }
 
 func TestRound2(t *testing.T) {
@@ -221,5 +251,43 @@ func TestRound2(t *testing.T) {
 func TestDTOShapeHasNoSecrets(t *testing.T) {
 	raw := dto.RedisStatus{Version: "7"}
 	assert.Empty(t, raw.Version[:0])
-	assert.False(t, strings.Contains(strings.ToLower(apiStatsTODO), "password"))
+	assert.False(t, strings.Contains(strings.ToLower(dto.SlowQuery{Query: "SELECT 1"}.Query), "password"))
+}
+
+func TestQuantileFromHistogram(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	h := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "starbyte_http_request_duration_seconds",
+		Help:    "t",
+		Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1},
+	}, []string{"method", "path"})
+	require.NoError(t, reg.Register(h))
+	for i := 0; i < 90; i++ {
+		h.WithLabelValues("GET", "/a").Observe(0.02)
+	}
+	for i := 0; i < 10; i++ {
+		h.WithLabelValues("GET", "/a").Observe(0.4)
+	}
+	metrics.ResetRecentHTTPLatenciesForTest()
+	t.Cleanup(metrics.ResetRecentHTTPLatenciesForTest)
+	p50, p95, p99, src, note := resolvePercentiles(reg)
+	require.NotNil(t, p50)
+	require.NotNil(t, p95)
+	require.NotNil(t, p99)
+	assert.Equal(t, "prometheus_histogram", src)
+	assert.Contains(t, note, "直方图")
+	assert.Greater(t, *p95, *p50)
+}
+
+func TestMapRedisSlow(t *testing.T) {
+	entries := []redis.SlowLog{{
+		Args:     []string{"GET", "session:1"},
+		Duration: 1500 * time.Microsecond,
+	}}
+	got := mapRedisSlow(entries, time.Date(2026, 9, 12, 8, 0, 0, 0, time.UTC))
+	require.Len(t, got, 1)
+	assert.Equal(t, "GET session:1", got[0].Query)
+	assert.Equal(t, "redis_slowlog", got[0].Source)
+	assert.InDelta(t, 1.5, got[0].MeanTimeMs, 0.01)
+	assert.Empty(t, collectRedisSlow(context.Background(), nil, time.Now(), 0))
 }

--- a/backend/pkg/database/slowlog.go
+++ b/backend/pkg/database/slowlog.go
@@ -3,7 +3,10 @@ package database
 import (
 	"context"
 	"errors"
+	"strings"
+	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Yogdunana/StarByte/backend/pkg/logger"
 	"go.uber.org/zap"
@@ -11,7 +14,28 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
-const slowQueryThreshold = 500 * time.Millisecond
+const (
+	slowQueryThreshold = 500 * time.Millisecond
+	slowQueryRingCap   = 64
+	slowQuerySQLMax    = 400
+)
+
+// RecordedSlowQuery is a GORM-detected slow statement (no host credentials).
+type RecordedSlowQuery struct {
+	SQL        string
+	DurationMs int64
+	Rows       int64
+	At         time.Time
+}
+
+type slowQueryRing struct {
+	mu    sync.Mutex
+	items []RecordedSlowQuery
+	next  int
+	n     int
+}
+
+var gormSlowRing = &slowQueryRing{items: make([]RecordedSlowQuery, slowQueryRingCap)}
 
 // slowQueryLogger logs SQL that exceeds slowQueryThreshold.
 type slowQueryLogger struct {
@@ -64,6 +88,7 @@ func (l *slowQueryLogger) Trace(ctx context.Context, begin time.Time, fc func() 
 	if elapsed < slowQueryThreshold {
 		return
 	}
+	recordGormSlowQuery(sql, elapsed, rows)
 	reqID := logger.RequestIDFrom(ctx)
 	logger.Warn("slow query detected",
 		zap.String("sql", sql),
@@ -71,4 +96,81 @@ func (l *slowQueryLogger) Trace(ctx context.Context, begin time.Time, fc func() 
 		zap.Int64("rows", rows),
 		zap.String("request_id", reqID),
 	)
+}
+
+func recordGormSlowQuery(sql string, elapsed time.Duration, rows int64) {
+	item := RecordedSlowQuery{
+		SQL:        SanitizeSQL(sql),
+		DurationMs: elapsed.Milliseconds(),
+		Rows:       rows,
+		At:         time.Now().UTC(),
+	}
+	gormSlowRing.push(item)
+}
+
+func (r *slowQueryRing) push(item RecordedSlowQuery) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.items) == 0 {
+		return
+	}
+	r.items[r.next] = item
+	r.next = (r.next + 1) % len(r.items)
+	if r.n < len(r.items) {
+		r.n++
+	}
+}
+
+// RecentSlowQueries returns newest-first GORM slow statements (capped).
+func RecentSlowQueries(limit int) []RecordedSlowQuery {
+	return gormSlowRing.recent(limit)
+}
+
+// ResetSlowQueriesForTest clears the process-wide ring. Tests only.
+func ResetSlowQueriesForTest() {
+	gormSlowRing.mu.Lock()
+	defer gormSlowRing.mu.Unlock()
+	gormSlowRing.next = 0
+	gormSlowRing.n = 0
+}
+
+// RecordSlowQueryForTest appends one statement to the ring. Tests only.
+func RecordSlowQueryForTest(sql string, d time.Duration, rows int64) {
+	recordGormSlowQuery(sql, d, rows)
+}
+
+func (r *slowQueryRing) recent(limit int) []RecordedSlowQuery {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.n == 0 || limit <= 0 {
+		return nil
+	}
+	if limit > r.n {
+		limit = r.n
+	}
+	out := make([]RecordedSlowQuery, 0, limit)
+	// newest is just before next
+	idx := r.next
+	for i := 0; i < limit; i++ {
+		idx--
+		if idx < 0 {
+			idx = len(r.items) - 1
+		}
+		out = append(out, r.items[idx])
+	}
+	return out
+}
+
+// SanitizeSQL collapses whitespace and truncates so the API never returns
+// unbounded SQL text (may still contain application literals).
+func SanitizeSQL(sql string) string {
+	sql = strings.Join(strings.Fields(sql), " ")
+	if sql == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(sql) <= slowQuerySQLMax {
+		return sql
+	}
+	runes := []rune(sql)
+	return string(runes[:slowQuerySQLMax]) + "…"
 }

--- a/backend/pkg/database/slowlog_test.go
+++ b/backend/pkg/database/slowlog_test.go
@@ -3,11 +3,13 @@ package database
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/pkg/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 )
@@ -51,4 +53,38 @@ func TestSlowQueryLogger_SilentSkipsTrace(t *testing.T) {
 		t.Fatal("fc should not run")
 		return "", 0
 	}, nil)
+}
+
+func TestSanitizeSQLAndRing(t *testing.T) {
+	ResetSlowQueriesForTest()
+	t.Cleanup(ResetSlowQueriesForTest)
+
+	assert.Equal(t, "SELECT 1", SanitizeSQL("  SELECT   1  "))
+	long := strings.Repeat("x", 500)
+	got := SanitizeSQL(long)
+	assert.True(t, strings.HasSuffix(got, "…"))
+	assert.Equal(t, 401, len([]rune(got)))
+
+	assert.Nil(t, RecentSlowQueries(10))
+
+	l := newSlowQueryLogger()
+	l.Trace(context.Background(), time.Now().Add(-time.Second), func() (string, int64) {
+		return "SELECT * FROM members WHERE secret='x'", 4
+	}, nil)
+	items := RecentSlowQueries(5)
+	require.Len(t, items, 1)
+	assert.Contains(t, items[0].SQL, "SELECT * FROM members")
+	assert.GreaterOrEqual(t, items[0].DurationMs, int64(500))
+}
+
+func TestSlowQueryRingNewestFirst(t *testing.T) {
+	r := &slowQueryRing{items: make([]RecordedSlowQuery, 3)}
+	r.push(RecordedSlowQuery{SQL: "a"})
+	r.push(RecordedSlowQuery{SQL: "b"})
+	r.push(RecordedSlowQuery{SQL: "c"})
+	r.push(RecordedSlowQuery{SQL: "d"})
+	got := r.recent(3)
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"d", "c", "b"}, []string{got[0].SQL, got[1].SQL, got[2].SQL})
+	assert.Nil(t, r.recent(0))
 }

--- a/backend/pkg/metrics/latency.go
+++ b/backend/pkg/metrics/latency.go
@@ -1,0 +1,107 @@
+package metrics
+
+import (
+	"math"
+	"sort"
+	"sync"
+)
+
+const recentLatencyCap = 2048
+
+type latencyWindow struct {
+	mu      sync.Mutex
+	samples []float64
+	next    int
+	n       int
+}
+
+var recentHTTP = newLatencyWindow(recentLatencyCap)
+
+func newLatencyWindow(cap int) *latencyWindow {
+	if cap <= 0 {
+		cap = recentLatencyCap
+	}
+	return &latencyWindow{samples: make([]float64, cap)}
+}
+
+// RecordHTTPLatency stores a request duration (seconds) for recent P50/P95/P99.
+func RecordHTTPLatency(seconds float64) {
+	recentHTTP.record(seconds)
+}
+
+// RecentHTTPPercentiles returns nearest-rank P50/P95/P99 of the recent window.
+func RecentHTTPPercentiles() (p50, p95, p99 float64, ok bool) {
+	return recentHTTP.percentiles()
+}
+
+// ResetRecentHTTPLatenciesForTest clears the process-wide window. Tests only.
+func ResetRecentHTTPLatenciesForTest() {
+	recentHTTP.reset()
+}
+
+func (w *latencyWindow) record(seconds float64) {
+	if w == nil || seconds < 0 || math.IsNaN(seconds) || math.IsInf(seconds, 0) {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.samples) == 0 {
+		return
+	}
+	w.samples[w.next] = seconds
+	w.next = (w.next + 1) % len(w.samples)
+	if w.n < len(w.samples) {
+		w.n++
+	}
+}
+
+func (w *latencyWindow) percentiles() (p50, p95, p99 float64, ok bool) {
+	w.mu.Lock()
+	n := w.n
+	if n == 0 {
+		w.mu.Unlock()
+		return 0, 0, 0, false
+	}
+	cp := make([]float64, n)
+	if n < len(w.samples) {
+		copy(cp, w.samples[:n])
+	} else {
+		// ring is full: samples are [next..end) + [0..next)
+		copied := copy(cp, w.samples[w.next:])
+		copy(cp[copied:], w.samples[:w.next])
+	}
+	w.mu.Unlock()
+
+	p50, p95, p99 = nearestRankPercentiles(cp)
+	return p50, p95, p99, true
+}
+
+func (w *latencyWindow) reset() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.next = 0
+	w.n = 0
+}
+
+func nearestRankPercentiles(samples []float64) (p50, p95, p99 float64) {
+	sort.Float64s(samples)
+	return nearestRank(samples, 0.50), nearestRank(samples, 0.95), nearestRank(samples, 0.99)
+}
+
+func nearestRank(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	idx := int(math.Ceil(p*float64(n))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= n {
+		idx = n - 1
+	}
+	return sorted[idx]
+}

--- a/backend/pkg/metrics/latency_test.go
+++ b/backend/pkg/metrics/latency_test.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecentHTTPPercentiles(t *testing.T) {
+	ResetRecentHTTPLatenciesForTest()
+	t.Cleanup(ResetRecentHTTPLatenciesForTest)
+
+	_, _, _, ok := RecentHTTPPercentiles()
+	assert.False(t, ok)
+
+	RecordHTTPLatency(math.NaN())
+	RecordHTTPLatency(-1)
+	RecordHTTPLatency(math.Inf(1))
+	_, _, _, ok = RecentHTTPPercentiles()
+	assert.False(t, ok)
+
+	for i := 1; i <= 100; i++ {
+		RecordHTTPLatency(float64(i) / 1000)
+	}
+	p50, p95, p99, ok := RecentHTTPPercentiles()
+	require.True(t, ok)
+	assert.InDelta(t, 0.050, p50, 0.002)
+	assert.InDelta(t, 0.095, p95, 0.002)
+	assert.InDelta(t, 0.099, p99, 0.002)
+}
+
+func TestLatencyWindowWraps(t *testing.T) {
+	w := newLatencyWindow(4)
+	for _, v := range []float64{1, 2, 3, 4, 5, 6} {
+		w.record(v)
+	}
+	p50, _, _, ok := w.percentiles()
+	require.True(t, ok)
+	// window holds 3,4,5,6 — nearest-rank p50 is index 1
+	assert.Equal(t, 4.0, p50)
+}
+
+func TestNearestRankEmpty(t *testing.T) {
+	assert.Equal(t, 0.0, nearestRank(nil, 0.5))
+	assert.Equal(t, 1.5, nearestRank([]float64{1.5}, 0.99))
+}

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -25,7 +25,7 @@ var (
 		Namespace: namespace,
 		Name:      "http_request_duration_seconds",
 		Help:      "HTTP request duration in seconds",
-		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1, 5},
+		Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 	}, []string{"method", "path"})
 
 	DBConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/backend/pkg/middleware/metrics.go
+++ b/backend/pkg/middleware/metrics.go
@@ -25,8 +25,10 @@ func Metrics() gin.HandlerFunc {
 				return
 			}
 			status := strconv.Itoa(c.Writer.Status())
+			elapsed := time.Since(start).Seconds()
 			metrics.HTTPRequestsTotal.WithLabelValues(c.Request.Method, path, status).Inc()
-			metrics.HTTPRequestDuration.WithLabelValues(c.Request.Method, path).Observe(time.Since(start).Seconds())
+			metrics.HTTPRequestDuration.WithLabelValues(c.Request.Method, path).Observe(elapsed)
+			metrics.RecordHTTPLatency(elapsed)
 		}()
 		c.Next()
 	}

--- a/backend/pkg/middleware/metrics.go
+++ b/backend/pkg/middleware/metrics.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/pkg/metrics"
@@ -25,8 +26,12 @@ func Metrics() gin.HandlerFunc {
 				return
 			}
 			status := strconv.Itoa(c.Writer.Status())
-			elapsed := time.Since(start).Seconds()
 			metrics.HTTPRequestsTotal.WithLabelValues(c.Request.Method, path, status).Inc()
+			// WS handlers block until disconnect; session length is not HTTP latency.
+			if strings.HasPrefix(path, "/ws") {
+				return
+			}
+			elapsed := time.Since(start).Seconds()
 			metrics.HTTPRequestDuration.WithLabelValues(c.Request.Method, path).Observe(elapsed)
 			metrics.RecordHTTPLatency(elapsed)
 		}()

--- a/backend/pkg/middleware/metrics_test.go
+++ b/backend/pkg/middleware/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Yogdunana/StarByte/backend/pkg/metrics"
 	"github.com/gin-gonic/gin"
@@ -45,4 +46,27 @@ func TestMetrics_RecordsPanicAs500(t *testing.T) {
 
 	after := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues("GET", "/boom", "500"))
 	assert.Equal(t, before+1, after)
+}
+
+func TestMetrics_SkipsWebsocketDuration(t *testing.T) {
+	metrics.ResetRecentHTTPLatenciesForTest()
+	t.Cleanup(metrics.ResetRecentHTTPLatenciesForTest)
+
+	r := gin.New()
+	gin.SetMode(gin.TestMode)
+	r.Use(Metrics())
+	r.GET("/ws/monitor", func(c *gin.Context) {
+		time.Sleep(20 * time.Millisecond)
+		c.Status(http.StatusSwitchingProtocols)
+	})
+
+	before := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues("GET", "/ws/monitor", "101"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ws/monitor", nil))
+	assert.Equal(t, http.StatusSwitchingProtocols, w.Code)
+	after := testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues("GET", "/ws/monitor", "101"))
+	assert.Equal(t, before+1, after)
+
+	_, _, _, ok := metrics.RecentHTTPPercentiles()
+	assert.False(t, ok)
 }

--- a/backend/pkg/response/error_codes.go
+++ b/backend/pkg/response/error_codes.go
@@ -326,6 +326,8 @@ const (
 	CodeMonitorCollectFail = 31001 // 采集主机指标失败
 	CodeMonitorRedisDown   = 31002 // Redis 不可用
 	CodeMonitorDBDown      = 31003 // 数据库连接池不可用
+	CodeMonitorWSAuthFail  = 31004 // 监控 WebSocket 认证失败
+	CodeMonitorWSForbidden = 31005 // 监控 WebSocket 权限不足
 
 	// ===== Backup / restore (#88, 32000-32999) =====
 	CodeBackupNotFound        = 32001 // 备份记录不存在

--- a/backend/pkg/response/response.go
+++ b/backend/pkg/response/response.go
@@ -308,9 +308,9 @@ func httpStatusFromCode(code int) int {
 		return http.StatusOK
 	case CodeBadRequest:
 		return http.StatusBadRequest
-	case CodeUnauthorized:
+	case CodeUnauthorized, CodeMonitorWSAuthFail, CodeNotificationWSAuthFail:
 		return http.StatusUnauthorized
-	case CodeForbidden, CodeWorkflowTaskNoAccess, CodeVoteNoAccess, CodeVoteResultPending, CodeMeetingNotAttendee, CodeTaskNoAccess, CodeScheduleNoAccess, CodeCalendarNoAccess, CodeLeaveNoAccess:
+	case CodeForbidden, CodeWorkflowTaskNoAccess, CodeVoteNoAccess, CodeVoteResultPending, CodeMeetingNotAttendee, CodeTaskNoAccess, CodeScheduleNoAccess, CodeCalendarNoAccess, CodeLeaveNoAccess, CodeMonitorWSForbidden:
 		return http.StatusForbidden
 	case CodeNotFound, CodeScheduleNotFound, CodeCalendarNotFound, CodeScheduleAttendeeGone, CodeLeaveNotFound, CodeLeaveTypeNotFound, CodeBackupNotFound:
 		return http.StatusNotFound

--- a/backend/pkg/response/response_test.go
+++ b/backend/pkg/response/response_test.go
@@ -251,7 +251,10 @@ func TestHttpStatusFromCode(t *testing.T) {
 		{CodeSuccess, http.StatusOK},
 		{CodeBadRequest, http.StatusBadRequest},
 		{CodeUnauthorized, http.StatusUnauthorized},
+		{CodeMonitorWSAuthFail, http.StatusUnauthorized},
+		{CodeNotificationWSAuthFail, http.StatusUnauthorized},
 		{CodeForbidden, http.StatusForbidden},
+		{CodeMonitorWSForbidden, http.StatusForbidden},
 		{CodeWorkflowTaskNoAccess, http.StatusForbidden},
 		{CodeVoteNoAccess, http.StatusForbidden},
 		{CodeVoteResultPending, http.StatusForbidden},
@@ -429,6 +432,8 @@ func TestModuleRanges(t *testing.T) {
 	assert.Equal(t, 31001, CodeMonitorCollectFail)
 	assert.Equal(t, 31002, CodeMonitorRedisDown)
 	assert.Equal(t, 31003, CodeMonitorDBDown)
+	assert.Equal(t, 31004, CodeMonitorWSAuthFail)
+	assert.Equal(t, 31005, CodeMonitorWSForbidden)
 	assert.True(t, r[0] > ModuleRanges["leave"][1], "monitor must not collide with leave 30000-30999")
 
 	r, ok = ModuleRanges["backup"]

--- a/docs/api.md
+++ b/docs/api.md
@@ -155,13 +155,17 @@ POST /api/v1/contracts
 
 健康检查（无前缀）：`GET /health` `GET /health/ready` `GET /metrics`。
 
-### 运维监控（#87 phase-1，`monitor:read`）
+### 运维监控（#87，`monitor:read`）
 
 - `GET /monitor/server` CPU / 内存 / 磁盘 / 负载
 - `GET /monitor/app` 运行时长、Goroutine、MemStats / GC
 - `GET /monitor/database` `sql.DB` 连接池
 - `GET /monitor/redis` INFO（连接数 / 内存 / 命中率，不含主机凭据）
-- `GET /monitor/api-stats` Prometheus 请求计数；P50/P95 持久化见响应 `percentiles_note`
+- `GET /monitor/api-stats` Prometheus 请求计数 + P50/P95/P99（最近请求窗口，不足时回退直方图插值）
+- `GET /monitor/slow-queries` 慢查询：`pg_stat_statements`（若已安装）否则 `pg_stat_activity` + 进程内 GORM 环；附 Redis SLOWLOG
+- `WS /ws/monitor` 实时快照推送（JWT query `token` 或 Bearer；需 `monitor:read`）。前端轮询为回退。
+
+进程列表 / 网卡流量深挖本切片不做。
 
 ### 数据备份（#88 phase-1，运维角色）
 

--- a/frontend/src/api/monitor.ts
+++ b/frontend/src/api/monitor.ts
@@ -95,3 +95,36 @@ export function getMonitorRedis(signal?: AbortSignal): Promise<MonitorRedis> {
 export function getMonitorAPIStats(signal?: AbortSignal): Promise<MonitorAPIStats> {
   return request.get('/monitor/api-stats', { signal });
 }
+
+export interface MonitorSlowQuery {
+  query: string;
+  calls: number;
+  mean_time_ms: number;
+  total_time_ms: number;
+  max_time_ms: number;
+  rows: number;
+  source: string;
+  collected_at?: string;
+}
+
+export interface MonitorSlowQueries {
+  available: boolean;
+  source: string;
+  note: string;
+  queries: MonitorSlowQuery[];
+  redis_commands: MonitorSlowQuery[];
+  collected_at: string;
+}
+
+export function getMonitorSlowQueries(signal?: AbortSignal): Promise<MonitorSlowQueries> {
+  return request.get('/monitor/slow-queries', { signal });
+}
+
+export interface MonitorLiveSnapshot {
+  server?: MonitorServer;
+  app?: MonitorApp;
+  database?: MonitorDatabase;
+  redis?: MonitorRedis;
+  api?: MonitorAPIStats;
+  errors?: string[];
+}

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -356,7 +356,7 @@
   },
   "monitor": {
     "title": "Ops monitor",
-    "hint": "Server, app, database, and Redis snapshots. WebSocket push when available; 8s HTTP poll as fallback.",
+    "hint": "Server, app, database, and Redis snapshots. With auto-refresh on, WebSocket push is preferred and HTTP polls every 8s if the socket drops. Turning auto-refresh off pauses live updates.",
     "refresh": "Refresh",
     "autoRefresh": "Auto refresh",
     "updatedAt": "Updated {{time}}",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -356,7 +356,7 @@
   },
   "monitor": {
     "title": "Ops monitor",
-    "hint": "Server, app, database, and Redis snapshots. Phase-1 polls every 8s; no WebSocket live stream.",
+    "hint": "Server, app, database, and Redis snapshots. WebSocket push when available; 8s HTTP poll as fallback.",
     "refresh": "Refresh",
     "autoRefresh": "Auto refresh",
     "updatedAt": "Updated {{time}}",
@@ -398,7 +398,21 @@
     "apiTotal": "Requests",
     "apiErrors": "5xx errors",
     "apiErrorRate": "Error rate",
-    "apiNote": "P50/P95/P99 persistence is deferred. Counters come from Prometheus; histograms remain on /metrics."
+    "apiNote": "P50/P95/P99 come from the recent request window, falling back to the Prometheus histogram.",
+    "apiP50": "P50",
+    "apiP95": "P95",
+    "apiP99": "P99",
+    "liveOn": "Live push",
+    "liveOff": "Polling fallback",
+    "slowQueries": "Slow queries",
+    "slowSource": "Source",
+    "slowEmpty": "No slow queries yet (empty is normal without pg_stat_statements)",
+    "slowQuery": "Statement",
+    "slowCalls": "Calls",
+    "slowMean": "Mean",
+    "slowMax": "Max",
+    "slowRows": "Rows",
+    "redisSlow": "Redis slow commands"
   },
   "backup": {
     "title": "Backups",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -356,7 +356,7 @@
   },
   "monitor": {
     "title": "运维监控",
-    "hint": "服务器、应用、数据库与 Redis 快照。优先 WebSocket 推送，断开后回退 8 秒轮询。",
+    "hint": "服务器、应用、数据库与 Redis 快照。自动刷新开启时优先 WebSocket 推送，断开后回退 8 秒轮询；关闭自动刷新会暂停实时更新。",
     "refresh": "刷新",
     "autoRefresh": "自动刷新",
     "updatedAt": "最近更新 {{time}}",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -356,7 +356,7 @@
   },
   "monitor": {
     "title": "运维监控",
-    "hint": "服务器、应用、数据库与 Redis 快照。phase-1 每 8 秒轮询，不含 WebSocket 实时流。",
+    "hint": "服务器、应用、数据库与 Redis 快照。优先 WebSocket 推送，断开后回退 8 秒轮询。",
     "refresh": "刷新",
     "autoRefresh": "自动刷新",
     "updatedAt": "最近更新 {{time}}",
@@ -398,7 +398,21 @@
     "apiTotal": "请求总数",
     "apiErrors": "5xx 次数",
     "apiErrorRate": "错误率",
-    "apiNote": "P50/P95/P99 持久化留到二期；当前复用 Prometheus 计数，直方图见 /metrics。"
+    "apiNote": "P50/P95/P99 来自最近请求耗时窗口，不足时回退 Prometheus 直方图。",
+    "apiP50": "P50",
+    "apiP95": "P95",
+    "apiP99": "P99",
+    "liveOn": "实时推送",
+    "liveOff": "轮询回退",
+    "slowQueries": "慢查询",
+    "slowSource": "来源",
+    "slowEmpty": "暂无慢查询（未安装 pg_stat_statements 时可能为空）",
+    "slowQuery": "语句",
+    "slowCalls": "次数",
+    "slowMean": "平均耗时",
+    "slowMax": "最大耗时",
+    "slowRows": "行数",
+    "redisSlow": "Redis 慢命令"
   },
   "backup": {
     "title": "数据备份",

--- a/frontend/src/pages/monitor/MonitorPage.tsx
+++ b/frontend/src/pages/monitor/MonitorPage.tsx
@@ -143,6 +143,10 @@ const MonitorPage: React.FC = () => {
   }, [auto, loadSlow]);
 
   useEffect(() => {
+    if (!auto) {
+      setLive(false);
+      return undefined;
+    }
     const token = getToken();
     if (!token) return undefined;
     let disposed = false;
@@ -187,7 +191,7 @@ const MonitorPage: React.FC = () => {
       }
       setLive(false);
     };
-  }, [applyLive]);
+  }, [applyLive, auto]);
 
   const server = data.server;
   const gauges = useMemo(() => ([

--- a/frontend/src/pages/monitor/MonitorPage.tsx
+++ b/frontend/src/pages/monitor/MonitorPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Button, Card, Col, Row, Space, Statistic, Switch, Typography } from 'antd';
+import { Alert, Button, Card, Col, Row, Space, Statistic, Switch, Table, Tag, Typography } from 'antd';
 import { ReloadOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import ChartCard from '@/components/Chart/ChartCard';
@@ -9,19 +9,28 @@ import {
   getMonitorDatabase,
   getMonitorRedis,
   getMonitorServer,
+  getMonitorSlowQueries,
+  type MonitorLiveSnapshot,
+  type MonitorSlowQueries,
+  type MonitorSlowQuery,
 } from '@/api/monitor';
+import { isCanceledError } from '@/api/error';
+import { getToken } from '@/utils/storage';
 import { gaugeOption, sparkOption } from './charts';
-import { formatBytes, formatDuration, formatPercent, pushSample } from './format';
+import { formatBytes, formatDuration, formatPercent, formatSeconds, pushSample } from './format';
 import {
   SNAPSHOT_KEYS,
+  applyLiveSnapshot,
   applySettledIfCurrent,
   createPollSession,
   type Snapshot,
   type SnapshotKey,
 } from './load';
+import { buildMonitorWSUrl, parseMonitorWSFrame } from './ws';
 import './monitor.css';
 
 const POLL_MS = 8000;
+const SLOW_POLL_MS = 15000;
 
 const MonitorPage: React.FC = () => {
   const { t } = useTranslation();
@@ -33,9 +42,14 @@ const MonitorPage: React.FC = () => {
   const [updatedAt, setUpdatedAt] = useState<string>();
   const [cpuHist, setCpuHist] = useState<number[]>([]);
   const [labels, setLabels] = useState<string[]>([]);
+  const [live, setLive] = useState(false);
+  const [slow, setSlow] = useState<MonitorSlowQueries>();
+  const [slowFailed, setSlowFailed] = useState(false);
   const dataRef = useRef<Snapshot>({});
   const pollRef = useRef(createPollSession());
+  const liveRef = useRef(false);
   dataRef.current = data;
+  liveRef.current = live;
 
   const sectionTitle = useCallback((key: SnapshotKey) => {
     const map: Record<SnapshotKey, string> = {
@@ -80,17 +94,100 @@ const MonitorPage: React.FC = () => {
     setLoading(false);
   }, [t]);
 
+  const loadSlow = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const next = await getMonitorSlowQueries(signal);
+      setSlow(next);
+      setSlowFailed(false);
+    } catch (err) {
+      if (isCanceledError(err)) return;
+      setSlowFailed(true);
+    }
+  }, []);
+
+  const applyLive = useCallback((incoming: MonitorLiveSnapshot) => {
+    const merged = applyLiveSnapshot(dataRef.current, incoming);
+    setData(merged.next);
+    setFailed(merged.failed);
+    if (merged.succeeded.includes('server') && merged.next.server) {
+      const stamp = new Date().toLocaleTimeString();
+      setUpdatedAt(stamp);
+      setCpuHist((hist) => pushSample(hist, formatPercent(merged.next.server?.cpu_percent)));
+      setLabels((prevLabels) => pushSample(prevLabels, stamp));
+    } else if (merged.succeeded.length > 0) {
+      setUpdatedAt(new Date().toLocaleTimeString());
+    }
+    setError(merged.failed.length ? t('monitor.loadFail') : undefined);
+    setLoading(false);
+  }, [t]);
+
   useEffect(() => {
     const session = pollRef.current;
     void load();
+    void loadSlow();
     return () => { session.invalidate(); };
-  }, [load]);
+  }, [load, loadSlow]);
 
   useEffect(() => {
     if (!auto) return undefined;
-    const id = window.setInterval(() => { void load(); }, POLL_MS);
+    const id = window.setInterval(() => {
+      if (!liveRef.current) void load();
+    }, POLL_MS);
     return () => window.clearInterval(id);
   }, [auto, load]);
+
+  useEffect(() => {
+    if (!auto) return undefined;
+    const id = window.setInterval(() => { void loadSlow(); }, SLOW_POLL_MS);
+    return () => window.clearInterval(id);
+  }, [auto, loadSlow]);
+
+  useEffect(() => {
+    const token = getToken();
+    if (!token) return undefined;
+    let disposed = false;
+    let socket: WebSocket | null = null;
+    let reconnect: ReturnType<typeof setTimeout> | undefined;
+    let attempt = 0;
+    const connect = () => {
+      const currentToken = getToken();
+      if (disposed || !currentToken) return;
+      const current = new WebSocket(buildMonitorWSUrl(currentToken));
+      socket = current;
+      current.onopen = () => {
+        if (disposed) { current.close(); return; }
+        attempt = 0;
+        setLive(true);
+      };
+      current.onmessage = (event) => {
+        if (disposed) return;
+        const frame = parseMonitorWSFrame(String(event.data));
+        if (frame?.type === 'snapshot' && frame.data && typeof frame.data === 'object') {
+          applyLive(frame.data as MonitorLiveSnapshot);
+        }
+      };
+      current.onclose = () => {
+        if (disposed) return;
+        setLive(false);
+        reconnect = setTimeout(connect, Math.min(30000, 2000 * 2 ** Math.min(attempt++, 4)));
+      };
+      current.onerror = () => { if (!disposed) setLive(false); };
+    };
+    connect();
+    const heartbeat = window.setInterval(() => {
+      if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify({ type: 'ping' }));
+    }, 30000);
+    return () => {
+      disposed = true;
+      window.clearInterval(heartbeat);
+      clearTimeout(reconnect);
+      if (socket) {
+        socket.onopen = socket.onclose = socket.onmessage = socket.onerror = null;
+        socket.close(1000, 'page disconnected');
+      }
+      setLive(false);
+    };
+  }, [applyLive]);
 
   const server = data.server;
   const gauges = useMemo(() => ([
@@ -110,9 +207,10 @@ const MonitorPage: React.FC = () => {
           <p className="monitor-meta">{t('monitor.hint')}</p>
         </div>
         <Space wrap>
+          <Tag color={live ? 'success' : 'default'}>{live ? t('monitor.liveOn') : t('monitor.liveOff')}</Tag>
           <span>{t('monitor.autoRefresh')}</span>
           <Switch checked={auto} onChange={setAuto} />
-          <Button size="large" icon={<ReloadOutlined />} onClick={() => void load()}>
+          <Button size="large" icon={<ReloadOutlined />} onClick={() => { void load(); void loadSlow(); }}>
             {t('monitor.refresh')}
           </Button>
         </Space>
@@ -256,13 +354,56 @@ const MonitorPage: React.FC = () => {
                   <Col span={8}><Statistic title={t('monitor.apiTotal')} value={data.api?.request_total ?? 0} /></Col>
                   <Col span={8}><Statistic title={t('monitor.apiErrors')} value={data.api?.error_total ?? 0} /></Col>
                   <Col span={8}><Statistic title={t('monitor.apiErrorRate')} value={data.api?.error_rate ?? 0} suffix="%" /></Col>
+                  <Col span={8}><Statistic title={t('monitor.apiP50')} value={formatSeconds(data.api?.p50_seconds)} /></Col>
+                  <Col span={8}><Statistic title={t('monitor.apiP95')} value={formatSeconds(data.api?.p95_seconds)} /></Col>
+                  <Col span={8}><Statistic title={t('monitor.apiP99')} value={formatSeconds(data.api?.p99_seconds)} /></Col>
                 </Row>
-                <p className="monitor-note">{t('monitor.apiNote')}</p>
+                <p className="monitor-note">{data.api?.percentiles_note || t('monitor.apiNote')}</p>
               </>
             )}
           </Card>
         </Col>
       </Row>
+
+      <Card title={t('monitor.slowQueries')} className="monitor-section">
+        {slowFailed && !slow ? (
+          <Alert type="warning" message={t('monitor.cardUnavailable')} />
+        ) : (
+          <>
+            <p className="monitor-note">{slow?.note || t('monitor.slowEmpty')}</p>
+            <Table<MonitorSlowQuery>
+              size="small"
+              rowKey={(row, i) => `${row.source}-${row.query}-${i}`}
+              pagination={false}
+              dataSource={slow?.queries || []}
+              locale={{ emptyText: t('monitor.slowEmpty') }}
+              columns={[
+                { title: t('monitor.slowQuery'), dataIndex: 'query', ellipsis: true },
+                { title: t('monitor.slowSource'), dataIndex: 'source', width: 160 },
+                { title: t('monitor.slowCalls'), dataIndex: 'calls', width: 80 },
+                { title: t('monitor.slowMean'), dataIndex: 'mean_time_ms', width: 110, render: (v: number) => `${Number(v || 0).toFixed(1)} ms` },
+                { title: t('monitor.slowMax'), dataIndex: 'max_time_ms', width: 110, render: (v: number) => `${Number(v || 0).toFixed(1)} ms` },
+                { title: t('monitor.slowRows'), dataIndex: 'rows', width: 80 },
+              ]}
+            />
+            {(slow?.redis_commands || []).length > 0 ? (
+              <>
+                <p className="monitor-note">{t('monitor.redisSlow')}</p>
+                <Table<MonitorSlowQuery>
+                  size="small"
+                  rowKey={(row, i) => `redis-${row.query}-${i}`}
+                  pagination={false}
+                  dataSource={slow?.redis_commands || []}
+                  columns={[
+                    { title: t('monitor.slowQuery'), dataIndex: 'query', ellipsis: true },
+                    { title: t('monitor.slowMean'), dataIndex: 'mean_time_ms', width: 110, render: (v: number) => `${Number(v || 0).toFixed(1)} ms` },
+                  ]}
+                />
+              </>
+            ) : null}
+          </>
+        )}
+      </Card>
     </div>
   );
 };

--- a/frontend/src/pages/monitor/format.test.ts
+++ b/frontend/src/pages/monitor/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatBytes, formatDuration, formatPercent, pushSample } from './format';
+import { formatBytes, formatDuration, formatPercent, formatSeconds, pushSample } from './format';
 
 describe('monitor format', () => {
   it('formats bytes', () => {
@@ -21,5 +21,8 @@ describe('monitor format', () => {
     expect(formatPercent(12.34)).toBe(12.3);
     expect(formatPercent(undefined)).toBe(0);
     expect(pushSample([1, 2], 3, 2)).toEqual([2, 3]);
+    expect(formatSeconds(null)).toBe('—');
+    expect(formatSeconds(0.0123)).toBe('12.3 ms');
+    expect(formatSeconds(1.5)).toBe('1.50 s');
   });
 });

--- a/frontend/src/pages/monitor/format.ts
+++ b/frontend/src/pages/monitor/format.ts
@@ -33,3 +33,11 @@ export function pushSample<T>(list: T[], item: T, max = 20): T[] {
   const next = [...list, item];
   return next.length > max ? next.slice(next.length - max) : next;
 }
+
+export function formatSeconds(n: number | null | undefined): string {
+  if (n == null || Number.isNaN(Number(n))) return '—';
+  const ms = Number(n) * 1000;
+  if (ms < 1) return `${ms.toFixed(2)} ms`;
+  if (ms < 1000) return `${ms.toFixed(1)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}

--- a/frontend/src/pages/monitor/i18n.test.ts
+++ b/frontend/src/pages/monitor/i18n.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import en from '../../locales/en-US.json';
+import zh from '../../locales/zh-CN.json';
+
+const keys = [
+  'title', 'hint', 'refresh', 'autoRefresh', 'updatedAt', 'loadFail', 'loadPartial',
+  'partSep', 'cardUnavailable', 'server', 'cpu', 'memory', 'disk', 'cpuTrend', 'load',
+  'hostMeta', 'memDetail', 'diskDetail', 'app', 'uptime', 'goroutines', 'heap', 'numGC',
+  'database', 'dbDown', 'dbInUse', 'dbIdle', 'dbOpen', 'dbWait', 'dbMax', 'dbWaitMs',
+  'redis', 'redisDown', 'redisClients', 'redisMemory', 'redisHitRate', 'redisKeys',
+  'redisHits', 'redisMisses', 'api', 'apiTotal', 'apiErrors', 'apiErrorRate', 'apiNote',
+  'apiP50', 'apiP95', 'apiP99', 'liveOn', 'liveOff', 'slowQueries', 'slowSource',
+  'slowEmpty', 'slowQuery', 'slowCalls', 'slowMean', 'slowMax', 'slowRows', 'redisSlow',
+] as const;
+
+function pick(obj: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object') {
+      return (acc as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
+}
+
+describe('monitor i18n', () => {
+  it('has matching zh-CN and en-US keys', () => {
+    keys.forEach((key) => {
+      expect(pick(zh.monitor, key), `zh missing monitor.${key}`).toBeTruthy();
+      expect(pick(en.monitor, key), `en missing monitor.${key}`).toBeTruthy();
+    });
+    expect(zh.menu['/monitor']).toBeTruthy();
+    expect(en.menu['/monitor']).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/monitor/load.test.ts
+++ b/frontend/src/pages/monitor/load.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { MonitorApp, MonitorDatabase, MonitorRedis, MonitorServer } from '@/api/monitor';
-import { applySettledIfCurrent, createPollSession, mergeSettledSnapshot } from './load';
+import { applyLiveSnapshot, applySettledIfCurrent, createPollSession, mergeSettledSnapshot } from './load';
 
 const server = { cpu_percent: 10, mem_percent: 20, disk_percent: 30 } as MonitorServer;
 const app = { goroutines: 8, uptime_seconds: 12 } as MonitorApp;
@@ -65,6 +65,20 @@ function settledAll(value: MonitorServer) {
     { status: 'rejected' as const, reason: new Error('api') },
   ];
 }
+
+describe('applyLiveSnapshot', () => {
+  it('fills present slices and records WS errors', () => {
+    const { next, failed, succeeded } = applyLiveSnapshot(
+      { server, app },
+      { server: { ...server, cpu_percent: 44 }, redis, errors: ['database', 'api'] },
+    );
+    expect(next.server?.cpu_percent).toBe(44);
+    expect(next.app).toEqual(app);
+    expect(next.redis).toEqual(redis);
+    expect(succeeded).toEqual(['server', 'redis']);
+    expect(failed).toEqual(['database', 'api']);
+  });
+});
 
 describe('poll generation rejects stale overwrite', () => {
   it('keeps the newer snapshot when an older poll settles later', () => {

--- a/frontend/src/pages/monitor/load.ts
+++ b/frontend/src/pages/monitor/load.ts
@@ -2,6 +2,7 @@ import type {
   MonitorAPIStats,
   MonitorApp,
   MonitorDatabase,
+  MonitorLiveSnapshot,
   MonitorRedis,
   MonitorServer,
 } from '@/api/monitor';
@@ -75,6 +76,30 @@ export function createPollSession(): PollSession {
       controller = null;
     },
   };
+}
+
+export function applyLiveSnapshot(prev: Snapshot, live: MonitorLiveSnapshot): MergeResult {
+  const next: Snapshot = { ...prev };
+  const failed: SnapshotKey[] = [];
+  const succeeded: SnapshotKey[] = [];
+  const assign = (key: SnapshotKey, value: Snapshot[SnapshotKey] | undefined) => {
+    if (value != null) {
+      next[key] = value as never;
+      succeeded.push(key);
+    }
+  };
+  assign('server', live.server);
+  assign('app', live.app);
+  assign('database', live.database);
+  assign('redis', live.redis);
+  assign('api', live.api);
+  const errSet = new Set((live.errors || []).filter((k): k is SnapshotKey => (
+    k === 'server' || k === 'app' || k === 'database' || k === 'redis' || k === 'api'
+  )));
+  SNAPSHOT_KEYS.forEach((key) => {
+    if (errSet.has(key) && !succeeded.includes(key)) failed.push(key);
+  });
+  return { next, failed, succeeded };
 }
 
 export function applySettledIfCurrent(

--- a/frontend/src/pages/monitor/ws.test.ts
+++ b/frontend/src/pages/monitor/ws.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { buildMonitorWSUrl, parseMonitorWSFrame } from './ws';
+
+describe('monitor websocket helpers', () => {
+  it('builds a same-origin ws URL', () => {
+    const url = buildMonitorWSUrl('tok en', { protocol: 'https:', host: 'app.example' }, '/ws');
+    expect(url).toBe('wss://app.example/ws/monitor?token=tok%20en');
+  });
+
+  it('keeps an absolute ws base', () => {
+    const url = buildMonitorWSUrl('abc', { protocol: 'http:', host: 'localhost:5173' }, 'ws://localhost:8080/ws');
+    expect(url).toBe('ws://localhost:8080/ws/monitor?token=abc');
+  });
+
+  it('parses snapshot frames and rejects junk', () => {
+    expect(parseMonitorWSFrame('{"type":"snapshot","data":{"app":{}}}')?.type).toBe('snapshot');
+    expect(parseMonitorWSFrame('{')).toBeNull();
+    expect(parseMonitorWSFrame('{"no":"type"}')).toBeNull();
+  });
+});

--- a/frontend/src/pages/monitor/ws.ts
+++ b/frontend/src/pages/monitor/ws.ts
@@ -1,0 +1,27 @@
+export function buildMonitorWSUrl(
+  token: string,
+  loc: Pick<Location, 'protocol' | 'host'> = window.location,
+  wsBase = import.meta.env.VITE_WS_URL || '/ws',
+): string {
+  const path = `${wsBase}/monitor`;
+  const origin = `${loc.protocol === 'https:' ? 'wss:' : 'ws:'}//${loc.host}`;
+  const url = /^wss?:\/\//.test(path) ? path : origin + path;
+  return `${url}?token=${encodeURIComponent(token)}`;
+}
+
+export interface MonitorWSFrame {
+  type: string;
+  data?: unknown;
+}
+
+export function parseMonitorWSFrame(raw: string): MonitorWSFrame | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null && 'type' in parsed && typeof (parsed as MonitorWSFrame).type === 'string') {
+      return parsed as MonitorWSFrame;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更描述

在 #172 phase-1（快照 API + 轮询仪表盘）之上补齐 #87 剩余验收：

1. **WebSocket 实时更新**：`GET /ws/monitor`（query `token` 或 Bearer），校验 JWT + `monitor:read`，每 5s 推送 server/app/database/redis/api 快照。前端优先 WS，断开后回退 8s HTTP 轮询。
2. **慢查询**：`GET /api/v1/monitor/slow-queries`。优先 `pg_stat_statements`；扩展不存在时回退 `pg_stat_activity`（当前长查询）+ 进程内 GORM 慢查询环（500ms）；附 Redis `SLOWLOG`。无扩展也能返回空列表而不是 500。
3. **API P50/P95/P99**：复用现有 `starbyte_http_request_duration_seconds`，并以进程内最近 2048 条请求耗时窗口为主；窗口为空时对直方图插值。
4. **连接池 / Redis / 应用健康**：沿用 phase-1 采集逻辑，并纳入 WS 快照，失败切片不整页清空。
5. **测试 / i18n**：monitor handler/service/repo 覆盖率均 ≥70%；zh-CN / en-US 键对齐；不落仓库密钥。

## 关联 Issue

Closes #87

## 已落地 vs 仍不做

| 验收项 | 状态 |
|--------|------|
| 服务器状态实时更新（WebSocket） | 已做 |
| 数据库连接池状态正确 | 已做（phase-1 + 本 PR 保持） |
| 慢查询日志记录 | 已做 |
| API 调用统计（P50/P95/P99） | 已做 |
| 前端仪表盘可视化 | 已做（分位数、慢查询表、实时/轮询标签） |
| 单元测试覆盖率 ≥ 70% | handler 83.5% / service 83.8% / repo 76.8% |

**明确延后（issue 原文有、本切片不做）：** 进程列表、网卡流量深挖、表大小统计、索引使用率。

## 测试方式

1. 后端：`cd backend && go test -count=1 ./internal/monitor/... ./pkg/metrics/ ./pkg/database/ ./pkg/middleware/ ./pkg/response/`
2. 前端：`cd frontend && npx vitest run src/pages/monitor`
3. 手工：登录具备 `monitor:read` 的账号，打开 `/monitor`。
   - 右上角应为「实时推送」，CPU 趋势随 WS 刷新。
   - 停后端或断 WS 后标签变为「轮询回退」，8s 轮询仍更新。
   - API 卡片显示 P50/P95/P99（有流量后非 `—`）。
   - 慢查询表在无 `pg_stat_statements` 时为空并带说明，不报错。
4. 权限：无 `monitor:read` 访问 `/api/v1/monitor/*` 与 `/ws/monitor` 应 403。

## 注意事项

- `/ws/monitor` 与 `/ws/notifications` 一样独立于 `/api/v1`，鉴权在 handler 内完成。
- 慢查询 SQL 会截断到 400 字符并折叠空白，仍可能含业务字面量；仅 `monitor:read` 可见。
- 直方图 bucket 略加密（不影响计数器）。
- 请勿指定 Yu-lonng / windmirror-pixel 为 reviewer。

## 检查清单

- [x] 代码遵循项目开发规范（四层：handler → service → repo）
- [x] 已进行自测（Go + vitest）
- [x] 已更新 `docs/api.md`
- [ ] CI 检查通过
- [x] 没有硬编码敏感信息
- [x] 命名符合规范
- [x] 没有调试代码
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2d4d634-5b07-51d4-a705-c03eac5693a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2d4d634-5b07-51d4-a705-c03eac5693a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

