### PR TITLE
fix(account): complete role permissions and editable profiles

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -524,7 +524,7 @@ func main() {
 		authHandler.RegisterRoutes(nil, protected, authH, nil, cacheService)
 
 		// 用户模块
-		handler.RegisterUserRoutes(protected, userHandler)
+		handler.RegisterUserRoutes(protected, userHandler, cacheService)
 
 		// RBAC 系统管理模块
 		// 权限校验和数据权限中间件在 RegisterRoutes 内部按正确顺序注册

--- a/backend/internal/auth/service/auth_service_test.go
+++ b/backend/internal/auth/service/auth_service_test.go
@@ -871,3 +871,7 @@ func TestLogin_SuperAdminRoles(t *testing.T) {
 	assert.Equal(t, []string{"super_admin"}, result.User.Roles)
 	assert.Equal(t, []string{"*"}, result.User.Permissions)
 }
+
+func (m *mockUserRepo) UpdateProfile(ctx context.Context, id uuid.UUID, changes map[string]interface{}) error {
+	return m.Called(ctx, id, changes).Error(0)
+}

--- a/backend/internal/rbac/handler/role_membership.go
+++ b/backend/internal/rbac/handler/role_membership.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"fmt"
+	"github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	userModel "github.com/Yogdunana/StarByte/backend/internal/user/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/response"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Role membership changes follow the same system-role protection as permission assignment.
+func roleMembership(db *gorm.DB, cache rbacService.PermissionCacheService, add bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		roleID, err := uuid.Parse(c.Param("id"))
+		if err != nil {
+			response.BadRequest(c, "无效角色ID")
+			return
+		}
+		userID, err := uuid.Parse(c.Param("user_id"))
+		if err != nil {
+			response.BadRequest(c, "无效用户ID")
+			return
+		}
+		err = db.WithContext(c.Request.Context()).Transaction(func(tx *gorm.DB) error {
+			var role model.Role
+			if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&role, "id = ?", roleID).Error; err != nil {
+				if err == gorm.ErrRecordNotFound {
+					return response.NewError(response.CodeNotFound, "角色不存在")
+				}
+				return err
+			}
+			if role.IsSystem {
+				return response.NewForbiddenError("系统内置角色由业务流程管理")
+			}
+			if add && role.Status != 0 {
+				return response.NewError(response.CodeBadRequest, "角色已禁用")
+			}
+			var user userModel.User
+			if err := tx.First(&user, "id = ?", userID).Error; err != nil {
+				if err == gorm.ErrRecordNotFound {
+					return response.NewError(response.CodeNotFound, "用户不存在")
+				}
+				return err
+			}
+			if !add {
+				return tx.Where("role_id = ? AND user_id = ?", roleID, userID).Delete(&model.UserRole{}).Error
+			}
+			if user.Status != 0 {
+				return response.NewError(response.CodeBadRequest, "用户不可用")
+			}
+			return tx.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "user_id"}, {Name: "role_id"}}, DoUpdates: clause.Assignments(map[string]interface{}{"expired_at": nil})}).Create(&model.UserRole{ID: uuid.New(), UserID: userID, RoleID: roleID}).Error
+		})
+		if err == nil {
+			err = cache.InvalidateUserPermissions(c.Request.Context(), userID)
+		}
+		if err != nil {
+			response.Error(c, fmt.Errorf("role membership: %w", err))
+			return
+		}
+		response.OKWithoutData(c)
+	}
+}

--- a/backend/internal/rbac/handler/role_membership_test.go
+++ b/backend/internal/rbac/handler/role_membership_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"context"
+	"github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	userModel "github.com/Yogdunana/StarByte/backend/internal/user/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+)
+
+type membershipCache struct {
+	rbacService.PermissionCacheService
+	invalidated []uuid.UUID
+}
+
+func (c *membershipCache) InvalidateUserPermissions(_ context.Context, id uuid.UUID) error {
+	c.invalidated = append(c.invalidated, id)
+	return nil
+}
+func TestRoleMembershipCustomRoleAndSystemProtection(t *testing.T) {
+	db := testutil.OpenPostgres(t)
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+	defer tx.Rollback()
+	role := model.Role{ID: uuid.New(), Name: "Custom", Code: "test_" + uuid.NewString()}
+	require.NoError(t, tx.Create(&role).Error)
+	user := userModel.User{ID: uuid.New(), Username: "membership_" + uuid.NewString(), PasswordHash: "not-a-login-hash"}
+	require.NoError(t, tx.Create(&user).Error)
+	cache := &membershipCache{}
+	r := testutil.NewEngine()
+	r.PUT("/roles/:id/users/:user_id", roleMembership(tx, cache, true))
+	r.DELETE("/roles/:id/users/:user_id", roleMembership(tx, cache, false))
+	path := "/roles/" + role.ID.String() + "/users/" + user.ID.String()
+	for i := 0; i < 2; i++ {
+		w := testutil.JSONRequest(t, r, "PUT", path, nil, nil)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	}
+	var count int64
+	require.NoError(t, tx.Model(&model.UserRole{}).Where("user_id = ? AND role_id = ?", user.ID, role.ID).Count(&count).Error)
+	require.EqualValues(t, 1, count)
+	w := testutil.JSONRequest(t, r, "DELETE", path, nil, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, cache.invalidated, 3)
+	require.NoError(t, tx.Model(&role).Update("is_system", true).Error)
+	w = testutil.JSONRequest(t, r, "PUT", path, nil, nil)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	w = testutil.JSONRequest(t, r, "DELETE", path, nil, nil)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Len(t, cache.invalidated, 3)
+}

--- a/backend/internal/rbac/handler/routes.go
+++ b/backend/internal/rbac/handler/routes.go
@@ -47,6 +47,8 @@ func RegisterRoutes(
 			withPermission(roles, "role:update", cacheService).PUT("/:id", roleHandler.Update)
 			withPermission(roles, "role:delete", cacheService).DELETE("/:id", roleHandler.Delete)
 			withPermission(roles, "role:assign", cacheService).PUT("/:id/permissions", roleHandler.AssignPermissions)
+			withPermission(roles, "role:assign", cacheService).PUT("/:id/users/:user_id", roleMembership(db, cacheService, true))
+			withPermission(roles, "role:assign", cacheService).DELETE("/:id/users/:user_id", roleMembership(db, cacheService, false))
 		}
 		// 角色用户列表：查询用户数据，需应用数据权限
 		roleUsers := system.Group("/roles")

