### PR TITLE
fix(feature): preserve concurrent manual edits during scheduled updates

### DIFF
--- a/backend/internal/feature/repo/repo.go
+++ b/backend/internal/feature/repo/repo.go
@@ -18,6 +18,7 @@ type Repository interface {
 	ListAll(ctx context.Context) ([]model.Flag, error)
 	Create(ctx context.Context, flag *model.Flag) error
 	Update(ctx context.Context, flag *model.Flag) error
+	UpdateScheduledState(ctx context.Context, id uuid.UUID, expectedUpdatedAt time.Time, enabled bool, updatedAt time.Time) (bool, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	CreateAudit(ctx context.Context, row *model.Audit) error
 	ListAudits(ctx context.Context, q dto.AuditQuery) ([]model.Audit, int64, error)
@@ -82,6 +83,15 @@ func (r *repo) Create(ctx context.Context, flag *model.Flag) error {
 
 func (r *repo) Update(ctx context.Context, flag *model.Flag) error {
 	return r.db.WithContext(ctx).Save(flag).Error
+}
+
+// UpdateScheduledState skips a schedule computed before a concurrent edit.
+// Only scheduling fields are written, never rules or administrator metadata.
+func (r *repo) UpdateScheduledState(ctx context.Context, id uuid.UUID, expectedUpdatedAt time.Time, enabled bool, updatedAt time.Time) (bool, error) {
+	result := r.db.WithContext(ctx).Model(&model.Flag{}).
+		Where("id = ? AND updated_at = ? AND enabled = ?", id, expectedUpdatedAt, !enabled).
+		UpdateColumns(map[string]interface{}{"enabled": enabled, "updated_at": updatedAt})
+	return result.RowsAffected == 1, result.Error
 }
 
 func (r *repo) Delete(ctx context.Context, id uuid.UUID) error {

--- a/backend/internal/feature/repo/schedule_test.go
+++ b/backend/internal/feature/repo/schedule_test.go
@@ -1,0 +1,70 @@
+package repo
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/feature/model"
+	"github.com/google/uuid"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestScheduledStateCompareAndSwapPostgres(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		if os.Getenv("TEST_DATABASE_REQUIRED") == "1" {
+			t.Fatal("TEST_DATABASE_URL required")
+		}
+		t.Skip("set TEST_DATABASE_URL to a migrated test database")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	defer tx.Rollback()
+	r := New(tx)
+	ctx := context.Background()
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	flag := &model.Flag{ID: uuid.New(), FlagKey: "test.cas." + uuid.NewString(),
+		Name: "Original", FlagType: model.TypeBoolean, CreatedAt: now, UpdatedAt: now}
+	if err := r.Create(ctx, flag); err != nil {
+		t.Fatal(err)
+	}
+	// A manual edit lands after the scheduler's read.
+	flag.Name, flag.UpdatedAt = "Manual", now.Add(time.Second)
+	if err := r.Update(ctx, flag); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := r.UpdateScheduledState(ctx, flag.ID, now, true, now.Add(2*time.Second)); err != nil || changed {
+		t.Fatalf("stale write accepted: %v %v", changed, err)
+	}
+	fresh, err := r.GetByID(ctx, flag.ID)
+	if err != nil || fresh == nil {
+		t.Fatalf("load: %v", err)
+	}
+	if fresh.Enabled || fresh.Name != "Manual" {
+		t.Fatalf("manual edit lost: %+v", fresh)
+	}
+	if changed, err := r.UpdateScheduledState(ctx, flag.ID, fresh.UpdatedAt, true, now.Add(3*time.Second)); err != nil || !changed {
+		t.Fatalf("fresh write skipped: %v %v", changed, err)
+	}
+	if changed, err := r.UpdateScheduledState(ctx, flag.ID, fresh.UpdatedAt, true, now.Add(4*time.Second)); err != nil || changed {
+		t.Fatalf("duplicate write accepted: %v %v", changed, err)
+	}
+	got, err := r.GetByID(ctx, flag.ID)
+	if err != nil || got == nil || !got.Enabled || got.Name != "Manual" {
+		t.Fatalf("state or unrelated field incorrect: %+v %v", got, err)
+	}
+}

--- a/backend/internal/feature/service/mem_test.go
+++ b/backend/internal/feature/service/mem_test.go
@@ -92,6 +92,17 @@ func (m *memRepo) Update(_ context.Context, flag *model.Flag) error {
 	return nil
 }
 
+func (m *memRepo) UpdateScheduledState(_ context.Context, id uuid.UUID, expectedUpdatedAt time.Time, enabled bool, updatedAt time.Time) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	row := m.flags[id]
+	if row == nil || !row.UpdatedAt.Equal(expectedUpdatedAt) || row.Enabled == enabled {
+		return false, nil
+	}
+	row.Enabled, row.UpdatedAt = enabled, updatedAt
+	return true, nil
+}
+
 func (m *memRepo) Delete(_ context.Context, id uuid.UUID) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/feature/service/schedule.go
+++ b/backend/internal/feature/service/schedule.go
@@ -78,8 +78,12 @@ func (s *flagService) persistSchedule(ctx context.Context, id uuid.UUID, actor u
 	before := *latest
 	latest.Enabled = enabled
 	latest.UpdatedAt = now
-	if err := s.rows.Update(ctx, latest); err != nil {
+	updated, err := s.rows.UpdateScheduledState(ctx, latest.ID, before.UpdatedAt, enabled, now)
+	if err != nil {
 		logCacheErr("schedule-update", err)
+		return false
+	}
+	if !updated {
 		return false
 	}
 	s.audit(ctx, latest, actor, action, &before, latest, action)

--- a/backend/internal/feature/service/schedule_race_test.go
+++ b/backend/internal/feature/service/schedule_race_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Yogdunana/StarByte/backend/internal/feature/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/feature/model"
+	"github.com/google/uuid"
+)
+
+type afterGetScheduleRepo struct {
+	*memRepo
+	afterGet func()
+}
+
+func (r *afterGetScheduleRepo) GetByID(ctx context.Context, id uuid.UUID) (*model.Flag, error) {
+	row, err := r.memRepo.GetByID(ctx, id)
+	if fn := r.afterGet; fn != nil {
+		r.afterGet = nil
+		fn()
+	}
+	return row, err
+}
+
+func TestSchedulePreservesEditAfterRead(t *testing.T) {
+	for _, initiallyEnabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "schedule_on", true: "schedule_off"}[initiallyEnabled], func(t *testing.T) {
+			ctx := context.Background()
+			rows := &afterGetScheduleRepo{memRepo: newMemRepo()}
+			svc := New(rows, NewMemorySnapshot(), NewMemoryBus(), stubRoles{}, stubUsers{}, stubPerms{}).(*flagService)
+			now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+			boundary := now.Add(time.Hour)
+			svc.now = func() time.Time { return now }
+			rules := model.Rules{StartsAt: &boundary}
+			if initiallyEnabled {
+				rules = model.Rules{EndsAt: &boundary}
+			}
+			created, err := svc.Create(ctx, uuid.New(), &dto.CreateFlagRequest{
+				FlagKey: "race.after_read", Name: "Race", FlagType: model.TypeBoolean,
+				Enabled: initiallyEnabled, Rules: rules,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			id := uuid.MustParse(created.ID)
+			now = boundary.Add(time.Second)
+			rows.afterGet = func() {
+				_, err := svc.Update(ctx, uuid.New(), id, &dto.UpdateFlagRequest{Enabled: &initiallyEnabled})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if n := svc.applySchedules(ctx); n != 0 {
+				t.Fatalf("stale scheduler reported %d updates", n)
+			}
+			got, err := rows.GetByID(ctx, id)
+			if err != nil || got.Enabled != initiallyEnabled || !got.UpdatedAt.Equal(now) {
+				t.Fatalf("manual choice lost: %+v, %v", got, err)
+			}
+			for _, audit := range rows.audits {
+				if audit.Action == model.ActionScheduleOn || audit.Action == model.ActionScheduleOff {
+					t.Fatal("skipped scheduler wrote an audit")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
定时器读取开关后，管理员可能先保存人工选择或规则；原代码随后全行 Save，覆盖这次编辑。现在定时更新按读取到的 updated_at 和原 enabled 状态执行条件写入，仅修改 enabled/updated_at，冲突时跳过，也不生成虚假定时审计。

验证：旧代码在定时开启、定时关闭的读后人工修改回归中均失败；修复后全部 feature 包 go test -race 通过，含 PostgreSQL 条件更新、过期写入拒绝和保留无关字段测试。新回归随现有 CI 执行。

延续 #186 原分支，无 Autofix 分支或新增迁移。计划 #188 合并后 rebase 最新 main，再以最终 head 的 CI/Security 结果合并。Bugbot 当前仓库禁用，不声称已通过 Bugbot。