### PR TITLE
fix(member): preserve customized approval templates in migration 000070

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
           migrate -path backend/migrations -database "postgres://starbyte:starbyte@localhost:5432/starbyte_test?sslmode=disable" down 1
           migrate -path backend/migrations -database "postgres://starbyte:starbyte@localhost:5432/starbyte_test?sslmode=disable" up
 
+      - name: Preserve customized member approval templates
+        run: psql "postgres://starbyte:starbyte@localhost:5432/starbyte_test?sslmode=disable" -X -v ON_ERROR_STOP=1 -f backend/migrations/tests/member_application_v2.sql
+
   # ─────────────────────────────────────────────────────────
   # Docker 镜像构建测试
   # ─────────────────────────────────────────────────────────

--- a/backend/migrations/000070_member_application_workflow_v2.up.sql
+++ b/backend/migrations/000070_member_application_workflow_v2.up.sql
@@ -1,12 +1,27 @@
 -- Membership approval template v2 (#64):
 -- 干事审批 → 部长审批 → 社长审批，可转交；会员申请跳过干事，无部门跳过部长。
 -- Only replace the published version when it is still the phase-1 default
--- (4 nodes, allowTransfer=false). Designer-published graphs are left alone.
+-- (exact JSONB match of the 000061 seed). Preserve every customized graph,
+-- including graphs that only change roles, signing policy, edges or layout.
 
 DO $migration$
 DECLARE
   target_definition_id uuid;
   next_version integer;
+  phase1_graph jsonb := $phase1${
+    "nodes": [
+      {"id": "start", "type": "start", "position": {"x": 280, "y": 20}, "data": {"label": "干事申请", "config": {}}},
+      {"id": "minister", "type": "approval", "position": {"x": 280, "y": 160}, "data": {"label": "部长审批", "config": {"assigneeStrategy": "role", "roleCode": "minister", "approvalType": "any", "departmentScope": true, "allowReject": true, "allowTransfer": false, "allowRollback": false}}},
+      {"id": "president", "type": "approval", "position": {"x": 280, "y": 300}, "data": {"label": "社长审批", "config": {"assigneeStrategy": "role", "roleCode": "president", "approvalType": "any", "allowReject": true, "allowTransfer": false, "allowRollback": false}}},
+      {"id": "end", "type": "end", "position": {"x": 280, "y": 440}, "data": {"label": "结束", "config": {}}}
+    ],
+    "edges": [
+      {"id": "start-minister", "source": "start", "target": "minister"},
+      {"id": "minister-president", "source": "minister", "target": "president"},
+      {"id": "president-end", "source": "president", "target": "end"}
+    ],
+    "viewport": {"x": 0, "y": 0, "zoom": 1}
+  }$phase1$::jsonb;
   graph jsonb := $json${
     "nodes": [
       {"id": "start", "type": "start", "position": {"x": 280, "y": 20}, "data": {"label": "提交申请", "config": {}}},
@@ -44,8 +59,7 @@ BEGIN
   IF EXISTS (
     SELECT 1 FROM flow_definition_versions v
     WHERE v.definition_id = target_definition_id AND v.status = 1
-      AND jsonb_array_length(v.bpmn_data->'nodes') = 4
-      AND COALESCE((v.bpmn_data #>> '{nodes,1,data,config,allowTransfer}')::boolean, false) = false
+      AND v.bpmn_data = phase1_graph
   ) THEN
     SELECT COALESCE(MAX(version), 0) + 1 INTO next_version
     FROM flow_definition_versions WHERE definition_id = target_definition_id;

--- a/backend/migrations/tests/member_application_v2.sql
+++ b/backend/migrations/tests/member_application_v2.sql
@@ -1,0 +1,50 @@
+\set ON_ERROR_STOP on
+-- Run after migrations up. All fixtures are temporary and rolled back.
+BEGIN;
+CREATE TEMP TABLE flow_definitions (LIKE public.flow_definitions INCLUDING ALL);
+CREATE TEMP TABLE flow_definition_versions (LIKE public.flow_definition_versions INCLUDING ALL);
+
+-- The untouched phase-1 seed must still upgrade exactly once.
+\ir ../000061_member_application_workflow.up.sql
+\ir ../000070_member_application_workflow_v2.up.sql
+\ir ../000070_member_application_workflow_v2.up.sql
+DO $$ BEGIN
+  IF (SELECT count(*) FROM flow_definition_versions) <> 2 OR
+     (SELECT count(*) FROM flow_definition_versions WHERE status = 1) <> 1 OR
+     NOT EXISTS (SELECT 1 FROM flow_definition_versions WHERE status = 1
+                 AND bpmn_data #>> '{nodes,1,id}' = 'officer') THEN
+    RAISE EXCEPTION 'Default seed did not upgrade idempotently';
+  END IF;
+END $$;
+
+-- Changing the role and all-sign policy must preserve the published graph.
+TRUNCATE flow_definition_versions, flow_definitions;
+\ir ../000061_member_application_workflow.up.sql
+UPDATE flow_definition_versions SET bpmn_data = jsonb_set(
+  jsonb_set(bpmn_data, '{nodes,1,data,config,roleCode}', '"custom_reviewer"'),
+  '{nodes,1,data,config,approvalType}', '"all"');
+CREATE TEMP TABLE expected_graph AS SELECT * FROM flow_definition_versions;
+\ir ../000070_member_application_workflow_v2.up.sql
+DO $$ BEGIN
+  IF (SELECT count(*) FROM flow_definition_versions) <> 1 OR
+     NOT EXISTS (SELECT 1 FROM flow_definition_versions v JOIN expected_graph e
+                 ON v.id = e.id WHERE v.status = 1 AND v.bpmn_data = e.bpmn_data) THEN
+    RAISE EXCEPTION 'Customized approval policy was replaced';
+  END IF;
+END $$;
+
+-- An edge-only change must also survive, with the same four nodes.
+TRUNCATE flow_definition_versions, flow_definitions, expected_graph;
+\ir ../000061_member_application_workflow.up.sql
+UPDATE flow_definition_versions SET bpmn_data = jsonb_set(
+  bpmn_data, '{edges,0,target}', '"president"');
+INSERT INTO expected_graph SELECT * FROM flow_definition_versions;
+\ir ../000070_member_application_workflow_v2.up.sql
+DO $$ BEGIN
+  IF (SELECT count(*) FROM flow_definition_versions) <> 1 OR
+     NOT EXISTS (SELECT 1 FROM flow_definition_versions v JOIN expected_graph e
+                 ON v.id = e.id WHERE v.status = 1 AND v.bpmn_data = e.bpmn_data) THEN
+    RAISE EXCEPTION 'Customized routing was replaced';
+  END IF;
+END $$;
+ROLLBACK;

--- a/docs/member-migration-070-check.md
+++ b/docs/member-migration-070-check.md
@@ -1,0 +1,26 @@
+# 000070 入会审批模板部署核对
+
+修复后的 000070 只升级与 000061 种子完全相同的 JSONB，保留任何自定义发布图。迁移号不变；已执行到 70/71 的数据库不会重新执行此文件，因此本修复不能自动恢复已经被旧版迁移停用的自定义图。
+
+部署方先执行以下只读查询，核对迁移状态及所有入会流程版本：
+
+```sql
+SELECT version, dirty FROM schema_migrations;
+SELECT v.id, v.version, v.status, v.published_at, v.created_at, v.bpmn_data
+FROM flow_definition_versions v
+JOIN flow_definitions d ON d.id = v.definition_id
+WHERE d.key = 'member_application'
+ORDER BY v.version DESC;
+```
+
+如果旧版 000070 已执行，而且迁移前有自定义发布流程：对比紧邻迁移生成版本之前的图与预期审批规则。确认被替换后，通过流程设计器将确认过的旧图另存为新版本并发布；不要仅凭“四个节点”自动选择旧版本，也不要删除版本或改写已有实例引用。新申请采用修正后的发布版本；迁移后已经发起的实例需逐项核对，重新发布不会自动改变其流程快照。
+
+未曾自定义且实际发布图符合干事→部长→社长预期时，无需恢复。不要通过回滚 000071/000070 来恢复流程，以免影响已写入的数据。
+
+回归检查已接入 Database Migration Check。也可在完成 migrations up 的隔离测试库运行：
+
+```sh
+psql "$TEST_DATABASE_URL" -X -v ON_ERROR_STOP=1 -f backend/migrations/tests/member_application_v2.sql
+```
+
+测试使用临时表并回滚，覆盖默认种子升级与重复执行、自定义角色/会签保留、仅更改连线的图保留。


### PR DESCRIPTION
旧版 000070 仅用四节点/禁止转交识别默认模板，会停用用户自定义角色、会签或连线的发布图。本修复改为完整匹配 000061 种子 JSONB，保留所有自定义图；没有新增迁移号。

验证：独立 PostgreSQL 16 执行全部 up 迁移；旧代码在自定义审批回归中失败，修复后默认升级/幂等、角色及会签保留、连线保留全部通过。回归已加入 Database Migration Check。

部署边界：已执行 70/71 的数据库不会重跑本文件；docs/member-migration-070-check.md 提供只读核对及按确认版本重新发布说明，不能声称自动恢复已受影响实例。000070 down 的宽泛识别未在此 PR 修改，不能以回滚方式恢复。

延续 #184 原分支修复，无 Autofix 分支。Bugbot 当前仓库禁用，本 PR 不声称 Bugbot 扫描通过；CI/Security 结果待检查。