--- a/backend/internal/rbac/repo/role_repo.go
+++ b/backend/internal/rbac/repo/role_repo.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Yogdunana/StarByte/backend/internal/rbac/model"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // RoleRepo 角色数据访问接口
@@ -134,6 +135,18 @@ func (r *roleRepo) Delete(ctx context.Context, id uuid.UUID) error {
 // dataScope 指定数据权限范围，为空时默认使用 department
 func (r *roleRepo) AssignPermissions(ctx context.Context, tx *gorm.DB, roleID uuid.UUID, permissionIDs []uuid.UUID, dataScope string) error {
 	db := r.getDB(tx).WithContext(ctx)
+	// An omitted scope means edit the permission selection only. Keep retained
+	// grants (including custom department bindings) instead of resetting them.
+	if dataScope == "" && len(permissionIDs) > 0 {
+		if err := db.Where("role_id = ? AND permission_id NOT IN ?", roleID, permissionIDs).Delete(&model.RolePermission{}).Error; err != nil {
+			return err
+		}
+		grants := make([]model.RolePermission, 0, len(permissionIDs))
+		for _, id := range permissionIDs {
+			grants = append(grants, model.RolePermission{ID: uuid.New(), RoleID: roleID, PermissionID: id, DataScope: model.DataScopeDepartment})
+		}
+		return db.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "role_id"}, {Name: "permission_id"}}, DoNothing: true}).Create(&grants).Error
+	}
 
 	// 删除现有角色-权限关联
 	if err := db.Where("role_id = ?", roleID).Delete(&model.RolePermission{}).Error; err != nil {

--- a/backend/internal/rbac/repo/role_scope_test.go
+++ b/backend/internal/rbac/repo/role_scope_test.go
@@ -1,0 +1,34 @@
+package repo
+
+import (
+	"context"
+	"github.com/Yogdunana/StarByte/backend/internal/rbac/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPermissionSelectionPreservesExistingDataScope(t *testing.T) {
+	tx := testutil.OpenPostgres(t).Begin()
+	require.NoError(t, tx.Error)
+	defer tx.Rollback()
+	role := model.Role{ID: uuid.New(), Name: "Scope", Code: "scope_" + uuid.NewString()}
+	require.NoError(t, tx.Create(&role).Error)
+	perms := []model.Permission{{ID: uuid.New(), Name: "Read", Code: "read_" + uuid.NewString(), Type: model.PermissionTypeAPI}, {ID: uuid.New(), Name: "Write", Code: "write_" + uuid.NewString(), Type: model.PermissionTypeAPI}}
+	require.NoError(t, tx.Create(&perms).Error)
+	grant := model.RolePermission{ID: uuid.New(), RoleID: role.ID, PermissionID: perms[0].ID, DataScope: model.DataScopeAll}
+	require.NoError(t, tx.Create(&grant).Error)
+	require.NoError(t, NewRoleRepo(tx).AssignPermissions(context.Background(), tx, role.ID, []uuid.UUID{perms[0].ID, perms[1].ID}, ""))
+	var grants []model.RolePermission
+	require.NoError(t, tx.Where("role_id = ?", role.ID).Find(&grants).Error)
+	require.Len(t, grants, 2)
+	for _, g := range grants {
+		if g.PermissionID == perms[0].ID {
+			require.Equal(t, grant.ID, g.ID)
+			require.Equal(t, model.DataScopeAll, g.DataScope)
+		} else {
+			require.Equal(t, model.DataScopeDepartment, g.DataScope)
+		}
+	}
+}

--- a/backend/internal/user/dto/user.go
+++ b/backend/internal/user/dto/user.go
@@ -13,11 +13,11 @@ type RegisterRequest struct {
 
 // UpdateProfileRequest 更新个人信息请求
 type UpdateProfileRequest struct {
-	RealName  string `json:"real_name" binding:"omitempty,max=50"`
-	AvatarURL string `json:"avatar_url" binding:"omitempty,max=500"`
-	Email     string `json:"email" binding:"omitempty,email"`
-	Phone     string `json:"phone" binding:"omitempty,max=20"`
-	Gender    *int   `json:"gender" binding:"omitempty,oneof=0 1 2"`
+	RealName  string  `json:"real_name" binding:"omitempty,max=50"`
+	AvatarURL string  `json:"avatar_url" binding:"omitempty,max=500"`
+	Email     *string `json:"email" binding:"omitempty,max=100,email|eq="`
+	Phone     *string `json:"phone" binding:"omitempty,max=20"`
+	Gender    *int    `json:"gender" binding:"omitempty,oneof=0 1 2"`
 }
 
 // ChangePasswordRequest 修改密码请求

--- a/backend/internal/user/handler/user_routes.go
+++ b/backend/internal/user/handler/user_routes.go
@@ -1,9 +1,13 @@
 package handler
 
-import "github.com/gin-gonic/gin"
+import (
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware"
+	"github.com/gin-gonic/gin"
+)
 
 // RegisterUserRoutes 注册用户路由（需要鉴权）
-func RegisterUserRoutes(r *gin.RouterGroup, handler *UserHandler) {
+func RegisterUserRoutes(r *gin.RouterGroup, handler *UserHandler, cache rbacService.PermissionCacheService) {
 	user := r.Group("/user")
 	{
 		user.GET("/me", handler.GetCurrentUser)
@@ -13,10 +17,10 @@ func RegisterUserRoutes(r *gin.RouterGroup, handler *UserHandler) {
 
 	users := r.Group("/users")
 	{
-		users.GET("", handler.ListUser)
-		users.GET("/:id", handler.GetUser)
-		users.POST("", handler.CreateUser)
-		users.PUT("/:id", handler.UpdateUser)
-		users.DELETE("/:id", handler.DeleteUser)
+		users.GET("", middleware.RequirePermission("user:read"), middleware.PermissionRequired(cache), handler.ListUser)
+		users.GET("/:id", middleware.RequirePermission("user:read"), middleware.PermissionRequired(cache), handler.GetUser)
+		users.POST("", middleware.RequirePermission("user:create"), middleware.PermissionRequired(cache), handler.CreateUser)
+		users.PUT("/:id", middleware.RequirePermission("user:update"), middleware.PermissionRequired(cache), handler.UpdateUser)
+		users.DELETE("/:id", middleware.RequirePermission("user:delete"), middleware.PermissionRequired(cache), handler.DeleteUser)
 	}
 }

--- a/backend/internal/user/handler/user_routes_test.go
+++ b/backend/internal/user/handler/user_routes_test.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"context"
+	rbacService "github.com/Yogdunana/StarByte/backend/internal/rbac/service"
+	"github.com/Yogdunana/StarByte/backend/internal/user/dto"
+	"github.com/Yogdunana/StarByte/backend/internal/user/service"
+	"github.com/Yogdunana/StarByte/backend/pkg/middleware/auth"
+	"github.com/Yogdunana/StarByte/backend/pkg/testutil"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+)
+
+type routeCache struct {
+	rbacService.PermissionCacheService
+	permissions []string
+}
+
+func (r routeCache) GetUserPermissionsAndSuperAdmin(context.Context, uuid.UUID) ([]string, bool, error) {
+	return r.permissions, false, nil
+}
+
+type profileService struct {
+	service.UserService
+	caller  string
+	profile *dto.UpdateProfileRequest
+}
+
+func (s *profileService) UpdateProfile(_ context.Context, caller string, profile *dto.UpdateProfileRequest) error {
+	s.caller, s.profile = caller, profile
+	return nil
+}
+func TestUserManagementRequiresPermissions(t *testing.T) {
+	id := uuid.NewString()
+	r := testutil.NewEngine()
+	r.Use(func(c *gin.Context) { c.Set(auth.ContextKeyUserID, id); c.Next() })
+	RegisterUserRoutes(r.Group(""), NewUserHandler(&profileService{}), routeCache{})
+	for _, route := range []struct{ method, path string }{{"GET", "/users"}, {"GET", "/users/" + id}, {"POST", "/users"}, {"PUT", "/users/" + id}, {"DELETE", "/users/" + id}} {
+		w := testutil.JSONRequest(t, r, route.method, route.path, nil, nil)
+		require.Equal(t, http.StatusForbidden, w.Code, route)
+	}
+}
+func TestProfileUsesCallerAndIgnoresPrivilegeFields(t *testing.T) {
+	id := uuid.NewString()
+	svc := &profileService{}
+	r := testutil.NewEngine()
+	r.Use(func(c *gin.Context) { c.Set(auth.ContextKeyUserID, id); c.Next() })
+	RegisterUserRoutes(r.Group(""), NewUserHandler(svc), routeCache{})
+	w := testutil.JSONRequest(t, r, "PUT", "/user/profile", map[string]interface{}{"real_name": "新姓名", "user_id": uuid.NewString(), "role_ids": []string{uuid.NewString()}, "status": 0, "phone": "", "email": ""}, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, id, svc.caller)
+	require.Equal(t, "新姓名", svc.profile.RealName)
+	require.NotNil(t, svc.profile.Phone)
+	require.Empty(t, *svc.profile.Phone)
+}

--- a/backend/internal/user/repo/profile_test.go
+++ b/backend/internal/user/repo/profile_test.go
@@ -1,0 +1,32 @@
+package repo
+
+import (
+	"context"
+	"github.com/Yogdunana/StarByte/backend/internal/user/model"
+	"github.com/Yogdunana/StarByte/backend/pkg/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestProfileUpdateKeepsIdentityAndSyncsMemberName(t *testing.T) {
+	db := testutil.OpenPostgres(t)
+	tx := db.Begin()
+	require.NoError(t, tx.Error)
+	defer tx.Rollback()
+	id := uuid.New()
+	u := &model.User{ID: id, Username: "profile_" + id.String(), PasswordHash: "not-a-login-hash", RealName: "Old", Email: "old@example.test", Status: 2}
+	require.NoError(t, tx.Create(u).Error)
+	require.NoError(t, tx.Exec("INSERT INTO member_profiles(id,user_id,real_name,student_no) VALUES (?,?,?,?)", uuid.New(), id, "Old", "student-"+id.String()[:20]).Error)
+	require.NoError(t, NewUserRepo(tx).UpdateProfile(context.Background(), id, map[string]interface{}{"real_name": "New", "email": ""}))
+	var got model.User
+	require.NoError(t, tx.First(&got, "id = ?", id).Error)
+	require.Equal(t, "New", got.RealName)
+	require.Empty(t, got.Email)
+	require.Equal(t, u.Username, got.Username)
+	require.Equal(t, 2, got.Status)
+	var p struct{ RealName, StudentNo string }
+	require.NoError(t, tx.Table("member_profiles").Where("user_id = ?", id).First(&p).Error)
+	require.Equal(t, "New", p.RealName)
+	require.Equal(t, "student-"+id.String()[:20], p.StudentNo)
+}

--- a/backend/internal/user/repo/user_repo.go
+++ b/backend/internal/user/repo/user_repo.go
@@ -11,6 +11,7 @@ import (
 
 // UserRepo 用户数据访问接口
 type UserRepo interface {
+	UpdateProfile(ctx context.Context, id uuid.UUID, changes map[string]interface{}) error
 	Create(ctx context.Context, tx *gorm.DB, user *model.User) error
 	GetByID(ctx context.Context, id uuid.UUID) (*model.User, error)
 	GetByUsername(ctx context.Context, username string) (*model.User, error)
@@ -139,4 +140,19 @@ func (r *userRepo) CreateIdentity(ctx context.Context, ident *model.UserIdentity
 		ident.ID = uuid.New()
 	}
 	return r.db.WithContext(ctx).Create(ident).Error
+}
+
+// UpdateProfile writes only self-editable fields and keeps the displayed member name in sync.
+func (r *userRepo) UpdateProfile(ctx context.Context, id uuid.UUID, changes map[string]interface{}) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&model.User{}).Where("id = ?", id).Updates(changes).Error; err != nil {
+			return err
+		}
+		if name, ok := changes["real_name"]; ok {
+			if err := tx.Table("member_profiles").Where("user_id = ?", id).Updates(map[string]interface{}{"real_name": name}).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }

--- a/backend/internal/user/service/user_service.go
+++ b/backend/internal/user/service/user_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Yogdunana/StarByte/backend/internal/user/dto"
@@ -307,23 +308,30 @@ func (s *userService) UpdateProfile(ctx context.Context, userID string, req *dto
 		return response.NewError(response.CodeNotFound, "用户不存在")
 	}
 
+	changes := map[string]interface{}{}
 	if req.RealName != "" {
-		user.RealName = req.RealName
+		name := strings.TrimSpace(req.RealName)
+		if name == "" {
+			return response.NewError(response.CodeBadRequest, "姓名不能为空")
+		}
+		changes["real_name"] = name
 	}
 	if req.AvatarURL != "" {
-		user.AvatarURL = req.AvatarURL
+		changes["avatar_url"] = req.AvatarURL
 	}
-	if req.Email != "" {
-		user.Email = req.Email
+	if req.Email != nil {
+		changes["email"] = strings.TrimSpace(*req.Email)
 	}
-	if req.Phone != "" {
-		user.Phone = req.Phone
+	if req.Phone != nil {
+		changes["phone"] = strings.TrimSpace(*req.Phone)
 	}
 	if req.Gender != nil {
-		user.Gender = *req.Gender
+		changes["gender"] = *req.Gender
 	}
-
-	return s.userRepo.Update(ctx, nil, user)
+	if len(changes) == 0 {
+		return nil
+	}
+	return s.userRepo.UpdateProfile(ctx, uid, changes)
 }
 
 // ========== 工具函数 ==========

--- a/backend/internal/user/service/user_service_test.go
+++ b/backend/internal/user/service/user_service_test.go
@@ -217,3 +217,22 @@ func TestGetCurrentUser_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "alice", result.Username)
 }
+
+func (m *mockUserRepo) UpdateProfile(ctx context.Context, id uuid.UUID, changes map[string]interface{}) error {
+	return m.Called(ctx, id, changes).Error(0)
+}
+
+func TestUpdateProfileOnlyWritesEditableFields(t *testing.T) {
+	r := &mockUserRepo{}
+	svc := newTestUserService(r)
+	id := uuid.New()
+	blank := ""
+	original := &model.User{ID: id, Username: "stable-login", RealName: "Old", Status: 2}
+	r.On("GetByID", mock.Anything, id).Return(original, nil)
+	r.On("UpdateProfile", mock.Anything, id, map[string]interface{}{"real_name": "New", "phone": ""}).Return(nil)
+	requireErr := svc.UpdateProfile(context.Background(), id.String(), &dto.UpdateProfileRequest{RealName: "New", Phone: &blank})
+	assert.NoError(t, requireErr)
+	assert.Equal(t, 2, original.Status)
+	assert.Equal(t, "Old", original.RealName)
+	r.AssertExpectations(t)
+}

--- a/frontend/src/api/role.ts
+++ b/frontend/src/api/role.ts
@@ -42,3 +42,38 @@ export function assignRolePermissions(roleId: string, permissionIds: string[]): 
 export function getPermissionTree(): Promise<Permission[]> {
   return request.get('/system/permissions');
 }
+
+export type PermissionInput = {
+  name: string;
+  code?: string;
+  type?: Permission['type'];
+  parent_id?: string;
+  description?: string;
+  path?: string;
+  icon?: string;
+  resource?: string;
+  action?: string;
+  api_method?: string;
+  api_path?: string;
+  status?: number;
+  sort_order?: number;
+};
+export const createPermission = (data: PermissionInput): Promise<Permission> =>
+  request.post('/system/permissions', data);
+export const updatePermission = (id: string, data: PermissionInput): Promise<Permission> =>
+  request.put(`/system/permissions/${id}`, data);
+export const deletePermission = (id: string): Promise<void> =>
+  request.delete(`/system/permissions/${id}`);
+
+export interface RoleMember {
+  id: string;
+  username: string;
+  real_name: string;
+  status: number;
+}
+export const getRoleMembers = (id: string, page: number): Promise<PageResponse<RoleMember>> =>
+  request.get(`/system/roles/${id}/users`, { params: { page, page_size: 20 } });
+export const addRoleMember = (id: string, userId: string): Promise<void> =>
+  request.put(`/system/roles/${id}/users/${userId}`);
+export const removeRoleMember = (id: string, userId: string): Promise<void> =>
+  request.delete(`/system/roles/${id}/users/${userId}`);

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -75,3 +75,13 @@ export function deleteUser(id: string): Promise<void> {
 export function resetUserPassword(id: string, newPassword: string): Promise<void> {
   return request.post(`/users/${id}/reset-password`, { new_password: newPassword });
 }
+
+export interface ProfileUpdate {
+  real_name?: string;
+  email?: string;
+  phone?: string;
+  gender?: number;
+  avatar_url?: string;
+}
+export const updateMyProfile = (data: ProfileUpdate): Promise<void> =>
+  request.put('/user/profile', data);

--- a/frontend/src/pages/member/application/ApplicationForm.test.tsx
+++ b/frontend/src/pages/member/application/ApplicationForm.test.tsx
@@ -1,0 +1,53 @@
+import { act, fireEvent, render, screen, waitFor, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { Modal } from 'antd';
+import ApplicationForm from './ApplicationForm';
+import { getMemberDepartments } from '@/api/member';
+import { getCurrentUser } from '@/api/auth';
+vi.mock('@/api/auth', () => ({ getCurrentUser: vi.fn() }));
+vi.mock('@/api/member', () => ({
+  getMemberDepartments: vi.fn().mockResolvedValue([]),
+  submitApplication: vi.fn(),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback: string) => fallback || key }),
+}));
+afterEach(() => {
+  cleanup();
+  Modal.destroyAll();
+  vi.restoreAllMocks();
+});
+beforeEach(() => {
+  vi.mocked(getMemberDepartments).mockResolvedValue([]);
+  vi.mocked(getCurrentUser).mockResolvedValue({
+    real_name: '张三',
+    student_no: '2026001',
+  } as Awaited<ReturnType<typeof getCurrentUser>>);
+});
+it('prefills identity, keeps it readonly on cancel, and unlocks only the confirmed field', async () => {
+  const confirm = vi.spyOn(Modal, 'confirm').mockReturnValue({ destroy: vi.fn(), update: vi.fn() });
+  render(<ApplicationForm />);
+  const name = (await screen.findByDisplayValue('张三')) as HTMLInputElement;
+  const student = screen.getByDisplayValue('2026001') as HTMLInputElement;
+  expect(name.readOnly).toBe(true);
+  expect(student.readOnly).toBe(true);
+  fireEvent.click(name);
+  expect(confirm.mock.calls[0][0].title).toBe('是否确定修改');
+  expect(name.readOnly).toBe(true);
+  fireEvent.click(name);
+  act(() => {
+    confirm.mock.calls[1][0].onOk?.();
+  });
+  await waitFor(() => expect(name.readOnly).toBe(false));
+  expect(student.readOnly).toBe(true);
+  fireEvent.change(name, { target: { value: '李四' } });
+  expect(name.value).toBe('李四');
+});
+it('keeps missing identity editable', async () => {
+  vi.mocked(getCurrentUser).mockResolvedValue({ real_name: '', student_no: '' } as Awaited<
+    ReturnType<typeof getCurrentUser>
+  >);
+  render(<ApplicationForm />);
+  await waitFor(() => expect(getCurrentUser).toHaveBeenCalled());
+  expect((screen.getByPlaceholderText('真实姓名') as HTMLInputElement).readOnly).toBe(false);
+});

--- a/frontend/src/pages/member/application/ApplicationForm.tsx
+++ b/frontend/src/pages/member/application/ApplicationForm.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Form, Input, Select, Steps, Tag, message } from 'antd';
+import { Button, Form, Input, Select, Steps, Tag, Modal, message } from 'antd';
+import { getCurrentUser } from '@/api/auth';
+import { useTranslation } from 'react-i18next';
 import { getMemberDepartments, submitApplication } from '@/api/member';
 import type { CreateMemberApplicationParams, MemberDepartmentOption } from '@/types/api';
 
@@ -10,6 +12,9 @@ interface ApplicationFormProps {
 }
 
 const ApplicationForm: React.FC<ApplicationFormProps> = ({ onSubmitted }) => {
+  const { t } = useTranslation();
+  const [identity, setIdentity] = useState<Partial<CreateMemberApplicationParams>>({});
+  const [locked, setLocked] = useState({ real_name: false, student_no: false });
   const [form] = Form.useForm<CreateMemberApplicationParams>();
   const applicantType = Form.useWatch('applicant_type', form);
   const [step, setStep] = useState(0);
@@ -21,6 +26,38 @@ const ApplicationForm: React.FC<ApplicationFormProps> = ({ onSubmitted }) => {
       .then(setDepartments)
       .catch(() => undefined);
   }, []);
+
+  useEffect(() => {
+    let active = true;
+    void getCurrentUser()
+      .then((user) => {
+        if (!active) return;
+        const values: Partial<CreateMemberApplicationParams> = {};
+        const locks = { real_name: false, student_no: false };
+        for (const field of ['real_name', 'student_no'] as const) {
+          if (user[field]?.trim() && !form.isFieldTouched(field)) {
+            values[field] = user[field];
+            locks[field] = true;
+          }
+        }
+        form.setFieldsValue(values);
+        setIdentity(values);
+        setLocked(locks);
+      })
+      .catch(() => undefined);
+    return () => {
+      active = false;
+    };
+  }, [form]);
+
+  const unlock = (field: 'real_name' | 'student_no') => {
+    if (!locked[field]) return;
+    Modal.confirm({
+      title: t('application.confirmIdentityEdit', '是否确定修改'),
+      content: t('application.identityEditHint', '此信息已自动获取，请确认修改后的信息准确。'),
+      onOk: () => setLocked((current) => ({ ...current, [field]: false })),
+    });
+  };
 
   const next = async () => {
     const fields =
@@ -41,6 +78,8 @@ const ApplicationForm: React.FC<ApplicationFormProps> = ({ onSubmitted }) => {
       });
       message.success('申请已提交');
       form.resetFields();
+      form.setFieldsValue(identity);
+      setLocked({ real_name: !!identity.real_name, student_no: !!identity.student_no });
       setStep(0);
       onSubmitted?.();
     } finally {
@@ -65,13 +104,63 @@ const ApplicationForm: React.FC<ApplicationFormProps> = ({ onSubmitted }) => {
               ]}
             />
           </Form.Item>
