### PR TITLE
fix(feature): 定时落库用条件更新，避免覆盖并发人工写入

### DIFF
--- a/backend/internal/feature/service/service_test.go
+++ b/backend/internal/feature/service/service_test.go
@@ -440,6 +440,66 @@ func TestApplySchedulesReevaluatesAfterList(t *testing.T) {
 	}
 }
 
+type afterGetRepo struct {
+	*memRepo
+	afterGet func()
+}
+
+func (r *afterGetRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Flag, error) {
+	row, err := r.memRepo.GetByID(ctx, id)
+	if fn := r.afterGet; fn != nil {
+		r.afterGet = nil
+		fn()
+	}
+	return row, err
+}
+
+func TestPersistScheduleSkipsStaleWriteAfterGet(t *testing.T) {
+	inner := newMemRepo()
+	rows := &afterGetRepo{memRepo: inner}
+	svc := New(rows, NewMemorySnapshot(), NewMemoryBus(), stubRoles{}, stubUsers{}, stubPerms{}).(*flagService)
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour)
+	svc.now = func() time.Time { return now }
+	ctx := context.Background()
+	created, err := svc.Create(ctx, uuid.New(), &dto.CreateFlagRequest{
+		FlagKey: "cas.window", Name: "CAS", FlagType: model.TypeBoolean, Enabled: false,
+		Rules: model.Rules{StartsAt: &future},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(created.ID)
+	svc.now = func() time.Time { return future.Add(time.Second) }
+	later := future.Add(2 * time.Hour)
+	auditsBefore := len(inner.audits)
+	rows.afterGet = func() {
+		row, err := inner.GetByID(ctx, id)
+		if err != nil || row == nil {
+			t.Errorf("concurrent get: %v", err)
+			return
+		}
+		row.Rules.StartsAt = &later
+		row.UpdatedAt = svc.clock().Add(time.Millisecond)
+		if err := inner.Update(ctx, row); err != nil {
+			t.Errorf("concurrent update: %v", err)
+		}
+	}
+	if svc.persistSchedule(ctx, id, uuid.Nil) {
+		t.Fatal("CAS must skip after a concurrent write")
+	}
+	got, err := inner.GetByID(ctx, id)
+	if err != nil || got == nil || got.Enabled {
+		t.Fatalf("admin row must stay off: %+v %v", got, err)
+	}
+	if got.Rules.StartsAt == nil || !got.Rules.StartsAt.Equal(later) {
+		t.Fatalf("admin rules must stay: %+v", got.Rules)
+	}
+	if n := len(inner.audits) - auditsBefore; n != 0 {
+		t.Fatalf("conflict must not write schedule audit, extra=%d", n)
+	}
+}
+
 type afterListRepo struct {
 	*memRepo
 	afterList func()

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -51,7 +51,7 @@
 
 - **评估时立即生效**：`enabled=true` 且未到 `starts_at` → `schedule_pending`；过了 `ends_at` → `schedule_expired`
 - **后台约 30s 落库**：窗口开始且仍关闭 → 打开并记 `schedule_on`；窗口结束且仍开启 → 关闭并记 `schedule_off`
-- **人工覆盖优先**：`UpdatedAt` 晚于 `starts_at` / `ends_at` 时，ticker 不再改回人工开关；评估层仍按窗口门闸
+- **人工覆盖优先**：`UpdatedAt` 晚于 `starts_at` / `ends_at` 时，ticker 不再改回人工开关；评估层仍按窗口门闸。落库用 `id + updated_at` 条件更新，只写 `enabled`/`updated_at`；读后被别人改过则跳过且不记审计
 - 列表里的「当前生效」= `enabled && 环境命中 && 窗口内`（不含用户定向）
 
 推荐：把开关设为启用，再填未来的 `starts_at` / `ends_at`。评估不会等 ticker。


### PR DESCRIPTION
定时落库读取开关后，管理员可能并发修改规则或开关状态。当前 main 已通过 UpdateScheduledState 条件更新防止覆盖，本 PR rebase 后保留该实现，补入读取后发生并发修改的回归测试和操作说明。

验证：go test -race ./internal/feature/... 通过；测试确认并发人工修改被保留，冲突时不生成定时审计。无新迁移。等待最新 CI、Security 通过后 squash 合并。