-          <Form.Item name="real_name" label="姓名" rules={[{ required: true, whitespace: true, max: 50 }]}>
-            <Input placeholder="真实姓名" />
+          <Form.Item
+            name="real_name"
+            label="姓名"
+            rules={[{ required: true, whitespace: true, max: 50 }]}
+          >
+            <Input
+              placeholder="真实姓名"
+              readOnly={locked.real_name}
+              style={
+                locked.real_name
+                  ? {
+                      background: 'var(--ant-color-fill-tertiary, #f5f5f5)',
+                      color: 'var(--ant-color-text-secondary, #666)',
+                      cursor: 'pointer',
+                    }
+                  : undefined
+              }
+              onClick={() => unlock('real_name')}
+              onKeyDown={(event) => {
+                if (locked.real_name && (event.key === 'Enter' || event.key === ' ')) {
+                  event.preventDefault();
+                  unlock('real_name');
+                }
+              }}
+            />
           </Form.Item>
-          <Form.Item name="student_no" label="学号" rules={[{ required: true, whitespace: true, max: 30 }]}>
-            <Input placeholder="学号" />
+          <Form.Item
+            name="student_no"
+            label="学号"
+            rules={[{ required: true, whitespace: true, max: 30 }]}
+          >
+            <Input
+              placeholder="学号"
+              readOnly={locked.student_no}
+              style={
+                locked.student_no
+                  ? {
+                      background: 'var(--ant-color-fill-tertiary, #f5f5f5)',
+                      color: 'var(--ant-color-text-secondary, #666)',
+                      cursor: 'pointer',
+                    }
+                  : undefined
+              }
+              onClick={() => unlock('student_no')}
+              onKeyDown={(event) => {
+                if (locked.student_no && (event.key === 'Enter' || event.key === ' ')) {
+                  event.preventDefault();
+                  unlock('student_no');
+                }
+              }}
+            />
           </Form.Item>
-          <Form.Item name="department_id" label="意向部门" rules={[{ required: applicantType === 2, message: '干事申请请选择意向部门' }]}>
+          <Form.Item
+            name="department_id"
+            label="意向部门"
+            rules={[{ required: applicantType === 2, message: '干事申请请选择意向部门' }]}
+          >
             <Select
               allowClear
               placeholder="选择部门"
@@ -92,7 +181,11 @@ const ApplicationForm: React.FC<ApplicationFormProps> = ({ onSubmitted }) => {
           </Form.Item>
         </div>
         <div style={{ display: step === 2 ? 'block' : 'none' }}>
-          <Form.Item name="reason" label="申请理由" rules={[{ required: true, whitespace: true, max: 2000 }]}>
+          <Form.Item
+            name="reason"
+            label="申请理由"
+            rules={[{ required: true, whitespace: true, max: 2000 }]}
+          >
             <TextArea rows={4} placeholder="为什么想加入协会" />
           </Form.Item>
           <Form.Item name="skills" label="技能标签">
@@ -108,11 +201,22 @@ const ApplicationForm: React.FC<ApplicationFormProps> = ({ onSubmitted }) => {
           上一步
         </Button>
         {step < 2 ? (
-          <Button type="primary" onClick={() => { void next().catch(() => undefined); }}>
+          <Button
+            type="primary"
+            onClick={() => {
+              void next().catch(() => undefined);
+            }}
+          >
             下一步
           </Button>
         ) : (
-          <Button type="primary" loading={submitting} onClick={() => { void handleSubmit().catch(() => undefined); }}>
+          <Button
+            type="primary"
+            loading={submitting}
+            onClick={() => {
+              void handleSubmit().catch(() => undefined);
+            }}
+          >
             提交申请
           </Button>
         )}

--- a/frontend/src/pages/system/permission/PermissionPage.tsx
+++ b/frontend/src/pages/system/permission/PermissionPage.tsx
@@ -1,0 +1,217 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Button,
+  Card,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Select,
+  Space,
+  Table,
+  Tag,
+  TreeSelect,
+  message,
+} from 'antd';
+import type { DataNode } from 'antd/es/tree';
+import { useTranslation } from 'react-i18next';
+import {
+  createPermission,
+  deletePermission,
+  getPermissionTree,
+  updatePermission,
+  type PermissionInput,
+} from '@/api/role';
+import { usePermissions } from '@/hooks/usePermission';
+import type { Permission } from '@/types/api';
+
+const PermissionPage: React.FC = () => {
+  const { t } = useTranslation();
+  const [canCreate, canUpdate, canDelete] = usePermissions([
+    'permission:create',
+    'permission:update',
+    'permission:delete',
+  ]);
+  const [rows, setRows] = useState<Permission[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState<Permission | null | undefined>();
+  const [form] = Form.useForm<PermissionInput>();
+  const kind = Form.useWatch('type', form);
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setRows(await getPermissionTree());
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  useEffect(() => {
+    void load().catch(() => undefined);
+  }, [load]);
+  const edit = (row?: Permission) => {
+    form.resetFields();
+    form.setFieldsValue(row ? { ...row, parent_id: row.parent_id || undefined } : { type: 'api' });
+    setEditing(row || null);
+  };
+  const save = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      if (editing) await updatePermission(editing.id, values);
+      else await createPermission(values);
+      setEditing(undefined);
+      await load();
+      message.success(t('common.saveSuccess', '保存成功'));
+    } finally {
+      setSaving(false);
+    }
+  };
+  const parentOptions = (items: Permission[]): (DataNode & { value: string })[] =>
+    items.map((p) => ({
+      key: p.id,
+      title: p.name,
+      value: p.id,
+      children: parentOptions(p.children || []),
+    }));
+  return (
+    <Card
+      title={t('rbac.permissions', '权限管理')}
+      extra={
+        canCreate && (
+          <Button type="primary" onClick={() => edit()}>
+            {t('common.create', '新增')}
+          </Button>
+        )
+      }
+    >
+      <Table<Permission>
+        rowKey="id"
+        dataSource={rows}
+        loading={loading}
+        pagination={false}
+        columns={[
+          { title: t('common.name', '名称'), dataIndex: 'name' },
+          { title: t('rbac.code', '编码'), dataIndex: 'code' },
+          {
+            title: t('common.type', '类型'),
+            dataIndex: 'type',
+            render: (value: string) => t(`rbac.type.${value}`, value),
+          },
+          {
+            title: t('common.status', '状态'),
+            render: (_, row) => (
+              <Tag>
+                {row.status === 0 ? t('common.enabled', '启用') : t('common.disabled', '禁用')}
+              </Tag>
+            ),
+          },
+          {
+            title: t('common.actions', '操作'),
+            render: (_, row) => (
+              <Space>
+                {canUpdate && <Button onClick={() => edit(row)}>{t('common.edit', '编辑')}</Button>}
+                {canDelete && !row.is_system && (
+                  <Popconfirm
+                    title={t('rbac.confirmDeletePermission', '确定删除该权限？')}
+                    onConfirm={async () => {
+                      await deletePermission(row.id);
+                      await load();
+                    }}
+                  >
+                    <Button danger>{t('common.delete', '删除')}</Button>
+                  </Popconfirm>
+                )}
+              </Space>
+            ),
+          },
+        ]}
+      />
+      <Modal
+        title={
+          editing ? t('rbac.editPermission', '编辑权限') : t('rbac.createPermission', '新增权限')
+        }
+        open={editing !== undefined}
+        onCancel={() => setEditing(undefined)}
+        onOk={() => void save().catch(() => undefined)}
+        confirmLoading={saving}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" preserve={false}>
+          <Form.Item
+            name="name"
+            label={t('common.name', '名称')}
+            rules={[{ required: true, whitespace: true, max: 100 }]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            name="code"
+            label={t('rbac.code', '编码')}
+            rules={[{ required: true, whitespace: true, max: 100 }]}
+          >
+            <Input disabled={!!editing} />
+          </Form.Item>
+          <Form.Item name="type" label={t('common.type', '类型')} rules={[{ required: true }]}>
+            <Select
+              disabled={!!editing}
+              options={['menu', 'button', 'api'].map((value) => ({
+                value,
+                label: t(`rbac.type.${value}`, value),
+              }))}
+            />
+          </Form.Item>
+          {!editing && (
+            <Form.Item name="parent_id" label={t('rbac.parentPermission', '父级权限')}>
+              <TreeSelect allowClear treeData={parentOptions(rows)} />
+            </Form.Item>
+          )}
+          <Form.Item
+            name="description"
+            label={t('common.description', '说明')}
+            rules={[{ max: 255 }]}
+          >
+            <Input.TextArea />
+          </Form.Item>
+          {kind === 'menu' && (
+            <Form.Item name="path" label={t('rbac.path', '页面路径')} rules={[{ max: 255 }]}>
+              <Input />
+            </Form.Item>
+          )}
+          {kind === 'api' && !editing && (
+            <>
+              <Form.Item name="api_method" label={t('rbac.method', '请求方法')}>
+                <Select
+                  allowClear
+                  options={['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((value) => ({
+                    value,
+                    label: value,
+                  }))}
+                />
+              </Form.Item>
+              <Form.Item
+                name="api_path"
+                label={t('rbac.apiPath', '接口路径')}
+                rules={[{ max: 255 }]}
+              >
+                <Input />
+              </Form.Item>
+            </>
+          )}
+          {editing && (
+            <Form.Item name="status" label={t('common.status', '状态')}>
+              <Select
+                disabled={editing.is_system}
+                options={[
+                  { value: 0, label: t('common.enabled', '启用') },
+                  { value: 1, label: t('common.disabled', '禁用') },
+                ]}
+              />
+            </Form.Item>
+          )}
+        </Form>
+      </Modal>
+    </Card>
+  );
+};
+export default PermissionPage;

--- a/frontend/src/pages/system/role/RoleMembers.tsx
+++ b/frontend/src/pages/system/role/RoleMembers.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button, Modal, Popconfirm, Select, Space, Table } from 'antd';
+import { useDispatch } from 'react-redux';
+import { fetchCurrentUser } from '@/store/slices/userSlice';
+import type { AppDispatch } from '@/store';
+import { useTranslation } from 'react-i18next';
+import { addRoleMember, getRoleMembers, removeRoleMember, type RoleMember } from '@/api/role';
+import { getUserList } from '@/api/user';
+import { usePermissions } from '@/hooks/usePermission';
+import type { Role } from '@/types/api';
+
+export default function RoleMembers({ role, onClose }: { role: Role; onClose: () => void }) {
+  const { t } = useTranslation();
+  const dispatch = useDispatch<AppDispatch>();
+  const [canAssign, canReadUsers] = usePermissions(['role:assign', 'user:read']);
+  const mutable = canAssign && !role.is_system;
+  const [rows, setRows] = useState<RoleMember[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [userId, setUserId] = useState<string>();
+  const [options, setOptions] = useState<{ value: string; label: string }[]>([]);
+  const requestNumber = useRef(0);
+  const load = useCallback(async () => {
+    const data = await getRoleMembers(role.id, page);
+    setRows(data.list);
+    setTotal(data.total);
+  }, [role.id, page]);
+  useEffect(() => {
+    void load().catch(() => undefined);
+  }, [load]);
+  const search = async (keyword: string) => {
+    const number = ++requestNumber.current;
+    const result = await getUserList({ page: 1, page_size: 20, keyword, status: 0 });
+    if (number === requestNumber.current)
+      setOptions(
+        result.list.map((user) => ({
+          value: user.id,
+          label: `${user.real_name} (${user.username})`,
+        })),
+      );
+  };
+  const add = async () => {
+    if (!userId) return;
+    setBusy(true);
+    try {
+      await addRoleMember(role.id, userId);
+      void dispatch(fetchCurrentUser());
+      setUserId(undefined);
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <Modal
+      open
+      title={`${t('rbac.members', '角色成员')} · ${role.name}`}
+      onCancel={onClose}
+      footer={null}
+      width={720}
+    >
+      {mutable && canReadUsers && (
+        <Space style={{ marginBottom: 16 }}>
+          <Select
+            aria-label={t('rbac.selectUser', '搜索并选择用户')}
+            placeholder={t('rbac.selectUser', '搜索并选择用户')}
+            showSearch
+            filterOption={false}
+            options={options}
+            value={userId}
+            onChange={setUserId}
+            onSearch={(value) => void search(value).catch(() => undefined)}
+            onFocus={() => void search('').catch(() => undefined)}
+            style={{ minWidth: 260 }}
+          />
+          <Button
+            loading={busy}
+            disabled={!userId}
+            onClick={() => void add().catch(() => undefined)}
+          >
+            {t('rbac.addMember', '添加成员')}
+          </Button>
+        </Space>
+      )}
+      <Table<RoleMember>
+        rowKey="id"
+        dataSource={rows}
+        pagination={{
+          current: page,
+          total,
+          pageSize: 20,
+          onChange: setPage,
+          showSizeChanger: false,
+        }}
+        columns={[
+          { title: t('profile.name', '姓名'), dataIndex: 'real_name' },
+          { title: t('profile.username', '用户名'), dataIndex: 'username' },
+          {
+            title: t('common.actions', '操作'),
+            render: (_, user) =>
+              mutable && (
+                <Popconfirm
+                  title={t('rbac.confirmRemoveMember', '确定移除该角色成员？')}
+                  onConfirm={async () => {
+                    await removeRoleMember(role.id, user.id);
+                    void dispatch(fetchCurrentUser());
+                    await load();
+                  }}
+                >
+                  <Button danger>{t('common.remove', '移除')}</Button>
+                </Popconfirm>
+              ),
+          },
+        ]}
+      />
+    </Modal>
+  );
+}

--- a/frontend/src/pages/system/role/RolePage.test.tsx
+++ b/frontend/src/pages/system/role/RolePage.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import RolePage from './RolePage';
+import * as api from '@/api/role';
+import { usePermissions } from '@/hooks/usePermission';
+vi.mock('@/api/role', () => ({
+  getRoleList: vi.fn(),
+  getRoleDetail: vi.fn(),
+  getPermissionTree: vi.fn(),
+  createRole: vi.fn(),
+  updateRole: vi.fn(),
+  deleteRole: vi.fn(),
+  assignRolePermissions: vi.fn(),
+}));
+vi.mock('@/hooks/usePermission', () => ({ usePermissions: vi.fn() }));
+vi.mock('react-redux', () => ({ useDispatch: () => vi.fn() }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback: string) => fallback || key }),
+}));
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(usePermissions).mockReturnValue([true, true, true, true, true]);
+  vi.mocked(api.getRoleList).mockResolvedValue({
+    list: [{ id: '1', name: '自定义审核员', code: 'custom', status: 0, is_system: false }],
+    total: 1,
+  } as Awaited<ReturnType<typeof api.getRoleList>>);
+});
+it('creates a role through the actual form', async () => {
+  render(<RolePage />);
+  await screen.findByText('自定义审核员');
+  fireEvent.click(screen.getByRole('button', { name: /新\s*增/ }));
+  fireEvent.change(screen.getByLabelText('名称'), { target: { value: '编辑员' } });
+  fireEvent.change(screen.getByLabelText('编码'), { target: { value: 'editor' } });
+  fireEvent.click(screen.getByText('OK'));
+  await waitFor(() =>
+    expect(api.createRole).toHaveBeenCalledWith(
+      expect.objectContaining({ name: '编辑员', code: 'editor' }),
+    ),
+  );
+});
+it('hides mutation actions without their permissions', async () => {
+  vi.mocked(usePermissions).mockReturnValue([false, false, false, false, false]);
+  render(<RolePage />);
+  await screen.findByText('自定义审核员');
+  expect(screen.queryByText('新增')).toBeNull();
+  expect(screen.queryByText('分配权限')).toBeNull();
+  expect(screen.queryByText('编辑')).toBeNull();
+});

--- a/frontend/src/pages/system/role/RolePage.tsx
+++ b/frontend/src/pages/system/role/RolePage.tsx
@@ -1,0 +1,262 @@
+import RoleMembers from './RoleMembers';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Button,
+  Card,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Tree,
+  message,
+} from 'antd';
+import type { DataNode } from 'antd/es/tree';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import {
+  assignRolePermissions,
+  createRole,
+  deleteRole,
+  getPermissionTree,
+  getRoleDetail,
+  getRoleList,
+  updateRole,
+} from '@/api/role';
+import { usePermissions } from '@/hooks/usePermission';
+import { fetchCurrentUser } from '@/store/slices/userSlice';
+import type { AppDispatch } from '@/store';
+import type { CreateRoleParams, Permission, Role, UpdateRoleParams } from '@/types/api';
+
+const permissionNodes = (items: Permission[]): DataNode[] =>
+  items.map((p) => ({
+    key: p.id,
+    title: `${p.name} (${p.code})`,
+    children: permissionNodes(p.children || []),
+  }));
+
+const RolePage: React.FC = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch<AppDispatch>();
+  const [canCreate, canUpdate, canDelete, canAssign, canReadPermissions] = usePermissions([
+    'role:create',
+    'role:update',
+    'role:delete',
+    'role:assign',
+    'permission:read',
+  ]);
+  const [rows, setRows] = useState<Role[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [keyword, setKeyword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState<Role | null | undefined>();
+  const [members, setMembers] = useState<Role>();
+  const [assigning, setAssigning] = useState<Role>();
+  const [tree, setTree] = useState<DataNode[]>([]);
+  const [checked, setChecked] = useState<React.Key[]>([]);
+  const [form] = Form.useForm<CreateRoleParams & UpdateRoleParams>();
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await getRoleList({ page, page_size: 20, keyword });
+      setRows(result.list);
+      setTotal(result.total);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, keyword]);
+  useEffect(() => {
+    void load().catch(() => undefined);
+  }, [load]);
+  const edit = async (row?: Role) => {
+    const detail = row ? await getRoleDetail(row.id) : null;
+    form.resetFields();
+    form.setFieldsValue(detail ? { ...detail, parent_id: detail.parent_id || undefined } : {});
+    setEditing(detail);
+  };
+  const save = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      if (editing)
+        await updateRole(
+          editing.id,
+          editing.is_system ? { name: values.name, description: values.description } : values,
+        );
+      else await createRole(values as CreateRoleParams);
+      setEditing(undefined);
+      await load();
+      void dispatch(fetchCurrentUser());
+      message.success(t('common.saveSuccess', '保存成功'));
+    } finally {
+      setSaving(false);
+    }
+  };
+  const assign = async (row: Role) => {
+    const [detail, permissions] = await Promise.all([getRoleDetail(row.id), getPermissionTree()]);
+    setTree(permissionNodes(permissions));
+    setChecked(detail.permission_ids || []);
+    setAssigning(detail);
+  };
+  const savePermissions = async () => {
+    if (!assigning) return;
+    setSaving(true);
+    try {
+      await assignRolePermissions(assigning.id, checked.map(String));
+      setAssigning(undefined);
+      void dispatch(fetchCurrentUser());
+      message.success(t('common.saveSuccess', '保存成功'));
+    } finally {
+      setSaving(false);
+    }
+  };
+  return (
+    <Card
+      title={t('rbac.roles', '角色管理')}
+      extra={
+        canCreate && (
+          <Button type="primary" onClick={() => void edit().catch(() => undefined)}>
+            {t('common.create', '新增')}
+          </Button>
+        )
+      }
+    >
+      <Input.Search
+        aria-label={t('rbac.searchRoles', '搜索角色')}
+        placeholder={t('rbac.searchRoles', '搜索角色')}
+        allowClear
+        onSearch={(v) => {
+          setKeyword(v);
+          setPage(1);
+        }}
+        style={{ maxWidth: 360, marginBottom: 16 }}
+      />
+      <Table<Role>
+        rowKey="id"
+        dataSource={rows}
+        loading={loading}
+        pagination={{
+          current: page,
+          pageSize: 20,
+          total,
+          onChange: setPage,
+          showSizeChanger: false,
+        }}
+        columns={[
+          { title: t('common.name', '名称'), dataIndex: 'name' },
+          { title: t('rbac.code', '编码'), dataIndex: 'code' },
+          {
+            title: t('common.status', '状态'),
+            render: (_, row) => (
+              <Space>
+                <Tag>
+                  {row.status === 0 ? t('common.enabled', '启用') : t('common.disabled', '禁用')}
+                </Tag>
+                {row.is_system && <Tag>{t('rbac.system', '系统内置')}</Tag>}
+              </Space>
+            ),
+          },
+          {
+            title: t('common.actions', '操作'),
+            render: (_, row) => (
+              <Space>
+                <Button onClick={() => setMembers(row)}>{t('rbac.members', '角色成员')}</Button>
+                {canUpdate && (
+                  <Button onClick={() => void edit(row).catch(() => undefined)}>
+                    {t('common.edit', '编辑')}
+                  </Button>
+                )}
+                {canAssign && canReadPermissions && (
+                  <Button
+                    disabled={row.is_system}
+                    onClick={() => void assign(row).catch(() => undefined)}
+                  >
+                    {t('rbac.assignPermissions', '分配权限')}
+                  </Button>
+                )}
+                {canDelete && !row.is_system && (
+                  <Popconfirm
+                    title={t('rbac.confirmDeleteRole', '确定删除该角色？')}
+                    onConfirm={async () => {
+                      await deleteRole(row.id);
+                      await load();
+                    }}
+                  >
+                    <Button danger>{t('common.delete', '删除')}</Button>
+                  </Popconfirm>
+                )}
+              </Space>
+            ),
+          },
+        ]}
+      />
+      {members && (
+        <RoleMembers key={members.id} role={members} onClose={() => setMembers(undefined)} />
+      )}
+      <Modal
+        title={editing ? t('rbac.editRole', '编辑角色') : t('rbac.createRole', '新增角色')}
+        open={editing !== undefined}
+        onCancel={() => setEditing(undefined)}
+        onOk={() => void save().catch(() => undefined)}
+        confirmLoading={saving}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" preserve={false}>
+          <Form.Item
+            name="name"
+            label={t('common.name', '名称')}
+            rules={[{ required: true, whitespace: true, max: 50 }]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            name="code"
+            label={t('rbac.code', '编码')}
+            rules={[{ required: true, whitespace: true, max: 50 }]}
+          >
+            <Input disabled={editing?.is_system} />
+          </Form.Item>
+          <Form.Item
+            name="description"
+            label={t('common.description', '说明')}
+            rules={[{ max: 255 }]}
+          >
+            <Input.TextArea />
+          </Form.Item>
+          {editing && (
+            <Form.Item name="status" label={t('common.status', '状态')}>
+              <Select
+                disabled={editing.is_system}
+                options={[
+                  { value: 0, label: t('common.enabled', '启用') },
+                  { value: 1, label: t('common.disabled', '禁用') },
+                ]}
+              />
+            </Form.Item>
+          )}
+        </Form>
+      </Modal>
+      <Modal
+        title={`${t('rbac.assignPermissions', '分配权限')} · ${assigning?.name || ''}`}
+        open={!!assigning}
+        onCancel={() => setAssigning(undefined)}
+        onOk={() => void savePermissions().catch(() => undefined)}
+        confirmLoading={saving}
+      >
+        <Tree
+          checkable
+          checkStrictly
+          checkedKeys={checked}
+          treeData={tree}
+          onCheck={(keys) => setChecked(Array.isArray(keys) ? keys : keys.checked)}
+        />
+      </Modal>
+    </Card>
+  );
+};
+export default RolePage;

--- a/frontend/src/pages/user/ProfileMePage.test.tsx
+++ b/frontend/src/pages/user/ProfileMePage.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor, cleanup } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import reducer from '@/store/slices/userSlice';
+import { getCurrentUser } from '@/api/auth';
+import { updateMyProfile } from '@/api/user';
+import ProfileMePage from './ProfileMePage';
+vi.mock('@/api/auth', () => ({ getCurrentUser: vi.fn() }));
+vi.mock('@/api/user', () => ({ updateMyProfile: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback: string) => fallback || key }),
+}));
+afterEach(cleanup);
+it('saves only editable fields then refreshes the current user', async () => {
+  const user = {
+    id: 'me',
+    username: 'stable-login',
+    real_name: '原姓名',
+    roles: ['member'],
+    permissions: [],
+    email: 'old@example.test',
+    phone: '123',
+    gender: 0,
+  } as Awaited<ReturnType<typeof getCurrentUser>>;
+  vi.mocked(getCurrentUser).mockResolvedValue(user);
+  const store = configureStore({ reducer: { user: reducer } });
+  render(
+    <Provider store={store}>
+      <ProfileMePage />
+    </Provider>,
+  );
+  await screen.findByText('原姓名');
+  fireEvent.click(screen.getByRole('button', { name: '编辑资料' }));
+  fireEvent.change(screen.getByLabelText('姓名'), { target: { value: '新姓名' } });
+  vi.mocked(getCurrentUser).mockResolvedValue({ ...user, real_name: '新姓名' });
+  fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+  await waitFor(() =>
+    expect(updateMyProfile).toHaveBeenCalledWith({
+      real_name: '新姓名',
+      email: 'old@example.test',
+      phone: '123',
+      gender: 0,
+    }),
+  );
+  await screen.findByText('新姓名');
+  expect(store.getState().user.currentUser?.real_name).toBe('新姓名');
+});

--- a/frontend/src/pages/user/ProfileMePage.tsx
+++ b/frontend/src/pages/user/ProfileMePage.tsx
@@ -1,58 +1,133 @@
-import React, { useEffect } from 'react';
-import { Card, Descriptions, Tag } from 'antd';
+import React, { useEffect, useState } from 'react';
+import { Button, Card, Descriptions, Form, Input, Modal, Select, Tag, message } from 'antd';
 import { useDispatch, useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
 import { fetchCurrentUser, selectCurrentUser, selectUserLoading } from '@/store/slices/userSlice';
+import { updateMyProfile, type ProfileUpdate } from '@/api/user';
 import type { AppDispatch } from '@/store';
 
-const genderLabel = (gender?: number): string => {
-  if (gender === 1) return '男';
-  if (gender === 2) return '女';
-  return '未知';
-};
-
-const statusLabel = (status?: number): { text: string; color: string } => {
-  if (status === 1) return { text: '禁用', color: 'red' };
-  if (status === 2) return { text: '锁定', color: 'orange' };
-  return { text: '正常', color: 'green' };
-};
-
-const dash = (value?: string): string => (value && value.trim() ? value : '未填写');
-
 const ProfileMePage: React.FC = () => {
+  const { t } = useTranslation();
   const dispatch = useDispatch<AppDispatch>();
   const user = useSelector(selectCurrentUser);
   const loading = useSelector(selectUserLoading);
-
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [form] = Form.useForm<ProfileUpdate>();
   useEffect(() => {
     void dispatch(fetchCurrentUser());
   }, [dispatch]);
-
-  const status = statusLabel(user?.status);
-
+  const dash = (value?: string) => value?.trim() || t('profile.empty', '未填写');
+  const edit = () => {
+    form.resetFields();
+    form.setFieldsValue({
+      real_name: user?.real_name,
+      email: user?.email,
+      phone: user?.phone,
+      gender: user?.gender,
+    });
+    setOpen(true);
+  };
+  const save = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      await updateMyProfile(values);
+      await dispatch(fetchCurrentUser()).unwrap();
+      setOpen(false);
+      message.success(t('common.saveSuccess', '保存成功'));
+    } finally {
+      setSaving(false);
+    }
+  };
   return (
-    <Card title="个人中心" loading={loading && !user}>
+    <Card
+      title={t('profile.title', '个人中心')}
+      loading={loading && !user}
+      extra={
+        <Button disabled={!user} onClick={edit}>
+          {t('profile.edit', '编辑资料')}
+        </Button>
+      }
+    >
       <Descriptions column={2} bordered size="small">
-        <Descriptions.Item label="姓名">{dash(user?.real_name)}</Descriptions.Item>
-        <Descriptions.Item label="学号">{dash(user?.student_no)}</Descriptions.Item>
-        <Descriptions.Item label="用户名">{dash(user?.username)}</Descriptions.Item>
-        <Descriptions.Item label="性别">{genderLabel(user?.gender)}</Descriptions.Item>
-        <Descriptions.Item label="年级">{dash(user?.grade)}</Descriptions.Item>
-        <Descriptions.Item label="专业">{dash(user?.major)}</Descriptions.Item>
-        <Descriptions.Item label="部门">{dash(user?.department_name)}</Descriptions.Item>
-        <Descriptions.Item label="职位">{dash(user?.position_name)}</Descriptions.Item>
-        <Descriptions.Item label="邮箱">{dash(user?.email)}</Descriptions.Item>
-        <Descriptions.Item label="手机">{dash(user?.phone)}</Descriptions.Item>
-        <Descriptions.Item label="状态">
-          <Tag color={status.color}>{status.text}</Tag>
+        <Descriptions.Item label={t('profile.name', '姓名')}>
+          {dash(user?.real_name)}
         </Descriptions.Item>
-        <Descriptions.Item label="角色">
-          {(user?.roles || []).length > 0
-            ? user?.roles.map((role) => <Tag key={role}>{role}</Tag>)
-            : '未分配'}
+        <Descriptions.Item label={t('profile.studentNo', '学号')}>
+          {dash(user?.student_no)}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.username', '用户名')}>
+          {dash(user?.username)}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.gender', '性别')}>
+          {t(`profile.gender${user?.gender || 0}`, ['未知', '男', '女'][user?.gender || 0])}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.grade', '年级')}>
+          {dash(user?.grade)}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.major', '专业')}>
+          {dash(user?.major)}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.department', '部门')}>
+          {dash(user?.department_name)}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.position', '职位')}>
+          {dash(user?.position_name)}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.email', '邮箱')}>
+          {dash(user?.email)}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.phone', '手机')}>
+          {dash(user?.phone)}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('common.status', '状态')}>
+          <Tag>
+            {t(`profile.status${user?.status || 0}`, ['正常', '禁用', '锁定'][user?.status || 0])}
+          </Tag>
+        </Descriptions.Item>
+        <Descriptions.Item label={t('profile.roles', '角色')}>
+          {user?.roles.length
+            ? user.roles.map((role) => <Tag key={role}>{role}</Tag>)
+            : t('profile.noRoles', '未分配')}
         </Descriptions.Item>
       </Descriptions>
+      <Modal
+        title={t('profile.edit', '编辑资料')}
+        open={open}
+        onCancel={() => setOpen(false)}
+        onOk={() => void save().catch(() => undefined)}
+        confirmLoading={saving}
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item
+            name="real_name"
+            label={t('profile.name', '姓名')}
+            rules={[{ required: true, whitespace: true, max: 50 }]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            name="email"
+            label={t('profile.email', '邮箱')}
+            rules={[{ type: 'email', max: 100 }]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item name="phone" label={t('profile.phone', '手机')} rules={[{ max: 20 }]}>
+            <Input />
+          </Form.Item>
+          <Form.Item name="gender" label={t('profile.gender', '性别')}>
+            <Select
+              options={[0, 1, 2].map((value) => ({
+                value,
+                label: t(`profile.gender${value}`, ['未知', '男', '女'][value]),
+              }))}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
     </Card>
   );
 };
-
 export default ProfileMePage;

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -10,7 +10,6 @@ import PublicLayout from '@/layouts/PublicLayout';
 // 路由守卫
 import AuthRoute from '@/router/guards/AuthRoute';
 import PermissionRoute from '@/router/guards/PermissionRoute';
-import ComingSoon from '@/pages/error/ComingSoon';
 
 // 页面组件
 const Login = lazy(() => import('@/pages/login/Login'));
@@ -19,6 +18,8 @@ const CasRegister = lazy(() => import('@/pages/login/CasRegister'));
 const Dashboard = lazy(() => import('@/pages/dashboard/Dashboard'));
 const BigScreenPage = lazy(() => import('@/pages/dashboard/bigscreen/BigScreenPage'));
 const UserList = lazy(() => import('@/pages/user/UserList'));
+const RolePage = lazy(() => import('@/pages/system/role/RolePage'));
+const PermissionPage = lazy(() => import('@/pages/system/permission/PermissionPage'));
 const ProfileMePage = lazy(() => import('@/pages/user/ProfileMePage'));
 const AccountSettingsPage = lazy(() => import('@/pages/user/AccountSettingsPage'));
 const NotificationList = lazy(() => import('@/pages/notification/NotificationList'));
@@ -83,9 +84,7 @@ const NotFound = lazy(() => import('@/pages/error/NotFound'));
 
 const LoadingFallback: React.FC = () => {
   const { t } = useTranslation();
-  return (
-    <div style={{ padding: 24, textAlign: 'center' }}>{t('common.loading')}</div>
-  );
+  return <div style={{ padding: 24, textAlign: 'center' }}>{t('common.loading')}</div>;
 };
 
 // 懒加载包装器（无权限守卫）
@@ -96,21 +95,16 @@ const lazyWrap = (Component: React.LazyExoticComponent<React.FC>) => (
 );
 
 // 带权限守卫的懒加载包装器
-const lazyGuarded = (
-  Component: React.LazyExoticComponent<React.FC>,
-  permission?: string,
-) => {
+const lazyGuarded = (Component: React.LazyExoticComponent<React.FC>, permission?: string) => {
   const element = lazyWrap(Component);
   return permission ? (
     <PermissionRoute permission={permission}>{element}</PermissionRoute>
-  ) : element;
+  ) : (
+    element
+  );
 };
 
 // 带权限守卫的内联元素包装器
-const guarded = (element: React.ReactNode, permission?: string) =>
-  permission ? (
-    <PermissionRoute permission={permission}>{element}</PermissionRoute>
-  ) : element;
 
 // 路由元信息类型
 export interface RouteMeta {
@@ -176,15 +170,15 @@ const routes: AppRouteObject[] = [
   },
   {
     path: '/dashboard/bigscreen',
-    element: (
-      <AuthRoute>
-        {lazyGuarded(BigScreenPage, 'stats:read')}
-      </AuthRoute>
-    ),
+    element: <AuthRoute>{lazyGuarded(BigScreenPage, 'stats:read')}</AuthRoute>,
     meta: { title: '数据大屏', hidden: true, permission: 'stats:read' },
   },
   {
-    element: <AuthRoute><MainLayout /></AuthRoute>,
+    element: (
+      <AuthRoute>
+        <MainLayout />
+      </AuthRoute>
+    ),
     children: [
       {
         path: '403',
@@ -238,7 +232,11 @@ const routes: AppRouteObject[] = [
         path: 'member',
         meta: { title: '会员管理', icon: 'TeamOutlined' },
         children: [
-          { path: 'applications', element: <Navigate to="/member/application" replace />, meta: { hidden: true } },
+          {
+            path: 'applications',
+            element: <Navigate to="/member/application" replace />,
+            meta: { hidden: true },
+          },
           {
             path: 'application',
             element: lazyWrap(ApplicationPage),
@@ -351,7 +349,11 @@ const routes: AppRouteObject[] = [
           {
             path: 'list',
             element: lazyGuarded(AnnouncementListPage, 'announcement:read'),
-            meta: { title: '公告列表', permission: 'announcement:read', featureFlag: 'announcement.feed' },
+            meta: {
+              title: '公告列表',
+              permission: 'announcement:read',
+              featureFlag: 'announcement.feed',
+            },
           },
           {
             path: ':id',
@@ -527,12 +529,12 @@ const routes: AppRouteObject[] = [
         children: [
           {
             path: 'role',
-            element: guarded(<ComingSoon i18nKey="placeholder.roles" />, 'role:read'),
+            element: lazyGuarded(RolePage, 'role:read'),
             meta: { title: '角色管理', permission: 'role:read' },
           },
           {
             path: 'permission',
-            element: guarded(<ComingSoon i18nKey="placeholder.permissions" />, 'permission:read'),
+            element: lazyGuarded(PermissionPage, 'permission:read'),
             meta: { title: '权限管理', permission: 'permission:read' },
           },
           {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -203,10 +203,12 @@ export interface Role {
   id: string;
   name: string;
   code: string;
-  sort: number;
+  sort_order: number;
   status: number;
+  is_system: boolean;
+  parent_id?: string | null;
   description?: string;
-  permissions: string[];
+  permission_ids?: string[];
   created_at: string;
   updated_at: string;
 }
@@ -215,30 +217,36 @@ export interface Permission {
   id: string;
   name: string;
   code: string;
-  type: number; // 1=菜单 2=按钮 3=接口
-  parent_id?: string;
-  sort: number;
+  type: 'menu' | 'button' | 'api';
+  parent_id?: string | null;
+  sort_order: number;
   icon?: string;
   path?: string;
+  resource?: string;
+  action?: string;
+  api_method?: string;
+  api_path?: string;
+  description?: string;
+  is_system: boolean;
+  status: number;
+  children?: Permission[];
   created_at: string;
 }
 
 export interface CreateRoleParams {
   name: string;
   code: string;
-  sort?: number;
-  status?: number;
+  parent_id?: string;
+  sort_order?: number;
   description?: string;
-  permission_ids?: string[];
 }
 
 export interface UpdateRoleParams {
   name?: string;
   code?: string;
-  sort?: number;
+  parent_id?: string;
   status?: number;
   description?: string;
-  permission_ids?: string[];
 }
 
 export interface ListRoleParams extends ListParams {
@@ -832,7 +840,11 @@ export interface TaskStats {
 }
 
 export interface CreateTaskParams {
-  workflow?: { reviewer_id: string; acceptor_id: string; assignment?: { mode: string; role_id?: string } };
+  workflow?: {
+    reviewer_id: string;
+    acceptor_id: string;
+    assignment?: { mode: string; role_id?: string };
+  };
   title: string;
   description?: string;
   priority?: TaskPriority;
@@ -983,12 +995,7 @@ export type NotificationPriority = 'low' | 'normal' | 'high' | 'urgent';
 
 /** 通知分类 */
 export type NotificationCategory =
-  | 'system'
-  | 'task'
-  | 'meeting'
-  | 'approval'
-  | 'interview'
-  | 'other';
+  'system' | 'task' | 'meeting' | 'approval' | 'interview' | 'other';
 
 /** 通知发送者信息 */
 export interface NotificationSender {
@@ -1580,5 +1587,3 @@ export interface SearchQueryBody {
   cursor?: string;
   aggregations?: SearchAggRequest[];
 }
-
-


### PR DESCRIPTION
角色、权限管理原先仍为前端占位页，个人中心没有编辑入口，入会表单没有使用已获取的身份资料。本 PR 接通这些页面和现有接口，并补齐自定义角色成员管理。入会姓名/学号自动填充为灰色只读，确认“是否确定修改”后分别解锁；个人资料允许修改姓名、邮箱、手机和性别，保存时同步会员姓名而不改变登录身份或学号。

核验时还发现用户管理 API 只有登录校验，现补齐 user:read/create/update/delete 权限；个人资料仍是当前登录用户独立入口，只写允许字段。自定义角色成员增删校验角色、用户状态并失效权限缓存，系统角色保持业务流程管理保护。权限勾选保留已有授权的数据范围。

验证：前端类型检查、全量 lint、真实表单创建/权限隐藏/资料保存刷新/身份确认解锁测试通过；user/rbac/auth/server 相关 Go race 测试通过，含独立 PostgreSQL 的资料同步、登录身份不变、成员幂等/系统角色保护/权限范围保留回归。无新增迁移。最终远程 CI/Security 待运行；Bugbot 若仍禁用不视为扫描通过。

后续通知/IP、SMTP/导出及独立中英俄翻译 PR 按计划推进，本 PR 的新文案使用 i18n key 和中文 fallback。